### PR TITLE
Fix exportProject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ vitest.config.*.timestamp*
 
 # Rust
 target/
-
-
-# Rust build artifacts
 /target/
+
+# web build stats
+web/stats.html

--- a/supabase/functions/_shared/utils/type_guards.test.ts
+++ b/supabase/functions/_shared/utils/type_guards.test.ts
@@ -459,7 +459,7 @@ Deno.test('Type Guard: isCitationsArray', async (t) => {
     await t.step('should return true for a valid array of Citation objects', () => {
         const citations = [
             { text: 'Source 1', url: 'http://example.com/1' },
-            { text: 'Source 2' }
+            { text: 'Source 2' },
         ];
         assert(isCitationsArray(citations));
     });
@@ -475,6 +475,11 @@ Deno.test('Type Guard: isCitationsArray', async (t) => {
 
     await t.step('should return false if text property is not a string', () => {
         const invalidCitations = [{ text: 123 }];
+        assert(!isCitationsArray(invalidCitations));
+    });
+
+    await t.step('should return false if url property is present but not a string', () => {
+        const invalidCitations = [{ text: 'Valid text', url: 123 }];
         assert(!isCitationsArray(invalidCitations));
     });
 

--- a/supabase/functions/_shared/utils/type_guards.ts
+++ b/supabase/functions/_shared/utils/type_guards.ts
@@ -183,18 +183,20 @@ export function isStageContext(obj: unknown): obj is StageContext {
 
 /**
  * Type guard to check if a value is a valid array of Citation objects.
+ * A citation must have a 'text' property of type string.
+ * It may optionally have a 'url' property of type string.
  * @param value The value to check.
  * @returns True if the value is a Citation[], false otherwise.
  */
-export function isCitationsArray(value: unknown): value is Citation[] {
+export function isCitationsArray(value: unknown): value is { text: string; url?: string }[] {
   return (
     Array.isArray(value) &&
     value.every(
       (item) =>
-        typeof item === 'object' &&
-        item !== null &&
+        isRecord(item) &&
         'text' in item &&
-        typeof item.text === 'string'
+        typeof item.text === 'string' &&
+        (!('url' in item) || typeof item.url === 'string')
     )
   );
 }


### PR DESCRIPTION
- Remove typecasting
- Use exact canonical paths
- Do not include zip files
- Fail loudly if resource access or downloads fail
- Add type guards to validate type

Extraneous: ignore transient stash.html files as build artifacts
