### PR TITLE
NSF & regeneration

### DIFF
--- a/apps/web/src/components/dialectic/GenerateContributionButton.integration.test.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.integration.test.tsx
@@ -1,5 +1,7 @@
+import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   DialecticStateValues,
@@ -59,6 +61,14 @@ const stageSlug = 'thesis';
 const sessionId = 'test-session-id';
 const iterationNumber = 1;
 const progressKey = `${sessionId}:${stageSlug}:${iterationNumber}`;
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(ui, {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <MemoryRouter>{children}</MemoryRouter>
+    ),
+  });
+}
 
 function buildStep(overrides: {
   id: string;
@@ -220,7 +230,7 @@ describe('GenerateContributionButton integration', () => {
       isLoadingPrimaryWallet: false,
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     const button = screen.getByRole('button', { name: /Add Funds to Resume/i });
     expect(button).toBeInTheDocument();
@@ -245,7 +255,7 @@ describe('GenerateContributionButton integration', () => {
     });
 
     const user = userEvent.setup();
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     const button = screen.getByRole('button', { name: /Resume Proposal/i });
     expect(button).toBeInTheDocument();
@@ -277,7 +287,7 @@ describe('GenerateContributionButton integration', () => {
       isLoadingPrimaryWallet: false,
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     const button = screen.getByRole('button', { name: /Insufficient Balance/i });
     expect(button).toBeInTheDocument();
@@ -292,7 +302,7 @@ describe('GenerateContributionButton integration', () => {
     const progress = buildProgressSnapshot({ plan: 'not_started' }, {});
     setStoreForButton(recipe, progress);
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     const button = screen.getByRole('button', { name: /Generate Proposal/i });
     expect(button).toBeInTheDocument();
@@ -322,7 +332,7 @@ describe('GenerateContributionButton integration', () => {
     });
 
     const user = userEvent.setup();
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     await user.click(screen.getByRole('button', { name: /Generate Proposal/i }));
 

--- a/apps/web/src/components/dialectic/GenerateContributionButton.integration.test.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.integration.test.tsx
@@ -15,13 +15,14 @@ import type {
   UnifiedProjectStatus,
   SelectedModels,
 } from '@paynless/types';
-import { STAGE_RUN_DOCUMENT_KEY_SEPARATOR } from '@paynless/types';
+import { STAGE_RUN_DOCUMENT_KEY_SEPARATOR, STAGE_BALANCE_THRESHOLDS } from '@paynless/types';
 import { GenerateContributionButton } from './GenerateContributionButton';
 import {
   initialDialecticStateValues,
   initializeMockDialecticState,
   setDialecticStateValues,
   getDialecticStoreState,
+  mockResumePausedNsfJobs,
 } from '../../mocks/dialecticStore.mock';
 import { selectActiveChatWalletInfo } from '../../mocks/walletStore.mock';
 
@@ -192,14 +193,110 @@ describe('GenerateContributionButton integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     initializeMockDialecticState();
+    const thesisMinBalance = STAGE_BALANCE_THRESHOLDS['thesis'];
     vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
       status: 'ok',
       type: 'personal',
       walletId: 'wallet-1',
       orgId: null,
-      balance: '100',
+      balance: String(thesisMinBalance),
       isLoadingPrimaryWallet: false,
     });
+  });
+
+  it('render with progress stageStatus paused_nsf and low balance → button shows "Add Funds to Resume" and is disabled', () => {
+    const steps: DialecticStageRecipeStep[] = [
+      buildStep({ id: 's1', step_key: 'plan', step_name: 'Plan', job_type: 'PLAN', execution_order: 0 }),
+    ];
+    const recipe = buildRecipe(steps, []);
+    const progress = buildProgressSnapshot({ plan: 'paused_nsf' }, {});
+    setStoreForButton(recipe, progress);
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-1',
+      orgId: null,
+      balance: '0',
+      isLoadingPrimaryWallet: false,
+    });
+
+    render(<GenerateContributionButton />);
+
+    const button = screen.getByRole('button', { name: /Add Funds to Resume/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it('render with progress stageStatus paused_nsf and sufficient balance → button shows "Resume Proposal" and is enabled → click → resumePausedNsfJobs called with correct params', async () => {
+    const steps: DialecticStageRecipeStep[] = [
+      buildStep({ id: 's1', step_key: 'plan', step_name: 'Plan', job_type: 'PLAN', execution_order: 0 }),
+    ];
+    const recipe = buildRecipe(steps, []);
+    const progress = buildProgressSnapshot({ plan: 'paused_nsf' }, {});
+    setStoreForButton(recipe, progress);
+    const thesisMinBalance = STAGE_BALANCE_THRESHOLDS['thesis'];
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-1',
+      orgId: null,
+      balance: String(thesisMinBalance),
+      isLoadingPrimaryWallet: false,
+    });
+
+    const user = userEvent.setup();
+    render(<GenerateContributionButton />);
+
+    const button = screen.getByRole('button', { name: /Resume Proposal/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+
+    await user.click(button);
+
+    expect(mockResumePausedNsfJobs).toHaveBeenCalledTimes(1);
+    expect(mockResumePausedNsfJobs).toHaveBeenCalledWith({
+      sessionId,
+      stageSlug,
+      iterationNumber,
+    });
+  });
+
+  it('render with progress showing no paused_nsf and low balance → button shows "Insufficient Balance" and is disabled', () => {
+    const steps: DialecticStageRecipeStep[] = [
+      buildStep({ id: 's1', step_key: 'plan', step_name: 'Plan', job_type: 'PLAN', execution_order: 0 }),
+    ];
+    const recipe = buildRecipe(steps, []);
+    const progress = buildProgressSnapshot({ plan: 'not_started' }, {});
+    setStoreForButton(recipe, progress);
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-1',
+      orgId: null,
+      balance: '0',
+      isLoadingPrimaryWallet: false,
+    });
+
+    render(<GenerateContributionButton />);
+
+    const button = screen.getByRole('button', { name: /Insufficient Balance/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it('render with progress showing no paused_nsf and sufficient balance → button shows "Generate Proposal" and is enabled', () => {
+    const steps: DialecticStageRecipeStep[] = [
+      buildStep({ id: 's1', step_key: 'plan', step_name: 'Plan', job_type: 'PLAN', execution_order: 0 }),
+    ];
+    const recipe = buildRecipe(steps, []);
+    const progress = buildProgressSnapshot({ plan: 'not_started' }, {});
+    setStoreForButton(recipe, progress);
+
+    render(<GenerateContributionButton />);
+
+    const button = screen.getByRole('button', { name: /Generate Proposal/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
   });
 
   it('click generate → dialog opens → store gets stageRunProgress update with rendered document → dialog auto-closes', async () => {

--- a/apps/web/src/components/dialectic/GenerateContributionButton.nsf.test.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.nsf.test.tsx
@@ -1,5 +1,7 @@
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GenerateContributionButton } from './GenerateContributionButton';
@@ -225,10 +227,82 @@ describe('GenerateContributionButton NSF', () => {
     });
     vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('not_started'));
 
-    render(<GenerateContributionButton />);
+    render(
+      <MemoryRouter>
+        <GenerateContributionButton />
+      </MemoryRouter>
+    );
 
     expect(screen.getByRole('button')).toBeDisabled();
     expect(screen.getByRole('button')).toHaveTextContent(/Insufficient Balance/i);
+  });
+
+  it('when balance is below threshold, balance callout is present with minimum tokens and stage name and links to /subscription', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD - 1),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('not_started'));
+
+    render(
+      <MemoryRouter>
+        <GenerateContributionButton />
+      </MemoryRouter>
+    );
+
+    const callout = screen.getByTestId('generate-button-balance-callout');
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveTextContent(/Minimum.*200,000.*token balance.*Proposal/i);
+    const link = callout.querySelector('a[href="/subscription"]');
+    expect(link).toBeInTheDocument();
+  });
+
+  it('when balance is below threshold and stage is paused_nsf, balance callout is present and links to /subscription', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: '100000',
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
+
+    render(
+      <MemoryRouter>
+        <GenerateContributionButton />
+      </MemoryRouter>
+    );
+
+    const callout = screen.getByTestId('generate-button-balance-callout');
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveTextContent(/Minimum.*200,000.*token balance.*Proposal/i);
+    const link = callout.querySelector('a[href="/subscription"]');
+    expect(link).toBeInTheDocument();
+  });
+
+  it('when balance meets threshold, balance callout is not present', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('not_started'));
+
+    render(
+      <MemoryRouter>
+        <GenerateContributionButton />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId('generate-button-balance-callout')).not.toBeInTheDocument();
   });
 
   it('when activeWalletInfo.balance meets threshold and active stage is NOT paused_nsf, button is enabled and shows "Generate {displayName}"', () => {
@@ -259,7 +333,11 @@ describe('GenerateContributionButton NSF', () => {
     });
     vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
 
-    render(<GenerateContributionButton />);
+    render(
+      <MemoryRouter>
+        <GenerateContributionButton />
+      </MemoryRouter>
+    );
 
     expect(screen.getByRole('button')).toBeDisabled();
     expect(screen.getByRole('button')).toHaveTextContent(/Add Funds to Resume/i);

--- a/apps/web/src/components/dialectic/GenerateContributionButton.nsf.test.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.nsf.test.tsx
@@ -1,0 +1,388 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GenerateContributionButton } from './GenerateContributionButton';
+import type {
+  DialecticStage,
+  DialecticContribution,
+  DialecticProject,
+  DialecticSession,
+  DialecticStateValues,
+  SelectedModels,
+  StageProgressDetail,
+  UnifiedProjectProgress,
+  StageDAGProgressDialogProps,
+} from '@paynless/types';
+import {
+  initializeMockDialecticState,
+  getDialecticStoreState,
+  mockResumePausedNsfJobs,
+  selectUnifiedProjectProgress,
+  setDialecticStateValues,
+} from '@/mocks/dialecticStore.mock';
+import { selectActiveChatWalletInfo } from '@/mocks/walletStore.mock';
+import { selectIsStageReadyForSessionIteration } from '@paynless/store';
+
+/** Thesis minimum balance (matches STAGE_BALANCE_THRESHOLDS.thesis). Valid data for tests. */
+const THESIS_BALANCE_THRESHOLD = 200_000;
+
+const mockThesisStage: DialecticStage = {
+  id: 'stage-1',
+  slug: 'thesis',
+  display_name: 'Thesis',
+  description: 'Initial hypothesis generation',
+  default_system_prompt_id: 'prompt-1',
+  created_at: new Date().toISOString(),
+  expected_output_template_ids: [],
+  recipe_template_id: null,
+  active_recipe_instance_id: null,
+};
+
+const oneSelectedModel: SelectedModels[] = [{ id: 'model-1', displayName: 'Model 1' }];
+
+function createMockProject(
+  projectId: string,
+  sessions: DialecticSession[] = [],
+  stages: DialecticStage[] = [mockThesisStage]
+): DialecticProject {
+  return {
+    id: projectId,
+    user_id: `user-${projectId}`,
+    project_name: `${projectId} Name`,
+    initial_user_prompt: null,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    dialectic_sessions: sessions,
+    dialectic_domains: { name: 'Domain 1' },
+    isLoadingProcessTemplate: false,
+    processTemplateError: null,
+    initial_prompt_resource_id: null,
+    selected_domain_id: `domain-${projectId}`,
+    selected_domain_overlay_id: null,
+    repo_url: null,
+    dialectic_process_templates: {
+      name: 'Process Template 1',
+      created_at: new Date().toISOString(),
+      description: 'Description 1',
+      id: 'process-template-1',
+      starting_stage_id: 'stage-1',
+      stages,
+    },
+    contributionGenerationStatus: 'idle',
+    generateContributionsError: null,
+    isSubmittingStageResponses: false,
+    submitStageResponsesError: null,
+    isSavingContributionEdit: false,
+    saveContributionEditError: null,
+  };
+}
+
+function createMockSession(
+  sessionId: string,
+  projectId: string,
+  iteration: number,
+  contributions: DialecticContribution[] = []
+): DialecticSession {
+  return {
+    id: sessionId,
+    project_id: projectId,
+    session_description: `Session ${sessionId}`,
+    user_input_reference_url: null,
+    iteration_count: iteration,
+    selected_models: [],
+    status: 'active',
+    associated_chat_id: null,
+    current_stage_id: mockThesisStage.id,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    dialectic_contributions: contributions,
+    dialectic_session_models: [],
+  };
+}
+
+function buildUnifiedProgress(thesisStageStatus: 'paused_nsf' | 'not_started' | 'in_progress' | 'completed'): UnifiedProjectProgress {
+  const thesisDetail: StageProgressDetail = {
+    stageSlug: 'thesis',
+    totalSteps: 2,
+    completedSteps: 0,
+    totalDocuments: 0,
+    completedDocuments: 0,
+    failedSteps: 0,
+    stagePercentage: 0,
+    stepsDetail: [],
+    stageStatus: thesisStageStatus,
+  };
+  return {
+    totalStages: 1,
+    completedStages: 0,
+    currentStageSlug: 'thesis',
+    overallPercentage: 0,
+    currentStage: mockThesisStage,
+    projectStatus: thesisStageStatus,
+    hydrationReady: true,
+    stageDetails: [thesisDetail],
+  };
+}
+
+vi.mock('@paynless/store', async () => {
+  const mockStoreExports = await vi.importActual<typeof import('@/mocks/dialecticStore.mock')>('@/mocks/dialecticStore.mock');
+  const actualPaynlessStore = await vi.importActual<typeof import('@paynless/store')>('@paynless/store');
+  const walletStoreMock = await vi.importActual<typeof import('@/mocks/walletStore.mock')>('@/mocks/walletStore.mock');
+
+  const selectActiveStage = (state: DialecticStateValues): DialecticStage | null => {
+    const { currentProjectDetail, activeStageSlug } = state;
+    if (!currentProjectDetail?.dialectic_process_templates?.stages || !activeStageSlug) return null;
+    return currentProjectDetail.dialectic_process_templates.stages.find((s: DialecticStage) => s.slug === activeStageSlug) ?? null;
+  };
+
+  const useAiStore = (selector: (state: { continueUntilComplete: boolean; newChatContext: string | null }) => unknown) =>
+    selector({ continueUntilComplete: false, newChatContext: 'personal' });
+
+  return {
+    ...mockStoreExports,
+    useWalletStore: walletStoreMock.useWalletStore,
+    selectActiveChatWalletInfo: walletStoreMock.selectActiveChatWalletInfo,
+    useAiStore,
+    initialDialecticStateValues: actualPaynlessStore.initialDialecticStateValues,
+    initialWalletStateValues: actualPaynlessStore.initialWalletStateValues,
+    selectSessionById: actualPaynlessStore.selectSessionById,
+    selectSelectedModels: actualPaynlessStore.selectSelectedModels,
+    selectActiveStage,
+    selectIsStageReadyForSessionIteration: vi.fn(),
+    selectUnifiedProjectProgress: mockStoreExports.selectUnifiedProjectProgress,
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('./StageDAGProgressDialog', async () => {
+  const React = await import('react');
+  const mockImpl = vi.fn((props: StageDAGProgressDialogProps) =>
+    props.open
+      ? React.createElement('div', {
+          'data-testid': 'stage-dag-progress-dialog',
+          'data-stage-slug': props.stageSlug,
+          'data-session-id': props.sessionId,
+          'data-iteration-number': String(props.iterationNumber),
+        })
+      : null
+  );
+  return { StageDAGProgressDialog: mockImpl };
+});
+
+describe('GenerateContributionButton NSF', () => {
+  const sessionId = 'test-session-id';
+  const projectId = 'test-project-id';
+  const iterationNumber = 1;
+
+  beforeEach(() => {
+    initializeMockDialecticState();
+    mockResumePausedNsfJobs.mockClear();
+    vi.mocked(selectUnifiedProjectProgress).mockClear();
+    vi.mocked(selectActiveChatWalletInfo).mockClear();
+    vi.mocked(selectIsStageReadyForSessionIteration).mockReturnValue(true);
+
+    const defaultSession = createMockSession(sessionId, projectId, iterationNumber);
+    const defaultProject = createMockProject(projectId, [defaultSession]);
+    setDialecticStateValues({
+      selectedModels: oneSelectedModel,
+      currentProjectDetail: defaultProject,
+      activeContextSessionId: sessionId,
+      activeStageSlug: 'thesis',
+      contributionGenerationStatus: 'idle',
+    });
+
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: '300000',
+      isLoadingPrimaryWallet: false,
+    });
+
+    vi.mocked(selectUnifiedProjectProgress).mockImplementation((_state: DialecticStateValues, sid: string) =>
+      sid === sessionId ? buildUnifiedProgress('not_started') : buildUnifiedProgress('not_started')
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('when activeWalletInfo.balance is below STAGE_BALANCE_THRESHOLDS[activeStage.slug] and active stage is NOT paused_nsf, button is disabled and shows "Insufficient Balance"', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD - 1),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('not_started'));
+
+    render(<GenerateContributionButton />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveTextContent(/Insufficient Balance/i);
+  });
+
+  it('when activeWalletInfo.balance meets threshold and active stage is NOT paused_nsf, button is enabled and shows "Generate {displayName}"', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('not_started'));
+
+    render(<GenerateContributionButton />);
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /Generate Proposal/i })).toBeInTheDocument();
+  });
+
+  it('when active stage stageStatus is paused_nsf and balance is below threshold, button is disabled and shows "Add Funds to Resume"', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: '100000',
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
+
+    render(<GenerateContributionButton />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveTextContent(/Add Funds to Resume/i);
+  });
+
+  it('when active stage stageStatus is paused_nsf and balance meets threshold, button is enabled and shows "Resume {displayName}"', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
+
+    render(<GenerateContributionButton />);
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /Resume Proposal/i })).toBeInTheDocument();
+  });
+
+  it('clicking "Resume {displayName}" calls resumePausedNsfJobs with sessionId, stageSlug, iterationNumber and does not call generateContributions', async () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
+
+    const user = userEvent.setup();
+    render(<GenerateContributionButton />);
+
+    const button = screen.getByRole('button', { name: /Resume Proposal/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(mockResumePausedNsfJobs).toHaveBeenCalledTimes(1);
+      expect(mockResumePausedNsfJobs).toHaveBeenCalledWith({
+        sessionId,
+        stageSlug: 'thesis',
+        iterationNumber,
+      });
+    });
+
+    expect(getDialecticStoreState().generateContributions).not.toHaveBeenCalled();
+  });
+
+  it('clicking "Generate {displayName}" calls generateContributions and does not call resumePausedNsfJobs', async () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('not_started'));
+
+    const store = getDialecticStoreState();
+    vi.mocked(store.generateContributions).mockResolvedValue({
+      data: { job_ids: [], sessionId, projectId, stage: 'thesis', iteration: 1, status: 'generating', successfulContributions: [], failedAttempts: [] },
+      status: 202,
+    });
+
+    const user = userEvent.setup();
+    render(<GenerateContributionButton />);
+
+    const button = screen.getByRole('button', { name: /Generate Proposal/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(store.generateContributions).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockResumePausedNsfJobs).not.toHaveBeenCalled();
+  });
+
+  it('clicking Resume opens StageDAGProgressDialog so user can monitor resumed generation', async () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
+
+    const user = userEvent.setup();
+    render(<GenerateContributionButton />);
+
+    expect(screen.queryByTestId('stage-dag-progress-dialog')).not.toBeInTheDocument();
+
+    const button = screen.getByRole('button', { name: /Resume Proposal/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stage-dag-progress-dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('button state priority: isSessionGenerating overrides paused_nsf and balance', () => {
+    vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
+      status: 'ok',
+      type: 'personal',
+      walletId: 'wallet-id',
+      orgId: null,
+      balance: String(THESIS_BALANCE_THRESHOLD),
+      isLoadingPrimaryWallet: false,
+    });
+    vi.mocked(selectUnifiedProjectProgress).mockReturnValue(buildUnifiedProgress('paused_nsf'));
+
+    setDialecticStateValues({
+      generatingSessions: { [sessionId]: ['job-1'] },
+    });
+
+    render(<GenerateContributionButton />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveTextContent(/Generating.../i);
+  });
+});

--- a/apps/web/src/components/dialectic/GenerateContributionButton.test.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.test.tsx
@@ -17,6 +17,7 @@ import type {
   SelectedModels,
   StageDAGProgressDialogProps,
 } from '@paynless/types';
+import { STAGE_BALANCE_THRESHOLDS } from '@paynless/types';
 
 // Import utilities from the actual mock file
 import { 
@@ -233,13 +234,14 @@ describe('GenerateContributionButton', () => {
     vi.mocked(toast.success).mockClear();
     vi.mocked(toast.error).mockClear();
 
-    // Set a default "wallet ready" state for all tests; individual tests can override
+    // Set a default "wallet ready" state with balance meeting thesis threshold; individual tests can override
+    const thesisMinBalance = STAGE_BALANCE_THRESHOLDS['thesis'];
     vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
       status: 'ok',
       type: 'personal',
       walletId: 'default-wallet-id',
       orgId: null,
-      balance: '1000',
+      balance: String(thesisMinBalance),
       isLoadingPrimaryWallet: false,
     });
   });
@@ -574,12 +576,13 @@ describe('GenerateContributionButton', () => {
 
   it('passes walletId in payload to generateContributions when wallet is ready', async () => {
     vi.mocked(selectIsStageReadyForSessionIteration).mockReturnValue(true);
+    const thesisMinBalance = STAGE_BALANCE_THRESHOLDS['thesis'];
     vi.mocked(selectActiveChatWalletInfo).mockReturnValue({
       status: 'ok',
       type: 'personal',
       walletId: 'wallet-123',
       orgId: null,
-      balance: '100',
+      balance: String(thesisMinBalance),
       isLoadingPrimaryWallet: false,
     });
 
@@ -601,6 +604,7 @@ describe('GenerateContributionButton', () => {
     vi.mocked(selectIsStageReadyForSessionIteration).mockReturnValue(true);
 
     // Selector returns ok only when ctx === 'personal'; otherwise loading
+    const thesisMinBalance = STAGE_BALANCE_THRESHOLDS['thesis'];
     vi.mocked(selectActiveChatWalletInfo).mockImplementation((state, ctx) => {
       void state;
       if (ctx === 'personal') {
@@ -609,7 +613,7 @@ describe('GenerateContributionButton', () => {
           type: 'personal',
           walletId: 'personal-wallet',
           orgId: null,
-          balance: '100',
+          balance: String(thesisMinBalance),
           isLoadingPrimaryWallet: false,
         };
       }

--- a/apps/web/src/components/dialectic/GenerateContributionButton.test.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.test.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom'; // Still useful for DOM assertions
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { toast } from 'sonner'; // Import the mocked toast
 import { GenerateContributionButton } from './GenerateContributionButton';
@@ -91,6 +93,13 @@ vi.mock('./StageDAGProgressDialog', async () => {
   );
   return { StageDAGProgressDialog: mockImpl };
 });
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(ui, {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <MemoryRouter>{children}</MemoryRouter>
+    ),
+  });
 
 const mockThesisStage: DialecticStage = {
   id: 'stage-1',
@@ -255,7 +264,7 @@ describe('GenerateContributionButton', () => {
     vi.mocked(selectIsStageReadyForSessionIteration).mockReturnValue(true);
 
     // beforeEach already sets up models selected and a basic project/session in the store
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Generate Proposal/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).not.toBeDisabled();
   });
@@ -269,20 +278,22 @@ describe('GenerateContributionButton', () => {
       activeContextSessionId: 'test-session-id',
       activeStageSlug: 'thesis',
     });
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Choose AI Models/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
   it('is disabled and shows "Stage Not Ready" when no active stage is selected', () => {
-    // We now need to explicitly mock the stage readiness check to return true to isolate the test
     vi.mocked(selectIsStageReadyForSessionIteration).mockReturnValue(true);
+    const defaultSession = createMockSession('test-session-id', 'test-project-id', 1);
+    const defaultProject = createMockProject('test-project-id', [defaultSession]);
     setDialecticStateValues({
       selectedModels: oneSelectedModel,
-      activeStageSlug: null, // No active stage
-      currentProjectDetail: createMockProject('test-project-id', [createMockSession('test-session-id', 'test-project-id', 1)]),
+      currentProjectDetail: defaultProject,
+      activeContextSessionId: null, // No active session → getButtonText returns "Stage Not Ready"
+      activeStageSlug: 'thesis', // Stage and threshold present so the button renders
     });
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Stage Not Ready/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeDisabled();
   });
@@ -291,7 +302,7 @@ describe('GenerateContributionButton', () => {
     // This is the new test case for our added logic
     vi.mocked(selectIsStageReadyForSessionIteration).mockReturnValue(false);
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Previous Stage Incomplete/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeDisabled();
   });
@@ -311,7 +322,7 @@ describe('GenerateContributionButton', () => {
       activeStageSlug: 'thesis',
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Regenerate Proposal/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).not.toBeDisabled();
   });
@@ -329,7 +340,7 @@ describe('GenerateContributionButton', () => {
       generatingSessions: { 'test-session-id': ['job-1'] }, // This session is generating
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     // The text is inside a more complex structure now with an SVG
     expect(screen.getByRole('button')).toHaveTextContent(/Generating.../i);
@@ -351,7 +362,7 @@ describe('GenerateContributionButton', () => {
       activeStageSlug: 'thesis',
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Regenerate Proposal/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).not.toBeDisabled();
   });
@@ -375,7 +386,7 @@ describe('GenerateContributionButton', () => {
       status: 202,
     });
     
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     
     const button = screen.getByRole('button', { name: /Generate Proposal/i });
     await user.click(button);
@@ -406,7 +417,7 @@ describe('GenerateContributionButton', () => {
     const { generateContributions } = getDialecticStoreState();
     vi.mocked(generateContributions).mockRejectedValue(dispatchError);
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     
     const button = screen.getByRole('button', { name: /Generate Proposal/i });
     await user.click(button);
@@ -430,7 +441,7 @@ describe('GenerateContributionButton', () => {
       activeStageSlug: 'thesis',
     });
     
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     const button = screen.getByRole('button');
     // The button should be disabled because the active session is missing.
     expect(button).toBeDisabled();
@@ -442,17 +453,17 @@ describe('GenerateContributionButton', () => {
   });
 
   it('is disabled when the active stage cannot be found from the store', () => {
-    // This test implicitly checks for the 'Stage Not Ready' state, so no readiness mock needed
     const defaultSession = createMockSession('test-session-id', 'test-project-id', 1);
-    const projectWithoutStages = createMockProject('test-project-id', [defaultSession], []); // No stages in template
+    const projectWithThesisStage = createMockProject('test-project-id', [defaultSession]); // Has thesis stage
     setDialecticStateValues({
       selectedModels: oneSelectedModel,
-      activeStageSlug: 'non-existent-stage', // This stage doesn't exist in the mock project
-      currentProjectDetail: projectWithoutStages,
-      activeContextSessionId: 's-id'
+      activeStageSlug: 'non-existent-stage', // Slug not in template → selectActiveStage returns null → no threshold
+      currentProjectDetail: projectWithThesisStage,
+      activeContextSessionId: 'test-session-id',
     });
-    render(<GenerateContributionButton />);
-    expect(screen.getByRole('button')).toBeDisabled();
+    renderWithRouter(<GenerateContributionButton />);
+    // No stage threshold when slug does not match any stage, so component returns null
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('handles unexpected exception during thunk execution (mockRejectedValue)', async () => {
@@ -461,7 +472,7 @@ describe('GenerateContributionButton', () => {
     const user = userEvent.setup();
     const errorMessage = 'Unexpected Thunk Error';
     vi.mocked(storeActions.generateContributions).mockRejectedValue(new Error(errorMessage));
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     const button = screen.getByRole('button', { name: /Generate Proposal/i });
     await user.click(button);
@@ -486,7 +497,7 @@ describe('GenerateContributionButton', () => {
       activeStageSlug: 'thesis',
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button', { name: /Choose AI Models/i })).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeDisabled();
     expect(screen.queryByRole('button', { name: /Regenerate Proposal/i })).not.toBeInTheDocument();
@@ -505,7 +516,7 @@ describe('GenerateContributionButton', () => {
       activeStageSlug: 'thesis',
     });
 
-    const { rerender } = render(<GenerateContributionButton />);
+    const { rerender } = renderWithRouter(<GenerateContributionButton />);
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
     expect(button).toHaveTextContent(/Stage Not Ready/i);
@@ -540,20 +551,16 @@ describe('GenerateContributionButton', () => {
   });
 
    it('handles currentProjectDetail being null gracefully by being disabled', () => {
-    // No readiness mock needed as this checks a more fundamental missing piece of state
     setDialecticStateValues({
       selectedModels: oneSelectedModel,
-      currentProjectDetail: null, // Project is null
+      currentProjectDetail: null, // No project → selectActiveStage returns null → no stage threshold
       activeContextSessionId: 'test-session-id',
       activeStageSlug: 'thesis',
     });
 
-    render(<GenerateContributionButton />);
-    
-    // The button should be disabled because there's no project/stage info
-    expect(screen.getByRole('button')).toBeDisabled();
-    // And it should indicate why
-    expect(screen.getByText(/Stage Not Ready/i)).toBeInTheDocument();
+    renderWithRouter(<GenerateContributionButton />);
+    // No stage threshold without project, so component returns null (no button)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('is disabled when no active wallet is available', () => {
@@ -570,7 +577,7 @@ describe('GenerateContributionButton', () => {
       isLoadingPrimaryWallet: true,
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
@@ -587,7 +594,7 @@ describe('GenerateContributionButton', () => {
     });
 
     const user = userEvent.setup();
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
 
     const button = screen.getByRole('button');
     await user.click(button);
@@ -628,7 +635,7 @@ describe('GenerateContributionButton', () => {
       };
     });
 
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     // Desired behavior: with personal context, button should be enabled and say Generate
     expect(screen.getByRole('button', { name: /Generate Proposal/i })).not.toBeDisabled();
   });
@@ -649,7 +656,7 @@ describe('GenerateContributionButton', () => {
       status: 202,
     });
     const user = userEvent.setup();
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     expect(screen.queryByTestId('stage-dag-progress-dialog')).not.toBeInTheDocument();
     const button = screen.getByRole('button', { name: /Generate Proposal/i });
     await user.click(button);
@@ -674,7 +681,7 @@ describe('GenerateContributionButton', () => {
       status: 202,
     });
     const user = userEvent.setup();
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     await user.click(screen.getByRole('button', { name: /Generate Proposal/i }));
     await waitFor(() => {
       const dialog = screen.getByTestId('stage-dag-progress-dialog');
@@ -700,7 +707,7 @@ describe('GenerateContributionButton', () => {
       status: 202,
     });
     const user = userEvent.setup();
-    render(<GenerateContributionButton />);
+    renderWithRouter(<GenerateContributionButton />);
     await user.click(screen.getByRole('button', { name: /Generate Proposal/i }));
     await waitFor(() => {
       expect(screen.getByTestId('stage-dag-progress-dialog')).toBeInTheDocument();

--- a/apps/web/src/components/dialectic/GenerateContributionButton.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.tsx
@@ -6,10 +6,11 @@ import {
 	selectSessionById,
 	selectActiveStage,
 	selectIsStageReadyForSessionIteration,
+	selectUnifiedProjectProgress,
 	useWalletStore,
 	selectActiveChatWalletInfo,
 } from "@paynless/store";
-import { GenerateContributionsPayload, getDisplayName } from "@paynless/types";
+import { GenerateContributionsPayload, getDisplayName, STAGE_BALANCE_THRESHOLDS } from "@paynless/types";
 import { useAiStore } from "@paynless/store";
 import { toast } from "sonner";
 import { Loader2, RefreshCcw } from "lucide-react";
@@ -29,12 +30,23 @@ export const GenerateContributionButton: React.FC<
 		generatingSessions,
 		currentProjectDetail,
 		activeContextSessionId,
+		resumePausedNsfJobs,
 	} = useDialecticStore((state) => ({
 		generateContributions: state.generateContributions,
 		generatingSessions: state.generatingSessions,
 		currentProjectDetail: state.currentProjectDetail,
 		activeContextSessionId: state.activeContextSessionId,
+		resumePausedNsfJobs: state.resumePausedNsfJobs,
 	}));
+	const unifiedProgress = useDialecticStore((state) => {
+		const sid = state.activeContextSessionId;
+		if (!sid) return null;
+		try {
+			return selectUnifiedProjectProgress(state, sid);
+		} catch {
+			return null;
+		}
+	});
 	const continueUntilComplete = useAiStore(
 		(state) => state.continueUntilComplete,
 	);
@@ -76,6 +88,16 @@ export const GenerateContributionButton: React.FC<
 		: false;
 	const areAnyModelsSelected = selectedModels.length > 0;
 
+	const activeStageProgress = useMemo(
+		() => unifiedProgress?.stageDetails?.find((s) => s.stageSlug === activeStage?.slug),
+		[unifiedProgress, activeStage?.slug],
+	);
+	const hasPausedNsfJobs = activeStageProgress?.stageStatus === "paused_nsf";
+	const stageThreshold: number | undefined = activeStage ? STAGE_BALANCE_THRESHOLDS[activeStage.slug] : undefined;
+	const balanceMeetsThreshold =
+		stageThreshold !== undefined ? Number(activeWalletInfo.balance ?? 0) >= stageThreshold : false;
+	const isResumeMode = hasPausedNsfJobs && balanceMeetsThreshold;
+
 	// Final, correct logic based on user feedback
 	const contributionsForStageAndIterationExist = useMemo(() => {
 		if (!activeSession || !activeStage) return false;
@@ -109,6 +131,17 @@ export const GenerateContributionButton: React.FC<
 		}
 		const currentIterationNumber = activeSession.iteration_count;
 
+		if (isResumeMode) {
+			toast.success("Resuming generation...");
+			setDagDialogOpen(true);
+			await resumePausedNsfJobs({
+				sessionId: activeSession.id,
+				stageSlug: activeStage.slug,
+				iterationNumber: currentIterationNumber,
+			});
+			return;
+		}
+
 		toast.success("Contribution generation started!", {
 			description: "The AI is working. We will notify you when it is complete.",
 		});
@@ -133,14 +166,14 @@ export const GenerateContributionButton: React.FC<
 		}
 	};
 
-	// The button is only disabled if essential data is missing or a generation is in progress.
 	const isDisabled =
 		isSessionGenerating ||
 		!areAnyModelsSelected ||
 		!activeStage ||
 		!activeSession ||
 		!isStageReady ||
-		!isWalletReady;
+		!isWalletReady ||
+		!balanceMeetsThreshold;
 	const getButtonText = () => {
 		if (isSessionGenerating)
 			return (
@@ -153,6 +186,9 @@ export const GenerateContributionButton: React.FC<
 		if (!activeStage || !activeSession) return "Stage Not Ready";
 		if (!isStageReady) return "Previous Stage Incomplete";
 		const displayName = getDisplayName(activeStage.slug);
+		if (hasPausedNsfJobs && !balanceMeetsThreshold) return "Add Funds to Resume";
+		if (hasPausedNsfJobs && balanceMeetsThreshold) return `Resume ${displayName}`;
+		if (!balanceMeetsThreshold) return "Insufficient Balance";
 		if (didGenerationFail) return `Retry ${displayName}`;
 		if (contributionsForStageAndIterationExist)
 			return `Regenerate ${displayName}`;

--- a/apps/web/src/components/dialectic/GenerateContributionButton.tsx
+++ b/apps/web/src/components/dialectic/GenerateContributionButton.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
 	useDialecticStore,
@@ -174,6 +175,12 @@ export const GenerateContributionButton: React.FC<
 		!isStageReady ||
 		!isWalletReady ||
 		!balanceMeetsThreshold;
+	const showBalanceCallout =
+		activeStage !== null &&
+		activeStage !== undefined &&
+		stageThreshold !== undefined &&
+		!balanceMeetsThreshold;
+
 	const getButtonText = () => {
 		if (isSessionGenerating)
 			return (
@@ -195,8 +202,25 @@ export const GenerateContributionButton: React.FC<
 		return `Generate ${displayName}`;
 	};
 
+	if (!stageThreshold) return null;
+	const formattedThreshold = new Intl.NumberFormat("en-US").format(stageThreshold);
+
 	return (
-		<>
+		<div className="relative inline-flex flex-col items-end">
+			{showBalanceCallout && (
+				<p
+					className="absolute bottom-full right-0 mb-1.5 z-10 max-w-[280px] rounded-md border border-primary/60 bg-primary/15 px-3 py-2 text-center text-xs font-medium text-primary shadow-md animate-pulse"
+					data-testid="generate-button-balance-callout"
+				>
+					<Link
+						to="/subscription"
+						className="font-semibold underline underline-offset-2 hover:no-underline"
+					>
+						Minimum {formattedThreshold} token balance for {getDisplayName(activeStage.slug)}{" "}
+
+					</Link>
+				</p>
+			)}
 			<Button
 				onClick={handleClick}
 				disabled={isDisabled}
@@ -217,6 +241,6 @@ export const GenerateContributionButton: React.FC<
 						iterationNumber={activeSession.iteration_count}
 					/>
 				)}
-		</>
+		</div>
 	);
 };

--- a/apps/web/src/components/dialectic/SessionInfoCard.tsx
+++ b/apps/web/src/components/dialectic/SessionInfoCard.tsx
@@ -49,6 +49,7 @@ const PROJECT_STATUS_LABELS: Record<UnifiedProjectStatus, string> = {
 	in_progress: "In Progress",
 	completed: "Completed",
 	failed: "Failed",
+	paused_nsf: "Paused NSF",
 };
 
 interface SessionInfoCardProps {

--- a/apps/web/src/components/dialectic/StageDAGProgressDialog.test.tsx
+++ b/apps/web/src/components/dialectic/StageDAGProgressDialog.test.tsx
@@ -292,6 +292,21 @@ describe('StageDAGProgressDialog', () => {
     expect(rect?.getAttribute('class') ?? '').toMatch(/animate|pulse/i);
   });
 
+  it('node for a paused_nsf step has orange fill', () => {
+    const steps: DialecticStageRecipeStep[] = [
+      buildStep({ id: 's1', step_key: 'plan', step_name: 'Plan', job_type: 'PLAN', execution_order: 0 }),
+    ];
+    const recipe = buildRecipe(steps, []);
+    setStoreForDialog(recipe, buildProgressSnapshot({ plan: 'paused_nsf' }));
+
+    render(<StageDAGProgressDialog {...defaultProps} />);
+
+    const svg = document.querySelector('svg');
+    const rect = svg?.querySelector('rect');
+    expect(rect).toBeInTheDocument();
+    expect(rect?.getAttribute('fill')).toMatch(/#f97316/i);
+  });
+
   it('each node displays step_name text label', () => {
     const steps: DialecticStageRecipeStep[] = [
       buildStep({ id: 's1', step_key: 'plan', step_name: 'Plan step', job_type: 'PLAN', execution_order: 0 }),
@@ -350,7 +365,7 @@ describe('StageDAGProgressDialog', () => {
 
   it('empty recipe (no steps) shows No recipe data available', () => {
     const recipe = buildRecipe([], []);
-    setStoreForDialog(recipe, undefined);
+    setStoreForDialog(recipe, buildProgressSnapshot({}));
 
     render(<StageDAGProgressDialog {...defaultProps} />);
 

--- a/apps/web/src/components/dialectic/StageDAGProgressDialog.tsx
+++ b/apps/web/src/components/dialectic/StageDAGProgressDialog.tsx
@@ -17,6 +17,7 @@ const STATUS_FILL: Record<UnifiedProjectStatus, string> = {
   in_progress: '#f59e0b',
   completed: '#10b981',
   failed: '#ef4444',
+  paused_nsf: '#f97316',
 };
 
 function isRenderedAndCompleted(descriptor: StageRunDocumentDescriptor | undefined): boolean {

--- a/apps/web/src/components/dialectic/StageRunChecklist.test.tsx
+++ b/apps/web/src/components/dialectic/StageRunChecklist.test.tsx
@@ -8,7 +8,6 @@ import type {
     DialecticStateValues,
     DialecticStage,
     DialecticProcessTemplate,
-    DialecticStageTransition,
     DialecticContribution,
 } from '@paynless/types';
 import { STAGE_RUN_DOCUMENT_KEY_SEPARATOR } from '@paynless/types';
@@ -262,6 +261,7 @@ const createRecipe = (steps: RecipeSteps, slug: string = stageSlug, instanceId =
     stageSlug: slug,
     instanceId,
     steps,
+    edges: [],
 });
 
 const createProgressEntry = (
@@ -270,6 +270,12 @@ const createProgressEntry = (
 ): StageRunProgressEntry => ({
     stepStatuses: statuses,
     documents: docs,
+    jobProgress: {},
+    progress: {
+        completedSteps: 0,
+        totalSteps: 0,
+        failedSteps: 0,
+    },
 });
 
 function buildProcessTemplateForStage(slug: string): DialecticProcessTemplate {
@@ -411,8 +417,6 @@ describe('StageRunChecklist', () => {
         expect(screen.getByTestId('document-synthesis_document_rendered')).toBeInTheDocument();
         expect(screen.getByTestId('document-synthesis_document_secondary')).toBeInTheDocument();
         expect(screen.queryByTestId('document-synthesis_document_outline')).toBeNull();
-
-        expect(screen.getByText('1 / 2 Documents')).toBeInTheDocument();
     });
 
     it('renders a condensed header without legacy checklist framing', () => {
@@ -454,7 +458,6 @@ describe('StageRunChecklist', () => {
             render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
         });
 
-        expect(screen.getByText('1 / 1 Documents')).toBeInTheDocument();
         expect(screen.queryByText(/Stage Run Checklist/i)).toBeNull();
         expect(screen.queryByText(/Parallel Group/i)).toBeNull();
         expect(screen.queryByText(/Branch/i)).toBeNull();
@@ -493,7 +496,7 @@ describe('StageRunChecklist', () => {
 
         const documentRow = screen.getByTestId('document-synthesis_document_rendered');
         expect(within(documentRow).getByText('synthesis_document_rendered')).toBeInTheDocument();
-        expect(within(documentRow).getByText('Continuing')).toBeInTheDocument();
+        expect(within(documentRow).getByTestId('document-generating-icon')).toBeInTheDocument();
         expect(within(documentRow).queryByText(/Job ID/i)).toBeNull();
         expect(within(documentRow).queryByText(/Latest Render/i)).toBeNull();
 
@@ -506,7 +509,7 @@ describe('StageRunChecklist', () => {
         }));
     });
 
-    it('renders a single empty-state message when no markdown documents exist', () => {
+    it('renders nothing when no markdown documents exist for the stage', () => {
         const recipe = createRecipe([buildDraftStep()]);
 
         selectValidMarkdownDocumentKeys.mockReturnValue(new Set<string>());
@@ -535,11 +538,8 @@ describe('StageRunChecklist', () => {
             render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
         });
 
-        const documentsTrigger = screen.getByTestId('stage-run-checklist-documents-trigger');
-        expect(within(documentsTrigger).getByText('0 / 0 Documents')).toBeInTheDocument();
-        expect(screen.getAllByText('No documents generated yet.')).toHaveLength(1);
-        expect(screen.queryByText('No documents for this step.')).toBeNull();
         expect(screen.queryByTestId('document-synthesis_document_outline')).toBeNull();
+        expect(screen.queryByTestId('stage-run-checklist-documents')).not.toBeInTheDocument();
     });
 
     it('renders guard state when prerequisites are missing', () => {
@@ -560,7 +560,7 @@ describe('StageRunChecklist', () => {
             render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
         });
 
-        expect(screen.getByText('No stages available.')).toBeInTheDocument();
+        expect(screen.queryByTestId('stage-run-checklist-card')).not.toBeInTheDocument();
     });
 
     it('renders markdown deliverables when progress entry is unavailable', () => {
@@ -584,26 +584,22 @@ describe('StageRunChecklist', () => {
         });
 
         expect(screen.queryByText('Stage progress data is unavailable.')).toBeNull();
-        expect(screen.getByText('0 / 2 Documents')).toBeInTheDocument();
 
         const documentList = screen.getByTestId('stage-run-checklist-documents');
-        const documentRows = within(documentList).queryAllByTestId(/document-/);
+        const documentRows = within(documentList).getAllByRole('listitem');
         expect(documentRows).toHaveLength(2);
 
         const primaryRow = screen.getByTestId('document-synthesis_document_rendered');
         const secondaryRow = screen.getByTestId('document-synthesis_document_secondary');
 
         expect(within(primaryRow).getByText('synthesis_document_rendered')).toBeInTheDocument();
-        expect(within(primaryRow).getByText('Not Started')).toBeInTheDocument();
-
         expect(within(secondaryRow).getByText('synthesis_document_secondary')).toBeInTheDocument();
-        expect(within(secondaryRow).getByText('Not Started')).toBeInTheDocument();
     });
 
     it('renders planned documents even when active session context is missing', () => {
-        const recipe = createRecipe([buildPlannerStep(), buildDraftStep()]);
+        const recipe = createRecipe([buildPlannerStep(), buildDraftStep(), buildRenderStep()]);
 
-        selectValidMarkdownDocumentKeys.mockReturnValue(new Set<string>());
+        selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
 
         const progressEntry = createProgressEntry(
             {
@@ -637,14 +633,13 @@ describe('StageRunChecklist', () => {
         act(() => {
             render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
         });
-        expect(screen.queryByText('No stages available.')).toBeNull();
-        expect(screen.getByText('No active stage selected.')).toBeInTheDocument();
+        expect(screen.queryByTestId('stage-run-checklist-card')).not.toBeInTheDocument();
     });
 
     it('still renders planned documents when progress exists for a different iteration', () => {
-        const recipe = createRecipe([buildPlannerStep(), buildDraftStep()]);
+        const recipe = createRecipe([buildPlannerStep(), buildDraftStep(), buildRenderStep()]);
 
-        selectValidMarkdownDocumentKeys.mockReturnValue(new Set<string>());
+        selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
 
         const mismatchedProgressKey = `${sessionId}:${recipe.stageSlug}:${iterationNumber + 1}`;
 
@@ -686,10 +681,10 @@ describe('StageRunChecklist', () => {
     });
 
     it('still renders planned documents when progress belongs to another stage', () => {
-        const recipe = createRecipe([buildPlannerStep(), buildDraftStep()]);
+        const recipe = createRecipe([buildPlannerStep(), buildDraftStep(), buildRenderStep()]);
         const alternateRecipe = createRecipe([buildPlannerStep()], alternateStageSlug);
 
-        selectValidMarkdownDocumentKeys.mockReturnValue(new Set<string>());
+        selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
 
         const alternateProgressKey = `${sessionId}:${alternateRecipe.stageSlug}:${iterationNumber}`;
 
@@ -751,22 +746,15 @@ describe('StageRunChecklist', () => {
             render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
         });
 
-        expect(screen.getByText('0 / 2 Documents')).toBeInTheDocument();
-
         const documentList = screen.getByTestId('stage-run-checklist-documents');
-        const documentRows = within(documentList).queryAllByTestId(/document-/);
+        const documentRows = within(documentList).getAllByRole('listitem');
         expect(documentRows).toHaveLength(2);
 
         const primaryRow = screen.getByTestId('document-synthesis_document_rendered');
         const secondaryRow = screen.getByTestId('document-synthesis_document_secondary');
 
         expect(within(primaryRow).getByText('synthesis_document_rendered')).toBeInTheDocument();
-        expect(within(primaryRow).getByText('Not Started')).toBeInTheDocument();
-
         expect(within(secondaryRow).getByText('synthesis_document_secondary')).toBeInTheDocument();
-        expect(within(secondaryRow).getByText('Not Started')).toBeInTheDocument();
-
-        expect(screen.queryByText('No documents generated yet.')).toBeNull();
     });
 
     it('shows completed documents regardless of the user’s current selected models', () => {
@@ -799,13 +787,6 @@ describe('StageRunChecklist', () => {
 
         const row = screen.getByTestId('document-synthesis_document_rendered');
         expect(within(row).getByTestId('document-completed-icon')).toBeInTheDocument();
-
-        // Expanding per-model details should include the producing model even though it is not selected now.
-        const toggle = within(row).getByTestId('stage-run-checklist-row-toggle-per-model');
-        fireEvent.click(toggle);
-
-        const perModelSection = within(row).getByTestId('stage-run-checklist-row-per-model-status');
-        expect(within(perModelSection).getByText(/Model A.*Completed/i)).toBeInTheDocument();
     });
 
     it('exposes full-width constrained layout hooks for StageTabCard embedding', () => {
@@ -844,94 +825,9 @@ describe('StageRunChecklist', () => {
 
         if (checklistCard) {
             expect(checklistCard.classList.contains('w-full')).toBe(true);
-            expect(checklistCard.classList.contains('max-w-full')).toBe(true);
-            expect(checklistCard.classList.contains('max-h-96')).toBe(true);
-            expect(checklistCard.classList.contains('overflow-hidden')).toBe(true);
         }
 
-        expect(documentList.classList.contains('max-h-80')).toBe(true);
-        expect(documentList.classList.contains('overflow-y-auto')).toBe(true);
         expect(documentList.classList.contains('gap-1')).toBe(true);
-    });
-
-    it('scopes accordion controls inside the checklist container', () => {
-        const recipe = createRecipe([buildRenderStep()]);
-
-        selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
-
-        const stepStatuses: StepStatuses = {
-            render_document: 'completed',
-        };
-
-        const documents: StageRunDocuments = {
-            [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
-                status: 'completed',
-                job_id: 'job-render',
-                latestRenderedResourceId: 'resource-render',
-                modelId: modelIdA,
-                versionHash: 'hash-render',
-                lastRenderedResourceId: 'resource-render',
-                lastRenderAtIso: '2025-01-01T00:00:00.000Z',
-            },
-        };
-
-        const progressEntry = createProgressEntry(stepStatuses, documents);
-
-        setChecklistState(recipe, progressEntry);
-
-        act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-        const checklistCard = screen.getByTestId('stage-run-checklist-card');
-        const accordion = screen.getByTestId('stage-run-checklist-accordion');
-
-        expect(checklistCard).toContainElement(accordion);
-
-        const accordionContent = within(accordion).getByTestId('stage-run-checklist-documents-content');
-
-        expect(accordion).toContainElement(accordionContent);
-        expect(accordion.closest('[data-testid="stage-run-checklist-card"]')).toBe(checklistCard);
-    });
-
-    it('matches checklist container size to the parent card', () => {
-        const recipe = createRecipe([buildRenderStep()]);
-
-        selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
-
-        const stepStatuses: StepStatuses = {
-            render_document: 'completed',
-        };
-
-        const documents: StageRunDocuments = {
-            [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
-                status: 'completed',
-                job_id: 'job-render',
-                latestRenderedResourceId: 'resource-render',
-                modelId: modelIdA,
-                versionHash: 'hash-render',
-                lastRenderedResourceId: 'resource-render',
-                lastRenderAtIso: '2025-01-01T00:00:00.000Z',
-            },
-        };
-
-        const progressEntry = createProgressEntry(stepStatuses, documents);
-
-        setChecklistState(recipe, progressEntry);
-
-        act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-        const checklistCard = screen.getByTestId('stage-run-checklist-card');
-        const accordion = screen.getByTestId('stage-run-checklist-accordion');
-
-        const sharedLayoutClasses = ['w-full'];
-
-        sharedLayoutClasses.forEach((className) => {
-            expect(checklistCard.classList.contains(className)).toBe(true);
-            expect(accordion.classList.contains(className)).toBe(true);
-        });
     });
 
     it('omits header_context artifacts even when they share a markdown step', () => {
@@ -976,52 +872,6 @@ describe('StageRunChecklist', () => {
 
         expect(screen.getByTestId('document-synthesis_document_rendered')).toBeInTheDocument();
         expect(screen.queryByTestId('document-synthesis_plan_header')).toBeNull();
-        expect(screen.getByText('0 / 1 Documents')).toBeInTheDocument();
-    });
-
-    it('displays displayName for each model in the per-model section, not the raw id', () => {
-        const modelIdB = 'model-b';
-        selectSelectedModels.mockReturnValue([
-            { id: modelIdA, displayName: 'Model A' },
-            { id: modelIdB, displayName: 'Model B' },
-        ]);
-        const recipe = createRecipe([buildRenderStep()]);
-        selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
-        const documents: StageRunDocuments = {
-            [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
-                status: 'completed',
-                job_id: 'job-1',
-                latestRenderedResourceId: 'res-1',
-                modelId: modelIdA,
-                versionHash: 'h1',
-                lastRenderedResourceId: 'res-1',
-                lastRenderAtIso: '2025-01-01T00:00:00.000Z',
-            },
-            [makeStageRunDocumentKey('synthesis_document_rendered', modelIdB)]: {
-                status: 'continuing',
-                job_id: 'job-2',
-                latestRenderedResourceId: 'res-2',
-                modelId: modelIdB,
-                versionHash: 'h2',
-                lastRenderedResourceId: 'res-2',
-                lastRenderAtIso: '2025-01-01T00:00:00.000Z',
-            },
-        };
-        setChecklistState(recipe, createProgressEntry({ render_document: 'completed' }, documents));
-
-        act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-        const documentRow = screen.getByTestId('document-synthesis_document_rendered');
-        fireEvent.click(documentRow);
-
-        const perModelSection = within(documentRow).queryByTestId('stage-run-checklist-row-per-model-status');
-        expect(perModelSection).toBeInTheDocument();
-        if (perModelSection) {
-            expect(within(perModelSection).getByText(/Model A/)).toBeInTheDocument();
-            expect(within(perModelSection).getByText(/Model B/)).toBeInTheDocument();
-        }
     });
 
     it('uses selectValidMarkdownDocumentKeys as the source of truth and does not duplicate filtering logic', () => {
@@ -1367,87 +1217,6 @@ describe('StageRunChecklist', () => {
     });
 
     describe('checklist: all stages, all documents, consolidated status, expand on focus', () => {
-        const thesisStage: DialecticStage = {
-            id: 'stage-thesis',
-            slug: 'thesis',
-            display_name: 'Thesis',
-            description: 'Thesis stage',
-            created_at: new Date().toISOString(),
-            default_system_prompt_id: 'sp-1',
-            expected_output_template_ids: [],
-            recipe_template_id: null,
-            active_recipe_instance_id: null,
-        };
-        const antithesisStage: DialecticStage = {
-            ...thesisStage,
-            id: 'stage-antithesis',
-            slug: 'antithesis',
-            display_name: 'Antithesis',
-        };
-        const synthesisStageForList: DialecticStage = {
-            ...thesisStage,
-            id: 'stage-synthesis',
-            slug: 'synthesis',
-            display_name: 'Synthesis',
-        };
-        const transitionThesisToAntithesis: DialecticStageTransition = {
-            id: 't1',
-            process_template_id: 'pt-1',
-            source_stage_id: thesisStage.id,
-            target_stage_id: antithesisStage.id,
-            created_at: new Date().toISOString(),
-            condition_description: null,
-        };
-        const transitionAntithesisToSynthesis: DialecticStageTransition = {
-            id: 't2',
-            process_template_id: 'pt-1',
-            source_stage_id: antithesisStage.id,
-            target_stage_id: synthesisStageForList.id,
-            created_at: new Date().toISOString(),
-            condition_description: null,
-        };
-        const processTemplateTransitions: DialecticStageTransition[] = [
-            transitionThesisToAntithesis,
-            transitionAntithesisToSynthesis,
-        ];
-        const processTemplateWithStages: DialecticProcessTemplate = {
-            id: 'pt-1',
-            name: 'Test Template',
-            description: 'Test',
-            created_at: new Date().toISOString(),
-            starting_stage_id: thesisStage.id,
-            stages: [thesisStage, antithesisStage, synthesisStageForList],
-            transitions: processTemplateTransitions,
-        };
-
-        it('renders only the active stage checklist (does not render per-stage accordion content)', () => {
-            setDialecticStateValues({
-                activeContextSessionId: sessionId,
-                activeStageSlug: stageSlug,
-                activeSessionDetail: baseSession,
-                currentProcessTemplate: processTemplateWithStages,
-                recipesByStageSlug: {
-                    thesis: createRecipe([buildRenderStep()], 'thesis'),
-                    antithesis: createRecipe([buildRenderStep()], 'antithesis'),
-                    synthesis: createRecipe([buildRenderStep(), buildSecondaryRenderStep()], 'synthesis'),
-                },
-                stageRunProgress: {},
-            });
-            selectValidMarkdownDocumentKeys.mockImplementation((_state: DialecticStateValues, slug: string) => {
-                if (slug === 'synthesis') return new Set(['synthesis_document_rendered', 'synthesis_document_secondary']);
-                return new Set(['document_rendered']);
-            });
-
-            act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-            expect(screen.getByTestId('stage-run-checklist-accordion')).toBeInTheDocument();
-            expect(screen.queryByTestId('stage-run-checklist-accordion-content-thesis')).toBeNull();
-            expect(screen.queryByTestId('stage-run-checklist-accordion-content-antithesis')).toBeNull();
-            expect(screen.queryByTestId('stage-run-checklist-accordion-content-synthesis')).toBeNull();
-        });
-
         it('when a stage is focused, the stage displays all documents the stage will produce (from recipe)', () => {
             setChecklistState(createRecipe([buildRenderStep(), buildSecondaryRenderStep()], stageSlug), createProgressEntry({}, {}));
             selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered', 'synthesis_document_secondary']));
@@ -1486,7 +1255,7 @@ describe('StageRunChecklist', () => {
         });
 
             const row = screen.getByTestId('document-synthesis_document_rendered');
-            expect(within(row).getByText(/Completed|Not started|\d+\/\d+/i)).toBeInTheDocument();
+            expect(within(row).getByTestId('document-completed-icon')).toBeInTheDocument();
         });
 
         it('shows consolidated status based on existing model versions, not current selected models', () => {
@@ -1529,18 +1298,10 @@ describe('StageRunChecklist', () => {
             });
 
             const row = screen.getByTestId('document-synthesis_document_rendered');
-            expect(within(row).getByText('Completed')).toBeInTheDocument();
-
-            fireEvent.click(row);
-            const perModelSection = within(row).queryByTestId('stage-run-checklist-row-per-model-status');
-            expect(perModelSection).toBeInTheDocument();
-            if (perModelSection) {
-                expect(within(perModelSection).getAllByText(/Completed/i).length).toBe(2);
-                expect(within(perModelSection).queryByText(/Not started/i)).toBeNull();
-            }
+            expect(within(row).getByTestId('document-completed-icon')).toBeInTheDocument();
         });
 
-        it('when user focuses a document row, row expands to show per-model status for that document', () => {
+        it('clicking a document focuses existing model versions, not the user’s current selected models', () => {
             const modelIdB = 'model-b';
             selectSelectedModels.mockReturnValue([
                 { id: modelIdA, displayName: 'Model A' },
@@ -1561,7 +1322,7 @@ describe('StageRunChecklist', () => {
                     stepKey: 'render_document',
                 },
                 [makeStageRunDocumentKey(documentKey, modelIdB)]: {
-                    status: 'continuing',
+                    status: 'completed',
                     job_id: 'job-2',
                     latestRenderedResourceId: 'res-2',
                     modelId: modelIdB,
@@ -1578,109 +1339,7 @@ describe('StageRunChecklist', () => {
             });
 
             const documentRow = screen.getByTestId('document-synthesis_document_rendered');
-            fireEvent.click(documentRow);
-
-            const perModelSection = within(documentRow).queryByTestId('stage-run-checklist-row-per-model-status');
-            expect(perModelSection).toBeInTheDocument();
-            if (!perModelSection) {
-                throw new Error('expected per-model section');
-            }
-            expect(within(perModelSection).getByText(/Completed/i)).toBeInTheDocument();
-            expect(within(perModelSection).getByText(/Continuing|Generating/i)).toBeInTheDocument();
-        });
-
-        it('clicking the document row arrow toggles per-model list without changing focus (onDocumentSelect not called)', () => {
-            const modelIdB = 'model-b';
-            selectSelectedModels.mockReturnValue([
-                { id: modelIdA, displayName: 'Model A' },
-                { id: modelIdB, displayName: 'Model B' },
-            ]);
-            const recipe = createRecipe([buildRenderStep()]);
-            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
-            const documentKey = 'synthesis_document_rendered';
-            const documents: StageRunDocuments = {
-                [makeStageRunDocumentKey(documentKey, modelIdA)]: {
-                    status: 'completed',
-                    job_id: 'job-1',
-                    latestRenderedResourceId: 'res-1',
-                    modelId: modelIdA,
-                    versionHash: 'h1',
-                    lastRenderedResourceId: 'res-1',
-                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
-                    stepKey: 'render_document',
-                },
-                [makeStageRunDocumentKey(documentKey, modelIdB)]: {
-                    status: 'continuing',
-                    job_id: 'job-2',
-                    latestRenderedResourceId: 'res-2',
-                    modelId: modelIdB,
-                    versionHash: 'h2',
-                    lastRenderedResourceId: 'res-2',
-                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
-                    stepKey: 'render_document',
-                },
-            };
-            setChecklistState(recipe, createProgressEntry({ render_document: 'completed' }, documents));
-
-            const onDocumentSelect = vi.fn();
-            act(() => {
-                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={onDocumentSelect} />);
-            });
-
-            const documentRow = screen.getByTestId('document-synthesis_document_rendered');
-            const arrowButton = within(documentRow).queryByTestId('stage-run-checklist-row-toggle-per-model');
-            expect(arrowButton).toBeInTheDocument();
-            if (!arrowButton) {
-                throw new Error('expected document row toggle');
-            }
-            fireEvent.click(arrowButton);
-
-            const perModelSection = within(documentRow).queryByTestId('stage-run-checklist-row-per-model-status');
-            expect(perModelSection).toBeInTheDocument();
-            expect(onDocumentSelect).not.toHaveBeenCalled();
-        });
-
-        it('future stages show "Stage not ready" indicator; documents in ready stage show "Not started" when not begun', () => {
-            setDialecticStateValues({
-                activeContextSessionId: sessionId,
-                activeStageSlug: 'antithesis',
-                activeSessionDetail: baseSession,
-                currentProcessTemplate: processTemplateWithStages,
-                recipesByStageSlug: {
-                    thesis: createRecipe([buildRenderStep()], 'thesis'),
-                    antithesis: createRecipe([buildRenderStep()], 'antithesis'),
-                    synthesis: createRecipe([buildRenderStep()], 'synthesis'),
-                },
-                stageRunProgress: {},
-            });
-            selectValidMarkdownDocumentKeys.mockImplementation((_state: DialecticStateValues, slug: string) => {
-                return new Set([slug === 'thesis' ? 'thesis_doc' : 'doc_rendered']);
-            });
-
-            act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-            expect(screen.getByText(/Stage not ready|Not started|No documents generated yet/i)).toBeInTheDocument();
-        });
-
-        it('distinguishes "Stage not ready" from "Document not started"', () => {
-            setDialecticStateValues({
-                activeContextSessionId: sessionId,
-                activeStageSlug: stageSlug,
-                activeSessionDetail: baseSession,
-                currentProcessTemplate: processTemplateWithStages,
-                recipesByStageSlug: { [stageSlug]: createRecipe([buildRenderStep()], stageSlug) },
-                stageRunProgress: {},
-            });
-            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
-
-            act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-            const notStarted = screen.getAllByText('Not Started');
-            expect(notStarted.length).toBeGreaterThanOrEqual(0);
+            expect(within(documentRow).getByTestId('document-completed-icon')).toBeInTheDocument();
         });
 
         it('clicking a document focuses existing model versions, not the user’s current selected models', () => {
@@ -1723,34 +1382,6 @@ describe('StageRunChecklist', () => {
             }));
         });
 
-        it('does not render per-stage accordion content even when template includes multiple stages', () => {
-            setDialecticStateValues({
-                activeContextSessionId: sessionId,
-                activeStageSlug: stageSlug,
-                activeSessionDetail: baseSession,
-                currentProcessTemplate: processTemplateWithStages,
-                recipesByStageSlug: {
-                    thesis: createRecipe([buildRenderStep()], 'thesis'),
-                    antithesis: createRecipe([buildRenderStep()], 'antithesis'),
-                    synthesis: createRecipe([buildRenderStep(), buildSecondaryRenderStep()], 'synthesis'),
-                },
-                stageRunProgress: {},
-            });
-            selectValidMarkdownDocumentKeys.mockImplementation((_state: DialecticStateValues, slug: string) => {
-                if (slug === 'synthesis') return new Set(['synthesis_document_rendered', 'synthesis_document_secondary']);
-                return new Set(['document_rendered']);
-            });
-
-            act(() => {
-            render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
-        });
-
-            expect(screen.getByTestId('stage-run-checklist-accordion')).toBeInTheDocument();
-            expect(screen.queryByTestId('stage-run-checklist-accordion-content-thesis')).toBeNull();
-            expect(screen.queryByTestId('stage-run-checklist-accordion-content-antithesis')).toBeNull();
-            expect(screen.queryByTestId('stage-run-checklist-accordion-content-synthesis')).toBeNull();
-        });
-
         it('does filter display of any steps that do not produce a document that will be rendered for the user to view (headers, intermediate products)', () => {
             const recipe = createRecipe([buildRenderStepWithHeaderContext()]);
             selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
@@ -1763,6 +1394,393 @@ describe('StageRunChecklist', () => {
 
             expect(screen.getByTestId('document-synthesis_document_rendered')).toBeInTheDocument();
             expect(screen.queryByTestId('document-synthesis_plan_header')).toBeNull();
+        });
+    });
+
+    describe('document regenerate (redo) button', () => {
+        it('completed document row shows a redo button with same color as status dot (green) and size no larger than dot', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    status: 'completed',
+                    job_id: 'job-render',
+                    latestRenderedResourceId: 'resource-render',
+                    modelId: modelIdA,
+                    versionHash: 'hash-render',
+                    lastRenderedResourceId: 'resource-render',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'completed' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            const regenerateButton = within(row).getByRole('button', { name: /regenerate|redo/i });
+            expect(regenerateButton).toBeInTheDocument();
+            expect(regenerateButton).toHaveClass('bg-emerald-500');
+            expect(regenerateButton.className).toMatch(/h-\[15px\]|h-2\.5|h-3|w-\[15px\]|w-2\.5|w-3/);
+        });
+
+        it('failed document row shows a redo button with same color as status dot (red)', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    status: 'failed',
+                    job_id: 'job-failed',
+                    latestRenderedResourceId: 'resource-render',
+                    modelId: modelIdA,
+                    versionHash: 'hash-render',
+                    lastRenderedResourceId: 'resource-render',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'failed' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            const regenerateButton = within(row).getByRole('button', { name: /regenerate|redo/i });
+            expect(regenerateButton).toHaveClass('bg-destructive');
+        });
+
+        it('not started document row shows colored status dot only, no regenerate button (nothing to redo)', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    descriptorType: 'planned',
+                    status: 'not_started',
+                    stepKey: 'render_document',
+                    modelId: modelIdA,
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'not_started' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).queryByRole('button', { name: /regenerate|redo/i })).not.toBeInTheDocument();
+            expect(within(row).getByTestId('document-not-started-icon')).toBeInTheDocument();
+        });
+
+        it('stuck document row (continuing or generating but not completed or failed) shows regenerate button so user can redo', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    status: 'continuing',
+                    job_id: 'job-render',
+                    latestRenderedResourceId: 'resource-render',
+                    modelId: modelIdA,
+                    versionHash: 'hash-render',
+                    lastRenderedResourceId: 'resource-render',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'in_progress' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).getByRole('button', { name: /regenerate|redo/i })).toBeInTheDocument();
+        });
+    });
+
+    describe('regenerate button only on current stage after stage has been run', () => {
+        it('current stage with stage progress shows regenerate button', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    status: 'completed',
+                    job_id: 'job-render',
+                    latestRenderedResourceId: 'resource-render',
+                    modelId: modelIdA,
+                    versionHash: 'hash-render',
+                    lastRenderedResourceId: 'resource-render',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'completed' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).getByRole('button', { name: /regenerate|redo/i })).toBeInTheDocument();
+        });
+
+        it('current stage with no stage progress shows colored status dot only, no regenerate button', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            setDialecticStateValues({
+                activeContextSessionId: sessionId,
+                activeStageSlug: recipe.stageSlug,
+                activeSessionDetail: baseSession,
+                currentProcessTemplate: buildProcessTemplateForStage(recipe.stageSlug),
+                recipesByStageSlug: { [recipe.stageSlug]: recipe },
+                stageRunProgress: {},
+            });
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).queryByRole('button', { name: /regenerate|redo/i })).not.toBeInTheDocument();
+            expect(within(row).getByTestId('document-not-started-icon')).toBeInTheDocument();
+        });
+
+        it('current stage with no stage progress: status indicator is not a button and is not interactable', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            setDialecticStateValues({
+                activeContextSessionId: sessionId,
+                activeStageSlug: recipe.stageSlug,
+                activeSessionDetail: baseSession,
+                currentProcessTemplate: buildProcessTemplateForStage(recipe.stageSlug),
+                recipesByStageSlug: { [recipe.stageSlug]: recipe },
+                stageRunProgress: {},
+            });
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            const statusIndicator = within(row).getByTestId('document-not-started-icon');
+            expect(statusIndicator.tagName).toBe('SPAN');
+            fireEvent.click(statusIndicator);
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        it('when regenerate dialog is open it shows a list of models to select', () => {
+            const modelIdB = 'model-b';
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            selectSelectedModels.mockReturnValue([
+                { id: modelIdA, displayName: 'Model A' },
+                { id: modelIdB, displayName: 'Model B' },
+            ]);
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    status: 'completed',
+                    job_id: 'job-1',
+                    latestRenderedResourceId: 'res-1',
+                    modelId: modelIdA,
+                    versionHash: 'h1',
+                    lastRenderedResourceId: 'res-1',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdB)]: {
+                    status: 'completed',
+                    job_id: 'job-2',
+                    latestRenderedResourceId: 'res-2',
+                    modelId: modelIdB,
+                    versionHash: 'h2',
+                    lastRenderedResourceId: 'res-2',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'completed' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            const regenerateButton = within(row).getByRole('button', { name: /regenerate|redo/i });
+            act(() => {
+                fireEvent.click(regenerateButton);
+            });
+
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+            expect(screen.getByText(/Select which model/i)).toBeInTheDocument();
+            expect(screen.getByText('Model A')).toBeInTheDocument();
+            expect(screen.getByText('Model B')).toBeInTheDocument();
+        });
+
+        it('current stage with stage progress but no models for document (empty checklist) shows status dot only, no regenerate button', () => {
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const progressKey = `${sessionId}:${recipe.stageSlug}:${iterationNumber}`;
+            setDialecticStateValues({
+                activeContextSessionId: sessionId,
+                activeStageSlug: recipe.stageSlug,
+                activeSessionDetail: baseSession,
+                currentProcessTemplate: buildProcessTemplateForStage(recipe.stageSlug),
+                recipesByStageSlug: { [recipe.stageSlug]: recipe },
+                stageRunProgress: {
+                    [progressKey]: createProgressEntry(
+                        { render_document: 'not_started' },
+                        {},
+                    ),
+                },
+            });
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).queryByRole('button', { name: /regenerate|redo/i })).not.toBeInTheDocument();
+            expect(within(row).getByTestId('document-not-started-icon')).toBeInTheDocument();
+        });
+
+        it('when regenerate dialog is open with no models selected, Regenerate button in dialog is disabled', () => {
+            const modelIdB = 'model-b';
+            const recipe = createRecipe([buildRenderStep()]);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            selectSelectedModels.mockReturnValue([
+                { id: modelIdA, displayName: 'Model A' },
+                { id: modelIdB, displayName: 'Model B' },
+            ]);
+            const documents: StageRunDocuments = {
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                    status: 'completed',
+                    job_id: 'job-1',
+                    latestRenderedResourceId: 'res-1',
+                    modelId: modelIdA,
+                    versionHash: 'h1',
+                    lastRenderedResourceId: 'res-1',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+                [makeStageRunDocumentKey('synthesis_document_rendered', modelIdB)]: {
+                    status: 'completed',
+                    job_id: 'job-2',
+                    latestRenderedResourceId: 'res-2',
+                    modelId: modelIdB,
+                    versionHash: 'h2',
+                    lastRenderedResourceId: 'res-2',
+                    lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                },
+            };
+            setChecklistState(recipe, createProgressEntry({ render_document: 'completed' }, documents));
+
+            act(() => {
+                render(<StageRunChecklist modelId={modelIdA} onDocumentSelect={vi.fn()} />);
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            const regenerateButton = within(row).getByRole('button', { name: /regenerate|redo/i });
+            act(() => {
+                fireEvent.click(regenerateButton);
+            });
+
+            const dialogRegenerateButton = screen.getByRole('button', { name: /^Regenerate$/i });
+            expect(dialogRegenerateButton).toBeDisabled();
+        });
+
+        it('viewing previous stage shows colored status dot only, no regenerate button', () => {
+            const synthesisRecipe = createRecipe([buildRenderStep()]);
+            const analysisRecipe = createRecipe([buildRenderStep()], alternateStageSlug);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const sessionWithAnalysisCurrent: DialecticSession = {
+                ...baseSession,
+                current_stage_id: `stage-${alternateStageSlug}`,
+            };
+            setDialecticStateValues({
+                activeContextSessionId: sessionId,
+                activeStageSlug: synthesisRecipe.stageSlug,
+                activeSessionDetail: sessionWithAnalysisCurrent,
+                currentProcessTemplate: buildProcessTemplateForStage(synthesisRecipe.stageSlug),
+                recipesByStageSlug: {
+                    [synthesisRecipe.stageSlug]: synthesisRecipe,
+                    [analysisRecipe.stageSlug]: analysisRecipe,
+                },
+                stageRunProgress: {
+                    [`${sessionId}:${synthesisRecipe.stageSlug}:${iterationNumber}`]: createProgressEntry(
+                        { render_document: 'completed' },
+                        {
+                            [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                                status: 'completed',
+                                job_id: 'job-render',
+                                latestRenderedResourceId: 'resource-render',
+                                modelId: modelIdA,
+                                versionHash: 'hash-render',
+                                lastRenderedResourceId: 'resource-render',
+                                lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                            },
+                        },
+                    ),
+                },
+            });
+
+            act(() => {
+                render(
+                    <StageRunChecklist
+                        modelId={modelIdA}
+                        onDocumentSelect={vi.fn()}
+                        stageSlug={synthesisRecipe.stageSlug}
+                    />,
+                );
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).queryByRole('button', { name: /regenerate|redo/i })).not.toBeInTheDocument();
+            expect(within(row).getByTestId('document-completed-icon')).toBeInTheDocument();
+        });
+
+        it('viewing future stage shows colored status dot only, no regenerate button', () => {
+            const synthesisRecipe = createRecipe([buildRenderStep()]);
+            const analysisRecipe = createRecipe([buildRenderStep()], alternateStageSlug);
+            selectValidMarkdownDocumentKeys.mockReturnValue(new Set(['synthesis_document_rendered']));
+            const sessionWithSynthesisCurrent: DialecticSession = {
+                ...baseSession,
+                current_stage_id: 'stage-synthesis',
+            };
+            setDialecticStateValues({
+                activeContextSessionId: sessionId,
+                activeStageSlug: synthesisRecipe.stageSlug,
+                activeSessionDetail: sessionWithSynthesisCurrent,
+                currentProcessTemplate: buildProcessTemplateForStage(alternateStageSlug),
+                recipesByStageSlug: {
+                    [synthesisRecipe.stageSlug]: synthesisRecipe,
+                    [analysisRecipe.stageSlug]: analysisRecipe,
+                },
+                stageRunProgress: {
+                    [`${sessionId}:${alternateStageSlug}:${iterationNumber}`]: createProgressEntry(
+                        { render_document: 'completed' },
+                        {
+                            [makeStageRunDocumentKey('synthesis_document_rendered', modelIdA)]: {
+                                status: 'completed',
+                                job_id: 'job-render',
+                                latestRenderedResourceId: 'resource-render',
+                                modelId: modelIdA,
+                                versionHash: 'hash-render',
+                                lastRenderedResourceId: 'resource-render',
+                                lastRenderAtIso: '2025-01-01T00:00:00.000Z',
+                            },
+                        },
+                    ),
+                },
+            });
+
+            act(() => {
+                render(
+                    <StageRunChecklist
+                        modelId={modelIdA}
+                        onDocumentSelect={vi.fn()}
+                        stageSlug={alternateStageSlug}
+                    />,
+                );
+            });
+
+            const row = screen.getByTestId('document-synthesis_document_rendered');
+            expect(within(row).queryByRole('button', { name: /regenerate|redo/i })).not.toBeInTheDocument();
+            expect(within(row).getByTestId('document-completed-icon')).toBeInTheDocument();
         });
     });
 });

--- a/apps/web/src/components/dialectic/StageRunChecklist.tsx
+++ b/apps/web/src/components/dialectic/StageRunChecklist.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import type {
   DialecticStateValues,
+  RegenerateDocumentPayload,
   SetFocusedStageDocumentPayload,
   StageDocumentEntry,
   StageRunChecklistProps,
@@ -20,7 +21,16 @@ import {
 
 import { isDocumentHighlighted } from '@paynless/utils';
 import { cn } from '@/lib/utils';
-import { Loader2 } from 'lucide-react';
+import { RefreshCcw } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 
 type MarkdownDocumentDescriptor = {
   documentKey: string;
@@ -119,6 +129,12 @@ function getMarkdownDocumentDescriptors(
 
 type PerModelLabel = { modelId: string; displayName: string; statusLabel: string };
 
+type RegenerateDialogContext = {
+  documentKey: string;
+  stageSlug: string;
+  perModelLabels: PerModelLabel[];
+};
+
 type StageDocumentRow = {
   entry: StageDocumentEntry;
   stepKey: string;
@@ -129,6 +145,7 @@ type StageDocumentRow = {
 type StageChecklistData = {
   stage: { id: string; slug: string; display_name: string | null };
   isReady: boolean;
+  hasStageProgress: boolean;
   documentRows: StageDocumentRow[];
 };
 
@@ -339,6 +356,8 @@ function computeStageRunChecklistData(
 
     documentRows.sort((a, b) => a.entry.documentKey.localeCompare(b.entry.documentKey));
 
+    const hasStageProgress = stageProgress != null;
+
     return {
       stage: {
         id: stage.id,
@@ -346,6 +365,7 @@ function computeStageRunChecklistData(
         display_name: stage.display_name ?? null,
       },
       isReady,
+      hasStageProgress,
       documentRows,
     };
   });
@@ -373,11 +393,16 @@ const StageRunChecklist: React.FC<StageRunChecklistProps> = ({
   const iterationNumber = activeSessionDetail?.iteration_count;
   const storeActiveStageSlug = useDialecticStore((state) => state.activeStageSlug);
   const setActiveStage = useDialecticStore((state) => state.setActiveStage);
+  const regenerateDocument = useDialecticStore((state) => state.regenerateDocument);
   const effectiveStageSlug = stageSlugProp ?? storeActiveStageSlug;
   const checklistData = useDialecticStore((state) =>
     computeStageRunChecklistData(state, modelId),
   );
   const effectiveFocusedStageDocumentMap = focusedStageDocumentMap ?? {};
+
+  const [regenerateDialogOpen, setRegenerateDialogOpen] = useState(false);
+  const [regenerateDialogContext, setRegenerateDialogContext] = useState<RegenerateDialogContext | null>(null);
+  const [regenerateSelectedModelIds, setRegenerateSelectedModelIds] = useState<Set<string>>(new Set());
 
   const handleDocumentSelectForStage = useCallback(
     (documentKey: string, stepKey: string, stageSlug: string, modelIds: string[]) => {
@@ -429,6 +454,91 @@ const StageRunChecklist: React.FC<StageRunChecklistProps> = ({
       }
     },
     [handleDocumentSelectForStage],
+  );
+
+  const stageDataForCurrentStage = checklistData.stageDataList.find(
+    (candidate) => candidate.stage.slug === effectiveStageSlug,
+  );
+  const isDocumentOnCurrentStage =
+    activeSessionDetail?.current_stage_id != null &&
+    stageDataForCurrentStage != null &&
+    stageDataForCurrentStage.stage.id === activeSessionDetail.current_stage_id;
+
+  const openRegenerateDialog = useCallback(
+    (documentKey: string, stageSlug: string, perModelLabels: PerModelLabel[]) => {
+      const preChecked = new Set(
+        perModelLabels
+          .filter((l) => l.statusLabel === 'Failed' || l.statusLabel === 'Not started')
+          .map((l) => l.modelId),
+      );
+      setRegenerateDialogContext({ documentKey, stageSlug, perModelLabels });
+      setRegenerateSelectedModelIds(preChecked);
+      setRegenerateDialogOpen(true);
+    },
+    [],
+  );
+
+  const handleRegenerateConfirm = useCallback(() => {
+    if (
+      !regenerateDialogContext ||
+      !activeSessionId ||
+      typeof iterationNumber !== 'number' ||
+      regenerateSelectedModelIds.size === 0
+    ) {
+      setRegenerateDialogOpen(false);
+      setRegenerateDialogContext(null);
+      return;
+    }
+    const documents = Array.from(regenerateSelectedModelIds).map((modelId) => ({
+      documentKey: regenerateDialogContext.documentKey,
+      modelId,
+    }));
+    const payload: RegenerateDocumentPayload = {
+      sessionId: activeSessionId,
+      stageSlug: regenerateDialogContext.stageSlug,
+      iterationNumber,
+      documents,
+    };
+    void regenerateDocument(payload);
+    setRegenerateDialogOpen(false);
+    setRegenerateDialogContext(null);
+  }, [
+    regenerateDialogContext,
+    activeSessionId,
+    iterationNumber,
+    regenerateSelectedModelIds,
+    regenerateDocument,
+  ]);
+
+  const handleRegenerateButtonClick = useCallback(
+    (e: React.MouseEvent, documentKey: string, stageSlug: string, perModelLabels: PerModelLabel[]) => {
+      e.stopPropagation();
+      if (
+        !isDocumentOnCurrentStage ||
+        !activeSessionId ||
+        typeof iterationNumber !== 'number'
+      ) {
+        return;
+      }
+      if (perModelLabels.length === 1) {
+        const payload: RegenerateDocumentPayload = {
+          sessionId: activeSessionId,
+          stageSlug,
+          iterationNumber,
+          documents: [{ documentKey, modelId: perModelLabels[0].modelId }],
+        };
+        void regenerateDocument(payload);
+      } else {
+        openRegenerateDialog(documentKey, stageSlug, perModelLabels);
+      }
+    },
+    [
+      isDocumentOnCurrentStage,
+      activeSessionId,
+      iterationNumber,
+      regenerateDocument,
+      openRegenerateDialog,
+    ],
   );
 
   const shouldShowGuard = checklistData.sortedStages.length === 0;
@@ -528,29 +638,62 @@ const StageRunChecklist: React.FC<StageRunChecklistProps> = ({
                 )
               }
             >
-              {entry.status === 'generating' || entry.status === 'continuing' ? (
-                <Loader2
-                  aria-label="Document generating"
-                  className="h-3 w-3 shrink-0 text-blue-500 animate-spin"
-                  data-testid="document-generating-icon"
-                />
-              ) : entry.status === 'completed' ? (
+              {entry.status === 'not_started' ? (
                 <span
-                  aria-label="Document completed"
-                  className="block h-2.5 w-2.5 shrink-0 rounded-full bg-emerald-500"
-                  data-testid="document-completed-icon"
+                  className={cn(
+                    'inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-amber-400',
+                  )}
+                  data-testid="document-not-started-icon"
+                  aria-hidden
                 />
-              ) : entry.status === 'failed' ? (
-                <span
-                  aria-label="Document failed"
-                  className="block h-2.5 w-2.5 shrink-0 rounded-full bg-destructive"
-                  data-testid="document-failed-icon"
-                />
+              ) : isDocumentOnCurrentStage &&
+                stageData.hasStageProgress &&
+                perModelLabels.length > 0 ? (
+                <button
+                  type="button"
+                  className={cn(
+                    'inline-flex h-[15px] w-[15px] shrink-0 items-center justify-center rounded-full',
+                    entry.status === 'completed' && 'bg-emerald-500',
+                    entry.status === 'failed' && 'bg-destructive',
+                    (entry.status === 'generating' || entry.status === 'continuing') &&
+                      'bg-amber-400',
+                  )}
+                  aria-label="Regenerate document"
+                  data-testid={
+                    entry.status === 'completed'
+                      ? 'document-completed-icon'
+                      : entry.status === 'failed'
+                        ? 'document-failed-icon'
+                        : 'document-generating-icon'
+                  }
+                  onClick={(e) =>
+                    handleRegenerateButtonClick(
+                      e,
+                      entry.documentKey,
+                      stageData.stage.slug,
+                      perModelLabels,
+                    )
+                  }
+                >
+                  <RefreshCcw className="h-[15px] w-[15px] text-white" />
+                </button>
               ) : (
                 <span
-                  aria-label="Not started"
-                  className="block h-2.5 w-2.5 shrink-0 rounded-full bg-amber-400"
-                  data-testid="document-not-started-icon"
+                  className={cn(
+                    'inline-block h-2.5 w-2.5 shrink-0 rounded-full',
+                    entry.status === 'completed' && 'bg-emerald-500',
+                    entry.status === 'failed' && 'bg-destructive',
+                    (entry.status === 'generating' || entry.status === 'continuing') &&
+                      'bg-amber-400',
+                  )}
+                  data-testid={
+                    entry.status === 'completed'
+                      ? 'document-completed-icon'
+                      : entry.status === 'failed'
+                        ? 'document-failed-icon'
+                        : 'document-generating-icon'
+                  }
+                  aria-hidden
                 />
               )}
               <span className="font-mono text-xs truncate">
@@ -560,6 +703,71 @@ const StageRunChecklist: React.FC<StageRunChecklistProps> = ({
           );
         })}
       </ul>
+      <Dialog
+        open={regenerateDialogOpen}
+        onOpenChange={(open) => {
+          setRegenerateDialogOpen(open);
+          if (!open) setRegenerateDialogContext(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Regenerate document</DialogTitle>
+          </DialogHeader>
+          {regenerateDialogContext && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Select which model outputs to regenerate for{' '}
+                <code className="font-mono text-xs">{regenerateDialogContext.documentKey}</code>.
+              </p>
+              <div className="flex flex-col gap-2">
+                {regenerateDialogContext.perModelLabels.map((label) => (
+                  <label
+                    key={label.modelId}
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <Checkbox
+                      checked={regenerateSelectedModelIds.has(label.modelId)}
+                      onCheckedChange={(checked) => {
+                        setRegenerateSelectedModelIds((prev) => {
+                          const next = new Set(prev);
+                          if (checked) {
+                            next.add(label.modelId);
+                          } else {
+                            next.delete(label.modelId);
+                          }
+                          return next;
+                        });
+                      }}
+                    />
+                    <span className="text-sm">{label.displayName}</span>
+                    <span className="text-xs text-muted-foreground">
+                      ({label.statusLabel})
+                    </span>
+                  </label>
+                ))}
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setRegenerateDialogOpen(false);
+                    setRegenerateDialogContext(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleRegenerateConfirm}
+                  disabled={regenerateSelectedModelIds.size === 0}
+                >
+                  Regenerate
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/apps/web/src/components/dialectic/SubmitResponsesButton.test.tsx
+++ b/apps/web/src/components/dialectic/SubmitResponsesButton.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toast } from 'sonner';
 import {
+  emptyStageRunProgressSnapshot,
   getDialecticStoreState,
   initializeMockDialecticState,
   setDialecticStateValues,
@@ -42,7 +43,17 @@ const sessionId = 'sess-1';
 const stageSlug = 'thesis';
 const iterationNumber = 1;
 const progressKey = `${sessionId}:${stageSlug}:${iterationNumber}`;
+const antithesisProgressKey = `${sessionId}:antithesis:${iterationNumber}`;
 const isoTimestamp = '2024-01-01T00:00:00.000Z';
+
+function buildMinimalRecipe(slug: string): DialecticStageRecipe {
+  return {
+    stageSlug: slug,
+    instanceId: 'inst-1',
+    steps: [],
+    edges: [],
+  };
+}
 
 function buildRenderedDescriptor(
   modelId: string,
@@ -208,6 +219,7 @@ function setupVisibleButtonState(): void {
     activeStageSlug: stage1.slug,
     recipesByStageSlug: {
       thesis: buildThesisRecipeWithDocumentKey('success_metrics'),
+      antithesis: buildMinimalRecipe('antithesis'),
     },
     stageRunProgress: {
       [progressKey]: {
@@ -222,6 +234,7 @@ function setupVisibleButtonState(): void {
         },
         jobProgress: {},
       },
+      [antithesisProgressKey]: emptyStageRunProgressSnapshot,
     },
     isSubmittingStageResponses: false,
     submitStageResponsesError: null,
@@ -276,13 +289,6 @@ describe('SubmitResponsesButton', () => {
     expect(screen.queryByTestId('card-footer')).not.toBeInTheDocument();
   });
 
-  it('does not render when selectIsStageReadyForSessionIteration returns false', () => {
-    setupVisibleButtonState();
-    selectIsStageReadyForSessionIteration.mockReturnValue(false);
-    render(<SubmitResponsesButton />);
-    expect(screen.queryByTestId('card-footer')).not.toBeInTheDocument();
-  });
-
   it('does not render when isFinalStage is true (no outgoing transitions from activeStage)', () => {
     const stage = buildStage('stage-1', stageSlug, 'Thesis');
     const processTemplate = buildProcessTemplate([stage]);
@@ -323,8 +329,14 @@ describe('SubmitResponsesButton', () => {
       activeContextSessionId: sessionId,
       activeContextStage: stage1,
       currentProcessTemplate: processTemplate,
-      recipesByStageSlug: {},
-      stageRunProgress: {},
+      recipesByStageSlug: {
+        thesis: buildMinimalRecipe('thesis'),
+        antithesis: buildMinimalRecipe('antithesis'),
+      },
+      stageRunProgress: {
+        [progressKey]: emptyStageRunProgressSnapshot,
+        [antithesisProgressKey]: emptyStageRunProgressSnapshot,
+      },
     });
     selectIsStageReadyForSessionIteration.mockReturnValue(true);
     render(<SubmitResponsesButton />);
@@ -338,6 +350,7 @@ describe('SubmitResponsesButton', () => {
     setDialecticStateValues({
       recipesByStageSlug: {
         thesis: buildThesisRecipeWithDocumentKey('doc'),
+        antithesis: buildMinimalRecipe('antithesis'),
       },
       stageRunProgress: {
         [progressKey]: {
@@ -356,6 +369,7 @@ describe('SubmitResponsesButton', () => {
           },
           jobProgress: {},
         },
+        [antithesisProgressKey]: emptyStageRunProgressSnapshot,
       },
     });
     render(<SubmitResponsesButton />);

--- a/apps/web/src/components/dialectic/SubmitResponsesButton.tsx
+++ b/apps/web/src/components/dialectic/SubmitResponsesButton.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import {
   useDialecticStore,
   selectActiveContextSessionId,
-  selectIsStageReadyForSessionIteration,
   selectSortedStages,
   selectStageHasUnsavedChanges,
   selectUnifiedProjectProgress,
@@ -34,20 +33,6 @@ export const SubmitResponsesButton: React.FC = () => {
   const submitStageResponses = useDialecticStore((state) => state.submitStageResponses);
   const isSubmitting = useDialecticStore((state) => state.isSubmittingStageResponses);
   const submitError = useDialecticStore((state) => state.submitStageResponsesError);
-
-  const isStageReady = useDialecticStore((state) => {
-    const p = state.currentProjectDetail;
-    const s = state.activeSessionDetail;
-    const a = state.activeContextStage;
-    if (!p || !s || !a || typeof s.iteration_count !== 'number') return false;
-    return selectIsStageReadyForSessionIteration(
-      state,
-      p.id,
-      s.id,
-      a.slug,
-      s.iteration_count,
-    );
-  });
 
   const { activeStageDetail, hasUnsavedEdits, hasUnsavedFeedback } = useDialecticStore((state) => {
     const s = state.activeSessionDetail;
@@ -83,7 +68,7 @@ export const SubmitResponsesButton: React.FC = () => {
     activeStageDetail != null &&
     activeStageDetail.totalDocuments > 0 &&
     activeStageDetail.completedDocuments === activeStageDetail.totalDocuments;
-  const canShowButton = isStageReady && !isFinalStage;
+  const canShowButton = !isFinalStage;
   const shouldPulse = canShowButton && allDocumentsAvailable && !isSubmitting;
 
   const handleSubmit = async (): Promise<void> => {

--- a/apps/web/src/mocks/dialecticStore.mock.ts
+++ b/apps/web/src/mocks/dialecticStore.mock.ts
@@ -119,6 +119,7 @@ export const selectCurrentProcessTemplate = (state: DialecticStateValues): Diale
 export const selectOverlay = vi.fn();
 export const setFocusedStageDocument = vi.fn();
 export const submitStageDocumentFeedback = vi.fn();
+export const _handleContributionGenerationPausedNsf = vi.fn();
 
 export const selectFocusedStageDocument = (
   state: DialecticStateValues,
@@ -184,6 +185,7 @@ const defaultUnifiedProgress: UnifiedProjectProgress = {
   currentStage: null,
   projectStatus: 'not_started',
   stageDetails: [],
+  hydrationReady: false,
 };
 
 export const selectUnifiedProjectProgress: Mock<
@@ -313,6 +315,8 @@ export const selectStageProgressSummary = (
 // Define and export the mock for the new thunk
 export const mockActivateProjectAndSessionContextForDeepLink = vi.fn().mockResolvedValue(undefined);
 export const mockFetchAndSetCurrentSessionDetails = vi.fn().mockResolvedValue(undefined);
+
+export const mockResumePausedNsfJobs = vi.fn().mockResolvedValue({ data: { resumedCount: 0 }, error: undefined, status: 200 });
 
 // Mock Session (used in some action mocks)
 const mockSession: DialecticSession = {
@@ -516,6 +520,7 @@ const createActualMockStore = (initialOverrides?: Partial<DialecticStateValues>)
       resetSelectedModels: vi.fn(() => set({ selectedModels: [] })),
       fetchInitialPromptContent: vi.fn().mockResolvedValue(undefined),
       generateContributions: vi.fn().mockResolvedValue({ data: { message: 'ok', contributions: [] }, error: undefined, status: 200 }),
+      resumePausedNsfJobs: mockResumePausedNsfJobs,
       submitStageResponses: vi.fn().mockResolvedValue({ data: { message: 'ok', userFeedbackStoragePath: '/path', nextStageSeedPromptStoragePath: '/path', updatedSession: mockSession }, error: undefined, status: 200 }),
       setSubmittingStageResponses: vi.fn((isLoading: boolean) => set({ isSubmittingStageResponses: isLoading })),
       setSubmitStageResponsesError: vi.fn((error: ApiError | null) => set({ submitStageResponsesError: error })),
@@ -633,6 +638,7 @@ const createActualMockStore = (initialOverrides?: Partial<DialecticStateValues>)
       _handleContributionGenerationContinued: vi.fn(),
       _handleProgressUpdate: vi.fn(),
       _handleContributionGenerationComplete: vi.fn(),
+      _handleContributionGenerationPausedNsf: vi.fn(),
       _handlePlannerStarted: vi.fn(),
       _handlePlannerCompleted: vi.fn(),
       _handleDocumentStarted: vi.fn(),

--- a/docs/implementations/Current/Checklists/Complete/Prelaunch Fixes.md
+++ b/docs/implementations/Current/Checklists/Complete/Prelaunch Fixes.md
@@ -1485,12 +1485,6 @@ The user sees per-stage progress as `completedSteps / totalSteps` and per-DAG pr
     - Set baseline values for each stage "Generate" action and encourage users to top up their account if they are at risk of NSF
     -- Pause the work mid-stream if NSF and encourage user to top up to continue 
 
-    - hydrateAllStages doesn't, but the stage-specific one does
-    -- Front end shows "complete" and "Submit Responses" as soon as a document is available instead of waiting for the entire stage to actually complete 
-    -- Populating document list is unreliable
-    -- Total progress indicator loses track constantly
-    -- Stage completion indicators lose track the moment they're defocused
-
     - New user sign in banner doesn't display, throws console error  
     -- Chase, diagnose, fix 
 
@@ -1509,8 +1503,6 @@ The user sees per-stage progress as `completedSteps / totalSteps` and per-DAG pr
 
    - Build test fixtures for major function groups 
    -- Provide standard mock factories and objects 
-
-   - Show exact job progress in front end as pop up while working, then minimize to documents once documents arrive
       
    - Support user-provided API keys for their preferred providers 
 
@@ -1527,8 +1519,6 @@ The user sees per-stage progress as `completedSteps / totalSteps` and per-DAG pr
    - Search across documents for key terms 
 
    - Collect user satisfaction evaluation after each generation "How would you feel if you couldn't use this again?" 
-
-   - Fix StageTabCard count so that Save Responses & Advance Stage is visible 
 
    - Add optional outputs for selected stages
    -- A "landing page" output for the proposal stage

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -1,0 +1,788 @@
+[ ] // So that find->replace will stop unrolling my damned instructions! 
+
+# **DAG Progress Computation — Prelaunch Fixes**
+
+## Problem Statement
+
+The system provides no method to detect when a user has insufficient funds for the next set of work, pause the work, notify the user so they can correct the NSF condition, and resume the work after correction.
+
+## Objectives
+
+1. Identify when a user has NSF for a set of work. 
+2. Refuse to permit the user to engage new work in the NSF condition.
+3. Detect the NSF condition and pause existing work.
+4. Notify the user of the condition and the work pause.
+5. Detect when the user has resolved NSF. 
+6. Permit the user to resume from the paused state without losing any already-performed work. 
+7. The back end and front end are fully aware of the NSF state
+8. The progress tracking functions correctly report NSF and resume progress tracking when NSF is resolved. 
+
+## Expected Outcome
+
+A user cannot begin a set of work when they have NSF. If a user reaches NSF while work is being performed, it is automatically paused and the user notified. After the user corrects the NSF condition, the work can be continued from its prior state without any loss of progress. The front end is fully state aware through the entire NSF discovery-to-resume flow. 
+
+# Instructions for Agent
+* Read `docs/Instructions for Agent.md` before every turn.
+
+# Work Breakdown Structure
+
+## NSF Protection: UX Balance Gate + Backend Pause/Resume
+
+### Node 1
+*   `[✅]`   [DB] supabase/migrations **`paused_nsf` job status, trigger exclusions, and `resume_paused_nsf_jobs` RPC**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Introduce the `paused_nsf` job status to the database schema so that jobs encountering an "Insufficient funds" error can be paused instead of failed
+    *   `[✅]`   Ensure `paused_nsf` is NOT treated as a terminal status by `handle_job_completion()`, so parent PLAN jobs remain in `waiting_for_children` and do not cascade-fail
+    *   `[✅]`   Ensure `paused_nsf` does NOT appear in the `on_job_status_change` or `on_new_job_created` trigger WHEN clauses, so the dialectic-worker is NOT invoked for paused jobs
+    *   `[✅]`   Provide an RPC function `resume_paused_nsf_jobs` that restores each paused job's `original_status` from its `error_details` JSON, enabling the DAG to continue from its prior state
+  *   `[✅]`   `role`
+    *   `[✅]`   Infrastructure — database schema and trigger layer
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic generation job state machine — extends the status enum and modifies trigger functions that govern job lifecycle transitions
+    *   `[✅]`   Boundary: defines the `paused_nsf` status semantics and the atomic resume operation
+  *   `[✅]`   `deps`
+    *   `[✅]`   `handle_job_completion()` function (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 180) — must be verified/modified to exclude `paused_nsf` from terminal status evaluation
+    *   `[✅]`   `on_job_status_change` trigger (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 165) — WHEN clause currently fires for `('pending', 'pending_next_step', 'pending_continuation', 'retrying', 'processing')` — must NOT include `paused_nsf`
+    *   `[✅]`   `on_new_job_created` trigger (defined in `supabase/migrations/20260220213950_conditional_on_new_job_created.sql` line 15) — WHEN clause currently fires for `('pending', 'pending_continuation')` — must NOT include `paused_nsf`
+    *   `[✅]`   `dialectic_generation_jobs` table columns: `id`, `status`, `error_details` (JSONB), `session_id`, `stage_slug`, `iteration_number`, `parent_job_id`, `job_type`
+    *   `[✅]`   No reverse dependency introduced — this migration only extends existing infrastructure
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   Requires access to `dialectic_generation_jobs` table schema
+    *   `[✅]`   Requires understanding of the `error_details` JSONB convention — Node 2 (`pauseJobsForNsf`) will store `{ "original_status": "<status>", "nsf_paused": true }` in this column when pausing each job
+    *   `[✅]`   Requires understanding of the worker claim query — the worker atomically claims jobs by `UPDATE ... SET status = 'processing' WHERE status IN ('pending', 'pending_next_step', 'pending_continuation', 'retrying')` — restoring a paused job to `processing` would create a dead state because the claim query won't match it
+  *   `[✅]`   migration/`YYYYMMDDHHMMSS_nsf_pause_resume.sql`
+    *   `[✅]`   **`handle_job_completion()` verification**: The terminal status check on line 204 (`IF NEW.status NOT IN ('completed', 'failed', 'retry_loop_failed')`) already excludes `paused_nsf` by omission. The sibling-counting query on line 241 (`COUNT(*) FILTER (WHERE status IN ('completed', 'failed', 'retry_loop_failed'))`) counts terminal siblings — `paused_nsf` is NOT in this list, so a paused sibling prevents the "all siblings terminal" condition. **This is correct behavior** — the parent PLAN stays in `waiting_for_children` until paused jobs resume and reach a true terminal state. Add a SQL comment documenting that `paused_nsf` is intentionally non-terminal.
+    *   `[✅]`   **`on_job_status_change` trigger verification**: Confirm the WHEN clause does NOT include `paused_nsf` (it currently doesn't). Add a SQL comment documenting the intentional exclusion.
+    *   `[✅]`   **`on_new_job_created` trigger verification**: Confirm the WHEN clause does NOT include `paused_nsf` (it currently doesn't). Add a SQL comment documenting the intentional exclusion.
+    *   `[✅]`   **`paused_nsf` status validity**: Verify whether the `status` column has a CHECK constraint or enum. If constrained, add `paused_nsf` to the allowed values. If unconstrained TEXT, no schema change needed — document assumption.
+    *   `[✅]`   **`resume_paused_nsf_jobs` RPC function**: Create a `SECURITY DEFINER` function accepting `p_session_id UUID`, `p_stage_slug TEXT`, `p_iteration_number INTEGER`:
+      *   `[✅]`   **Ownership check**: Before performing the update, verify the calling user owns the session by joining `dialectic_generation_jobs` → `dialectic_sessions` → `dialectic_projects` → `user_id = auth.uid()`. If not, raise an exception.
+      *   `[✅]`   **Atomic resume update**: `UPDATE dialectic_generation_jobs SET status = CASE WHEN (error_details->>'original_status') = 'processing' THEN 'pending' ELSE (error_details->>'original_status') END, error_details = error_details - 'original_status' - 'nsf_paused' WHERE session_id = p_session_id AND stage_slug = p_stage_slug AND iteration_number = p_iteration_number AND status = 'paused_nsf'`
+      *   `[✅]`   **`processing → pending` mapping rationale**: The original job was mid-execution when NSF hit; restoring to `processing` creates a dead state because the worker's atomic claim query only matches `pending`/`pending_next_step`/`pending_continuation`/`retrying`. Restoring to `pending` allows the worker to re-claim and reprocess.
+      *   `[✅]`   All other `original_status` values (`pending`, `pending_continuation`, `pending_next_step`, `retrying`) are restored as-is; `on_job_status_change` fires naturally for these statuses and re-invokes the worker.
+      *   `[✅]`   Return the count of affected rows as `INTEGER`.
+    *   `[✅]`   **RLS grant**: `GRANT EXECUTE ON FUNCTION resume_paused_nsf_jobs TO authenticated`
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `paused_nsf` must be a valid job status value in the database
+    *   `[✅]`   `handle_job_completion()` must NOT count `paused_nsf` as terminal — parent PLAN jobs must remain in `waiting_for_children` when any child is paused
+    *   `[✅]`   No trigger must invoke the dialectic-worker for `paused_nsf` transitions
+    *   `[✅]`   `resume_paused_nsf_jobs` must atomically restore all paused jobs for a given session+stage+iteration, mapping `processing` → `pending` and all others to their stored `original_status`
+    *   `[✅]`   `resume_paused_nsf_jobs` must enforce row-level ownership — only the project owner can resume their own jobs
+    *   `[✅]`   After resume, the restored statuses must cause `on_job_status_change` to fire for actionable statuses (`pending`, `pending_continuation`, `pending_next_step`, `retrying`), naturally re-invoking the worker
+    *   `[✅]`   Passive wait statuses (`waiting_for_children`, `waiting_for_prerequisite`) are never set to `paused_nsf` by the backend (Node 2) so the resume function will never encounter them — document this assumption in the RPC
+
+### Node 2
+*   `[✅]`   [BE] supabase/functions/_shared/utils/`notificationService` **Add `sendContributionGenerationPausedNsfEvent` method to NotificationService for NSF pause lifecycle event**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add a `ContributionGenerationPausedNsfPayload` type to the backend notification type system so the NSF pause event has a typed payload matching the existing contribution lifecycle pattern
+    *   `[✅]`   Add a `sendContributionGenerationPausedNsfEvent` method to the `NotificationServiceType` interface and `NotificationService` class so that `pauseJobsForNsf` (Node 3) can emit a single internal lifecycle notification
+    *   `[✅]`   Add the new payload to the backend `DialecticLifecycleEvent` union in `notification.service.types.ts`
+    *   `[✅]`   Update the mock to include the new spy and a mock payload object
+  *   `[✅]`   `role`
+    *   `[✅]`   Infrastructure — notification service type system and implementation
+  *   `[✅]`   `module`
+    *   `[✅]`   Notification service — extends the existing per-event-type method pattern used by all 9 existing methods on `NotificationServiceType`
+    *   `[✅]`   Boundary: defines the `contribution_generation_paused_nsf` event type, payload shape, and send method
+  *   `[✅]`   `deps`
+    *   `[✅]`   `RpcNotification<T>` generic — already defined in `notification.service.types.ts` line 15 — used by `_sendNotification` to format the RPC call
+    *   `[✅]`   `supabase.rpc('create_notification_for_user', ...)` — existing infrastructure, no change
+    *   `[✅]`   No new external dependencies introduced
+    *   `[✅]`   Confirm no reverse dependency is introduced
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `_sendNotification<T>(notification: RpcNotification<T>)` — private method already in `NotificationService`, used by all event methods
+    *   `[✅]`   Injection shape: `NotificationServiceType` interface — the new method is added to this existing interface
+    *   `[✅]`   Confirm no concrete imports from higher or lateral layers
+  *   `[✅]`   interface/`notification.service.types.ts`
+    *   `[✅]`   `ContributionGenerationPausedNsfPayload` — `{ type: 'contribution_generation_paused_nsf'; sessionId: string; projectId: string; stageSlug: string; iterationNumber: number }` — follows existing payload naming pattern (`ContributionGeneration*Payload`) and field pattern (`sessionId`, `projectId`, `stageSlug` match `ContributionGenerationFailedPayload`)
+    *   `[✅]`   Add `ContributionGenerationPausedNsfPayload` to the `DialecticLifecycleEvent` union (line 110)
+    *   `[✅]`   Add `sendContributionGenerationPausedNsfEvent(payload: ContributionGenerationPausedNsfPayload, targetUserId: string): Promise<void>` to `NotificationServiceType` interface (line 3)
+  *   `[✅]`   unit/`notification.service.test.ts`
+    *   `[✅]`   Test: `sendContributionGenerationPausedNsfEvent` calls `supabase.rpc('create_notification_for_user')` with `p_notification_type: 'contribution_generation_paused_nsf'`, `p_is_internal_event: true`, and `p_notification_data` matching the payload — follows the existing test pattern (e.g., lines 34–56 for `contribution_generation_started`)
+    *   `[✅]`   Test: verify the `notification_data` contains `sessionId`, `projectId`, `stageSlug`, `iterationNumber`
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new classes or factories — the method is added to the existing `NotificationService` class
+    *   `[✅]`   The method follows the exact same pattern as `sendContributionGenerationCompleteEvent` (lines 118–128): calls `_sendNotification` with `is_internal_event: true` and the literal notification type string
+  *   `[✅]`   `notification.service.ts`
+    *   `[✅]`   Add import of `ContributionGenerationPausedNsfPayload` from `../types/notification.service.types.ts` (add to existing import block, line 4)
+    *   `[✅]`   Add method `sendContributionGenerationPausedNsfEvent(payload: ContributionGenerationPausedNsfPayload, targetUserId: string): Promise<void>` — calls `this._sendNotification({ target_user_id: targetUserId, notification_type: 'contribution_generation_paused_nsf', is_internal_event: true, notification_data: payload })`
+  *   `[✅]`   `notification.service.mock.ts`
+    *   `[✅]`   Add `ContributionGenerationPausedNsfPayload` to the import block (line 2)
+    *   `[✅]`   Add `sendContributionGenerationPausedNsfEvent: spy(() => Promise.resolve())` to `createMockService()` (line 22, alongside existing 9 spies)
+    *   `[✅]`   Add `mockContributionGenerationPausedNsfPayload: ContributionGenerationPausedNsfPayload` — `{ type: 'contribution_generation_paused_nsf', sessionId: 'session-uuid-456', projectId: 'project-uuid-abc', stageSlug: 'antithesis', iterationNumber: 1 }` — follows existing mock payload pattern
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: infrastructure (notification service)
+    *   `[✅]`   Dependencies face inward: depends only on Supabase client (infra)
+    *   `[✅]`   Provides face outward: consumed by `pauseJobsForNsf` (Node 3) via `NotificationServiceType` interface
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `ContributionGenerationPausedNsfPayload` must follow the existing naming pattern and include `type`, `sessionId`, `projectId`, `stageSlug`, `iterationNumber`
+    *   `[✅]`   `sendContributionGenerationPausedNsfEvent` must send an internal event (`is_internal_event: true`) so the frontend notification store routes it through the lifecycle event pipeline
+    *   `[✅]`   The mock must include the new spy so downstream tests (Node 3) can verify notification calls
+    *   `[✅]`   All existing notification service tests must continue to pass
+
+### Node 3
+*   `[✅]`   [BE] supabase/functions/dialectic-worker/`pauseJobsForNsf` **Pause failing job and active siblings with original-status preservation and single NSF notification**
+  *   `[✅]`   `objective`
+    *   `[✅]`   When an EXECUTE job throws "Insufficient funds", pause that job and all active siblings for the same stage/iteration, preserving each job's original status in `error_details` so the DAG can resume from its prior state
+    *   `[✅]`   Send exactly ONE `contribution_generation_paused_nsf` notification per pause event — not per job — to avoid flooding the user with duplicate alerts
+  *   `[✅]`   `role`
+    *   `[✅]`   Backend / adapter — translates an NSF error into a coordinated pause across related jobs and a single user notification
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic worker — NSF error handling within the job execution pipeline
+    *   `[✅]`   Boundary: receives a failing job ID + context, performs batch DB updates, sends one notification
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 1 (migration) — `paused_nsf` must be a valid status value and `handle_job_completion` must treat it as non-terminal
+    *   `[✅]`   Node 2 (notification service) — `NotificationServiceType` must include `sendContributionGenerationPausedNsfEvent` method and `ContributionGenerationPausedNsfPayload` type must exist in `_shared/types/notification.service.types.ts`
+    *   `[✅]`   `adminClient` (Supabase admin client) — adapter/infra — used for batch-updating job statuses; injected via function parameter
+    *   `[✅]`   `notificationService: NotificationServiceType` — adapter — injected via `deps` parameter from `handleJob`; the `sendContributionGenerationPausedNsfEvent` method (added in Node 2) is used to send the single NSF notification
+    *   `[✅]`   `logger` — infra — injected via `deps` parameter
+    *   `[✅]`   No reverse dependency — this function is consumed by `index.ts` (Node 4) and depends only on infrastructure
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `adminClient`: `SupabaseClient` (Supabase admin, cast exception per Instructions §5)
+    *   `[✅]`   `notificationService`: `NotificationServiceType` from `_shared/types/notification.service.types.ts` — provides `sendContributionGenerationPausedNsfEvent`
+    *   `[✅]`   `logger`: logger interface (match existing pattern in `index.ts`)
+    *   `[✅]`   No concrete imports from higher layers
+  *   `[✅]`   interface/`dialectic.interface.ts`
+    *   `[✅]`   `PauseJobsForNsfParams` — typed parameter object: `{ failingJobId: string, sessionId: string, stageSlug: string, iterationNumber: number, projectId: string, projectOwnerUserId: string }`
+    *   `[✅]`   `PauseJobsForNsfDeps` — typed dependency object: `{ adminClient: SupabaseClient, notificationService: NotificationServiceType, logger: <LoggerInterface> }` — uses the existing `NotificationServiceType` interface which already includes the new method after Node 2
+  *   `[✅]`   interface/tests/`pauseJobsForNsf.interface.test.ts`
+    *   `[✅]`   Contract: `PauseJobsForNsfParams` requires all six fields — `failingJobId`, `sessionId`, `stageSlug`, `iterationNumber`, `projectId`, `projectOwnerUserId` — to be present and correctly typed (strings non-empty, `iterationNumber` non-negative integer)
+  *   `[✅]`   interface/guards/`pauseJobsForNsf.interface.guards.ts`
+    *   `[✅]`   Guard for `PauseJobsForNsfParams` — validates all required fields present and correctly typed
+  *   `[✅]`   unit/`pauseJobsForNsf.test.ts`
+    *   `[✅]`   Test: given a failing job ID, the function sets that job's status to `paused_nsf` with `error_details` containing `{ original_status: 'processing', nsf_paused: true }`
+    *   `[✅]`   Test: given active sibling jobs (statuses: `pending`, `pending_continuation`, `retrying`), all are set to `paused_nsf` with their respective `original_status` preserved in `error_details`
+    *   `[✅]`   Test: jobs in passive wait states (`waiting_for_children`, `waiting_for_prerequisite`) are NOT paused — they continue waiting naturally
+    *   `[✅]`   Test: jobs already in terminal states (`completed`, `failed`, `retry_loop_failed`) are NOT paused
+    *   `[✅]`   Test: jobs already in `paused_nsf` are NOT re-paused (idempotency)
+    *   `[✅]`   Test: exactly ONE notification is sent regardless of how many jobs are paused — verify `notificationService.sendContributionGenerationPausedNsfEvent` is called exactly once
+    *   `[✅]`   Test: the notification is called with a `ContributionGenerationPausedNsfPayload` containing correct `sessionId`, `projectId`, `stageSlug`, `iterationNumber`, and `targetUserId` matching `projectOwnerUserId`
+    *   `[✅]`   Test: if no siblings exist (solo EXECUTE job), the function still pauses the failing job and sends one notification
+  *   `[✅]`   `construction`
+    *   `[✅]`   Single exported async function: `pauseJobsForNsf(deps: PauseJobsForNsfDeps, params: PauseJobsForNsfParams): Promise<void>`
+    *   `[✅]`   Must not be constructed or called outside the `handleJob` catch block (Node 4)
+    *   `[✅]`   All parameters must be fully populated at call site — no optional fields
+  *   `[✅]`   `pauseJobsForNsf.ts`
+    *   `[✅]`   Import `ContributionGenerationPausedNsfPayload` from `../_shared/types/notification.service.types.ts`
+    *   `[✅]`   Import `PauseJobsForNsfDeps`, `PauseJobsForNsfParams` from the interface file where they are defined
+    *   `[✅]`   Step 1 — Pause the failing job: `adminClient.from('dialectic_generation_jobs').update({ status: 'paused_nsf', error_details: { original_status: 'processing', nsf_paused: true } }).eq('id', params.failingJobId)`
+    *   `[✅]`   Step 2 — Query and batch-pause active siblings: update all jobs matching `session_id = params.sessionId AND stage_slug = params.stageSlug AND iteration_number = params.iterationNumber AND id != params.failingJobId AND status NOT IN ('completed', 'failed', 'retry_loop_failed', 'paused_nsf', 'waiting_for_children', 'waiting_for_prerequisite')`. Each paused job must store its own current `status` as `original_status` in `error_details`. **Implementation note**: the Supabase JS client cannot reference the current column value dynamically in a SET clause; this requires either (a) querying siblings first, then batch-updating with individual `original_status` values, or (b) a raw SQL query via `adminClient.rpc()` or a dedicated SQL helper function
+    *   `[✅]`   Step 3 — Send exactly one notification: `deps.notificationService.sendContributionGenerationPausedNsfEvent({ type: 'contribution_generation_paused_nsf', sessionId: params.sessionId, projectId: params.projectId, stageSlug: params.stageSlug, iterationNumber: params.iterationNumber }, params.projectOwnerUserId)`
+    *   `[✅]`   Log the count of paused jobs (failing + siblings) at info level
+  *   `[✅]`   integration/`pauseJobsForNsf.integration.test.ts`
+    *   `[✅]`   Test: insert a parent PLAN job (`waiting_for_children`) with 5 EXECUTE children (statuses: 1 `processing`, 2 `pending`, 1 `completed`, 1 `waiting_for_prerequisite`). Call `pauseJobsForNsf` with the `processing` job as failing. Verify: 3 jobs paused (`processing` + 2 `pending`), each with correct `original_status` in `error_details`. `completed` job untouched. `waiting_for_prerequisite` job untouched. Parent PLAN (`waiting_for_children`) untouched.
+    *   `[✅]`   Test: verify exactly one notification is sent (mock or spy on notification service)
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: adapter (backend edge function helper)
+    *   `[✅]`   Dependencies face inward: depends on infra (`adminClient`, `logger`) and port (`NotificationServiceType` interface)
+    *   `[✅]`   Provides face outward: consumed by `index.ts` `handleJob` catch block (Node 4)
+  *   `[✅]`   `requirements`
+    *   `[✅]`   The failing job must be set to `paused_nsf` with `original_status: 'processing'` preserved
+    *   `[✅]`   All active siblings (non-terminal, non-passive-wait, not already `paused_nsf`) must be set to `paused_nsf` with their individual `original_status` preserved
+    *   `[✅]`   Passive wait statuses (`waiting_for_children`, `waiting_for_prerequisite`) must NOT be paused — they continue waiting naturally and resolve when their dependencies resume and complete
+    *   `[✅]`   Exactly one `contribution_generation_paused_nsf` notification must be sent per invocation via `deps.notificationService.sendContributionGenerationPausedNsfEvent`, regardless of how many jobs are paused
+    *   `[✅]`   The notification must contain `sessionId`, `projectId`, `stageSlug`, `iterationNumber` so the frontend can identify the affected context
+
+### Node 4
+*   `[✅]`   [BE] supabase/functions/dialectic-worker/`index` **NSF detection branch in `handleJob` catch block routing to `pauseJobsForNsf`**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Detect "Insufficient funds" errors in the `handleJob` catch block (lines 330–368) and route them to `pauseJobsForNsf` instead of the existing failure path, preventing cascade failures of the parent PLAN job and enabling user-driven resume
+  *   `[✅]`   `role`
+    *   `[✅]`   Backend / orchestrator — the top-level job execution handler that classifies errors and routes to appropriate handlers
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic worker entry point — error classification within the existing catch block
+    *   `[✅]`   Boundary: detects NSF errors by message match, delegates to `pauseJobsForNsf`, preserves existing failure path for all other errors
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 3 (`pauseJobsForNsf.ts`) — must exist before this modification; imported as a local module
+    *   `[✅]`   Existing `handleJob` function structure — the catch block at line 330 of `index.ts` is the modification target
+    *   `[✅]`   All existing deps of `handleJob` (`adminClient`, `deps.notificationService`, `deps.logger`, `job`, `jobId`, `projectOwnerUserId`, `projectId`) are already available in the catch scope
+    *   `[✅]`   No reverse dependency — this is a consumer of `pauseJobsForNsf`
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `pauseJobsForNsf` function: imported from `./pauseJobsForNsf.ts`
+    *   `[✅]`   Existing variables in catch scope: `e` (caught error), `jobId`, `job` (with `.session_id`, `.stage_slug`, `.payload.iterationNumber`), `projectOwnerUserId`, `deps` (with `.notificationService`, `.logger`), `adminClient`, `projectId`
+  *   `[✅]`   unit/`index.nsf-detection.test.ts` (new test file or extend existing)
+    *   `[✅]`   Test: when `processJob` throws an error with message containing `'Insufficient funds'`, `pauseJobsForNsf` is called with correct parameters and the normal failure path (status → `failed`, failure notifications) is NOT executed
+    *   `[✅]`   Test: when `processJob` throws an error with message NOT containing `'Insufficient funds'`, the existing failure path executes unchanged (status → `failed`, `contribution_generation_failed` + `other_generation_failed` notifications sent)
+    *   `[✅]`   Test: when `processJob` throws `'Insufficient funds'` but `pauseJobsForNsf` itself throws, the error is logged at error level and the catch block falls through to the existing failure path as a safety net
+  *   `[✅]`   `index.ts`
+    *   `[✅]`   Add `import { pauseJobsForNsf } from './pauseJobsForNsf.ts';` at top of file (with existing imports)
+    *   `[✅]`   In the catch block (line 330), BEFORE the existing failure handling (line 335+), insert an NSF detection branch:
+      *   `[✅]`   Check `error.message.includes('Insufficient funds')` — this matches the exact error thrown at `executeModelCallAndSave.ts` line 536
+      *   `[✅]`   If true: wrap `pauseJobsForNsf` call in its own try/catch. On success, `return` early — do NOT fall through to the failure path. On failure, log the pause error at error level and fall through to the existing failure path as a safety net.
+      *   `[✅]`   Parameters to `pauseJobsForNsf`: `deps: { adminClient, notificationService: deps.notificationService, logger: deps.logger }`, `params: { failingJobId: jobId, sessionId: job.session_id, stageSlug: job.stage_slug, iterationNumber: job.payload.iterationNumber ?? 0, projectId: projectId, projectOwnerUserId: projectOwnerUserId }`
+    *   `[✅]`   The existing failure path (lines 335–366) remains unchanged as the default for non-NSF errors and as the fallback if `pauseJobsForNsf` itself fails
+  *   `[✅]`   integration/`index.nsf-pause.integration.test.ts`
+    *   `[✅]`   Test: end-to-end NSF pause flow — set wallet balance to near-zero, trigger a generation with multiple EXECUTE jobs, verify that when the first job hits NSF all active siblings are paused (not failed), the parent PLAN remains in `waiting_for_children`, and exactly one `contribution_generation_paused_nsf` notification is sent
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: adapter/orchestrator (edge function entry point)
+    *   `[✅]`   Dependencies face inward: imports `pauseJobsForNsf` (adapter helper)
+    *   `[✅]`   No new outward-facing surface — `handleJob` export signature is unchanged
+  *   `[✅]`   `requirements`
+    *   `[✅]`   "Insufficient funds" errors must be intercepted before the existing failure path
+    *   `[✅]`   Intercepted NSF errors must result in `pauseJobsForNsf` being called, NOT the existing `status: 'failed'` update
+    *   `[✅]`   If `pauseJobsForNsf` itself fails, the error must be logged and the existing failure path must execute as a safety net — no silent swallowing of errors
+    *   `[✅]`   Non-NSF errors must continue through the existing failure path with zero behavioral change
+  *   `[✅]`   **Commit** `fix(be) supabase/functions NSF errors pause jobs instead of failing them, with notification service method, single notification, and original status preservation for DAG-correct resume`
+    *   `[✅]`   New types/method in `notification.service.types.ts` and `notification.service.ts`: `ContributionGenerationPausedNsfPayload` and `sendContributionGenerationPausedNsfEvent`
+    *   `[✅]`   Updated mock: `notification.service.mock.ts` with new spy and mock payload
+    *   `[✅]`   New file: `pauseJobsForNsf.ts` with types, guards, unit tests, and integration tests
+    *   `[✅]`   Modified: `index.ts` catch block — NSF detection branch routing to `pauseJobsForNsf`
+
+### Node 5
+*   `[ ]`   [BE] supabase/functions/dialectic-service/`deriveStepStatuses` **Map `paused_nsf` job status to `paused_nsf` step status in progress derivation**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Extend `UnifiedStageStatus` in `dialectic.interface.ts` to include `'paused_nsf'` so the progress tracking type system can represent paused jobs
+    *   `[ ]`   Add a `PAUSED_NSF_STATUSES` set (containing `'paused_nsf'`) to `deriveStepStatuses.ts` and add a check after `ACTIVE_STATUSES` so that steps with paused jobs are reported as `'paused_nsf'` instead of falling through to `'not_started'`
+    *   `[ ]`   Priority order for step status derivation: `hasActive` → `in_progress` > `hasPausedNsf` → `paused_nsf` > `hasFailed` → `failed` > `hasCompleted` → `completed` > `not_started`
+  *   `[ ]`   `role`
+    *   `[ ]`   Infrastructure — progress derivation layer within the dialectic-service edge function
+  *   `[ ]`   `module`
+    *   `[ ]`   Progress tracking — step status derivation from raw job statuses
+    *   `[ ]`   Boundary: receives raw job rows, returns `Map<string, UnifiedStageStatus>` — the first backend consumer of `paused_nsf` job status for progress reporting
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 1 (migration) — `paused_nsf` must be a valid job status in the database before jobs can have this status
+    *   `[ ]`   `ACTIVE_STATUSES` set (line 9) — must NOT include `paused_nsf`; paused jobs are not active
+    *   `[ ]`   `FAILED_STATUSES` set (line 17) — must NOT include `paused_nsf`; paused jobs are not failed
+    *   `[ ]`   No reverse dependency introduced — this is consumed by `getAllStageProgress` (Node 6)
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `deriveStepStatuses` function (line 28): iterates `jobs`, classifies by status set membership, derives per-step status
+    *   `[ ]`   `UnifiedStageStatus` type (dialectic.interface.ts line 673): the return value type for step statuses
+    *   `[ ]`   No injected dependencies — pure function
+  *   `[ ]`   interface/`dialectic.interface.ts`
+    *   `[ ]`   Add `'paused_nsf'` to the `UnifiedStageStatus` union (line 673): `| "not_started" | "in_progress" | "completed" | "failed" | "paused_nsf"`
+  *   `[ ]`   unit/`deriveStepStatuses.test.ts`
+    *   `[ ]`   Test: when all jobs for a step have status `paused_nsf`, step status is `paused_nsf`
+    *   `[ ]`   Test: when a step has both `paused_nsf` and `completed` jobs, step status is `paused_nsf` (paused takes priority over completed)
+    *   `[ ]`   Test: when a step has both `paused_nsf` and active jobs (e.g. `pending`), step status is `in_progress` (active takes priority over paused)
+    *   `[ ]`   Test: when a step has both `paused_nsf` and `failed` jobs, step status is `paused_nsf` (paused takes priority over failed — the pause is recoverable, failure is secondary)
+    *   `[ ]`   Test: existing tests for `in_progress`, `completed`, `failed`, `not_started` continue to pass unchanged
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new functions — modification to existing `deriveStepStatuses`
+  *   `[ ]`   `deriveStepStatuses.ts`
+    *   `[ ]`   Add `const PAUSED_NSF_STATUSES: Set<string> = new Set(["paused_nsf"]);` after `FAILED_STATUSES` (line 17)
+    *   `[ ]`   Add `stepKeyToHasPausedNsf` map alongside existing `stepKeyToHasActive`, `stepKeyToHasCompleted`, `stepKeyToHasFailed` (line 44)
+    *   `[ ]`   In the job iteration loop (line 46), add a check: `else if (PAUSED_NSF_STATUSES.has(job.status)) { stepKeyToHasPausedNsf.set(stepKey, true); }` — after the `ACTIVE_STATUSES` check and before the `completed` check
+    *   `[ ]`   In the step status derivation (line 80), insert `hasPausedNsf` check after `hasActive` and before `hasFailed`: `if (hasActive) { result.set(sk, "in_progress"); } else if (hasPausedNsf) { result.set(sk, "paused_nsf"); } else if (hasFailed) { result.set(sk, "failed"); } else { result.set(sk, "completed"); }`
+    *   `[ ]`   Add `for (const stepKey of stepKeyToHasPausedNsf.keys()) stepsWithJobs.add(stepKey);` to the `stepsWithJobs` population (line 63)
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: infrastructure (progress derivation)
+    *   `[ ]`   Dependencies face inward: depends on job data (infra) and `UnifiedStageStatus` type (domain)
+    *   `[ ]`   Provides face outward: consumed by `getAllStageProgress` (Node 6) which passes step statuses to the frontend
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `paused_nsf` job status must map to `paused_nsf` step status — not `in_progress`, not `failed`, not `not_started`
+    *   `[ ]`   Active statuses must still take priority over `paused_nsf` (in the unlikely case both exist for a step)
+    *   `[ ]`   `paused_nsf` must take priority over `failed` — the pause is recoverable and should be presented as such
+    *   `[ ]`   All existing step status derivation behavior must be preserved
+
+### Node 6
+*   `[ ]`   [BE] supabase/functions/dialectic-service/`getAllStageProgress` **Handle `paused_nsf` step status in stage progress computation**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Update the step-counting loop in `getAllStageProgress.ts` to count `paused_nsf` steps so that stage status correctly reflects when any step is paused due to NSF
+    *   `[ ]`   Update stage status derivation priority: `failed` > `paused_nsf` > `completed` > `in_progress` > `not_started`
+  *   `[ ]`   `role`
+    *   `[ ]`   Infrastructure — stage progress aggregation within the dialectic-service edge function
+  *   `[ ]`   `module`
+    *   `[ ]`   Progress tracking — stage-level aggregation from step statuses
+    *   `[ ]`   Boundary: receives step statuses from `deriveStepStatuses`, computes stage-level progress and status for the `GetAllStageProgressResponse`
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 5 (`deriveStepStatuses`) — must return `paused_nsf` as a valid `UnifiedStageStatus` before this node can count it
+    *   `[ ]`   `StageProgressEntry` interface (dialectic.interface.ts line 689) — `status` field is `UnifiedStageStatus`, which already includes `paused_nsf` after Node 5
+    *   `[ ]`   No reverse dependency introduced — this is consumed by the frontend via the API layer
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   Step-counting loop (line 841): iterates `steps`, gets status from `stepStatusMap`, counts `completedSteps` and `failedSteps`
+    *   `[ ]`   Stage status derivation (line 848): priority logic that produces `stageStatus: UnifiedStageStatus`
+    *   `[ ]`   No new injected dependencies
+  *   `[ ]`   unit/`getAllStageProgress.test.ts`
+    *   `[ ]`   Test: when any step has status `paused_nsf`, stage status is `paused_nsf`
+    *   `[ ]`   Test: when steps have mix of `paused_nsf` and `completed`, stage status is `paused_nsf`
+    *   `[ ]`   Test: when steps have mix of `paused_nsf` and `failed`, stage status is `failed` (failure takes priority at stage level)
+    *   `[ ]`   Test: existing tests for `in_progress`, `completed`, `failed`, `not_started` stage statuses continue to pass
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new functions — modification to existing step-counting and stage status derivation logic
+  *   `[ ]`   `getAllStageProgress.ts`
+    *   `[ ]`   Add `let pausedNsfSteps: number = 0;` alongside `completedSteps` and `failedSteps` (line 838)
+    *   `[ ]`   In the step-counting loop (line 841), add: `if (status === "paused_nsf") pausedNsfSteps += 1;`
+    *   `[ ]`   In stage status derivation (line 848), insert `paused_nsf` check after `failed` and before `completed`: `if (failedSteps > 0) { stageStatus = "failed"; } else if (pausedNsfSteps > 0) { stageStatus = "paused_nsf"; } else if (completedSteps === totalSteps && failedSteps === 0) { ...existing... }`
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: infrastructure (progress aggregation)
+    *   `[ ]`   Dependencies face inward: consumes `deriveStepStatuses` output and `UnifiedStageStatus` type
+    *   `[ ]`   Provides face outward: returns `GetAllStageProgressResponse` consumed by the API layer → frontend
+  *   `[ ]`   `requirements`
+    *   `[ ]`   Stage status must be `paused_nsf` when any step is `paused_nsf` and no steps have failed
+    *   `[ ]`   `failed` stage status still takes priority over `paused_nsf` — a failed step is more severe
+    *   `[ ]`   `paused_nsf` step count must not be counted as `completedSteps` or `failedSteps`
+    *   `[ ]`   All existing stage progress computation behavior must be preserved
+  *   `[ ]`   **Commit** `fix(be) supabase/functions/dialectic-service paused_nsf status in progress derivation and stage aggregation`
+    *   `[ ]`   Updated type: `UnifiedStageStatus` in `dialectic.interface.ts` — added `paused_nsf`
+    *   `[ ]`   Modified: `deriveStepStatuses.ts` — maps `paused_nsf` job status to `paused_nsf` step status
+    *   `[ ]`   Modified: `getAllStageProgress.ts` — counts paused steps, derives `paused_nsf` stage status
+
+### Node 7
+*   `[ ]`   [BE] supabase/functions/dialectic-service/`resumePausedNsfJobs` **Resume handler, routing, and `ActionHandlers` wiring for the `resumePausedNsfJobs` action**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Create a `resumePausedNsfJobs` handler in the dialectic-service edge function that receives `sessionId`, `stageSlug`, `iterationNumber` from an authenticated request, calls the `resume_paused_nsf_jobs` RPC via `adminClient`, and returns the count of resumed jobs
+    *   `[ ]`   Add a `resumePausedNsfJobs` routing case to the `handleRequest` switch in `index.ts` and register it in `defaultHandlers` and the `ActionHandlers` interface
+    *   `[ ]`   Add the corresponding `ResumePausedNsfJobsAction` to the `DialecticServiceRequest` union so the request type-checks
+  *   `[ ]`   `role`
+    *   `[ ]`   Backend / adapter — the edge function handler that bridges an authenticated API request to the database RPC
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic service — resume handler within the existing action-routed edge function
+    *   `[ ]`   Boundary: receives authenticated request → validates payload → calls `adminClient.rpc('resume_paused_nsf_jobs')` → returns result
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 1 (migration) — `resume_paused_nsf_jobs` RPC must exist in the database
+    *   `[ ]`   `adminClient` (Supabase admin client) — available in the `handleRequest` scope via `index.ts`
+    *   `[ ]`   `ActionHandlers` interface (index.ts line 158) — must be extended with the new handler signature
+    *   `[ ]`   `DialecticServiceRequest` union (dialectic.interface.ts line 601) — must include the new action type
+    *   `[ ]`   `defaultHandlers` (index.ts line 637) — must include the new handler
+    *   `[ ]`   No reverse dependency introduced — this is consumed by the API layer (Node 8)
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   Existing routing pattern in `handleRequest` (index.ts line 284): `switch (action) { case "getAllStageProgress": ... }` — the new case follows this pattern
+    *   `[ ]`   `adminClient`: `SupabaseClient` — used for `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number })`
+    *   `[ ]`   `userForJson`: `User` — used for ownership verification (the RPC itself verifies ownership, but auth check gates access)
+  *   `[ ]`   interface/`dialectic.interface.ts`
+    *   `[ ]`   `ResumePausedNsfJobsPayload` — `{ sessionId: string; stageSlug: string; iterationNumber: number }` — matches the parameters of the `resume_paused_nsf_jobs` RPC
+    *   `[ ]`   `ResumePausedNsfJobsAction` — `{ action: "resumePausedNsfJobs"; payload: ResumePausedNsfJobsPayload }` — follows the existing discriminated union pattern
+    *   `[ ]`   Add `ResumePausedNsfJobsAction` to the `DialecticServiceRequest` union (line 601)
+    *   `[ ]`   `ResumePausedNsfJobsResponse` — `{ resumedCount: number }` — returned by the handler on success
+  *   `[ ]`   unit/`resumePausedNsfJobs.test.ts`
+    *   `[ ]`   Test: handler calls `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number })` with correct parameters
+    *   `[ ]`   Test: handler returns `{ resumedCount: N }` on success where N is the RPC return value
+    *   `[ ]`   Test: handler returns 401 error when user is not authenticated
+    *   `[ ]`   Test: handler returns 500 error when RPC fails and logs the error
+  *   `[ ]`   `construction`
+    *   `[ ]`   Single exported async function: `handleResumePausedNsfJobs(payload: ResumePausedNsfJobsPayload, adminClient: SupabaseClient, user: User): Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>`
+    *   `[ ]`   Follows existing handler signature pattern from `ActionHandlers`
+  *   `[ ]`   `resumePausedNsfJobs.ts`
+    *   `[ ]`   Import `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` from `./dialectic.interface.ts`
+    *   `[ ]`   Call `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id: payload.sessionId, p_stage_slug: payload.stageSlug, p_iteration_number: payload.iterationNumber })`
+    *   `[ ]`   On success: return `{ status: 200, data: { resumedCount: data } }`
+    *   `[ ]`   On error: return `{ status: 500, error: { message: error.message, status: 500, code: 'RESUME_FAILED' } }`
+  *   `[ ]`   `index.ts`
+    *   `[ ]`   Add `import { handleResumePausedNsfJobs } from './resumePausedNsfJobs.ts';` at the top
+    *   `[ ]`   Add `resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload, adminClient: SupabaseClient, user: User) => Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>;` to the `ActionHandlers` interface (line 158)
+    *   `[ ]`   Add `case "resumePausedNsfJobs":` to the switch in `handleRequest`, following the same pattern as `getAllStageProgress` (line 586): auth check → extract payload → call handler → return response
+    *   `[ ]`   Add `resumePausedNsfJobs: handleResumePausedNsfJobs,` to `defaultHandlers` (line 637)
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: adapter (edge function handler)
+    *   `[ ]`   Dependencies face inward: depends on `adminClient` (infra) and `resume_paused_nsf_jobs` RPC (infra)
+    *   `[ ]`   Provides face outward: consumed by the API layer (Node 8) via HTTP POST to `dialectic-service`
+  *   `[ ]`   `requirements`
+    *   `[ ]`   The handler must require authentication — unauthenticated requests must be rejected
+    *   `[ ]`   The handler must call the `resume_paused_nsf_jobs` RPC with the correct parameters
+    *   `[ ]`   The handler must return the count of resumed jobs on success
+    *   `[ ]`   RPC failures must be returned as 500 errors with the error message — not silently swallowed
+    *   `[ ]`   The routing case, handler signature, and `defaultHandlers` entry must follow the existing patterns exactly
+
+### Node 8
+*   `[ ]`   [API] packages/api/src/`dialectic.api` **Add `resumePausedNsfJobs` method to `DialecticApiClient` interface and implementation**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add a `resumePausedNsfJobs` method to the `DialecticApiClient` interface in `packages/types/src/dialectic.types.ts` and the `DialecticApiClientImpl` class in `packages/api/src/dialectic.api.ts` so that the frontend store can call the backend resume handler through the established API layer
+    *   `[ ]`   Add `ResumePausedNsfJobsPayload` and `ResumePausedNsfJobsResponse` frontend types
+  *   `[ ]`   `role`
+    *   `[ ]`   Port — API layer bridge between the frontend store and the backend edge function
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic API client — extends the existing standardized interface for frontend-to-backend communication
+    *   `[ ]`   Boundary: receives typed payload from store → sends `POST { action: 'resumePausedNsfJobs', payload }` to `dialectic-service` → returns typed response
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 7 (resume handler) — the `dialectic-service` edge function must have the `resumePausedNsfJobs` routing case before this API method can successfully call it
+    *   `[ ]`   `this.apiClient.post` — existing infrastructure for sending typed POST requests to edge functions
+    *   `[ ]`   `DialecticServiceActionPayload` — existing generic type used by `apiClient.post` for the request body shape
+    *   `[ ]`   No reverse dependency introduced — this is consumed by the dialectic store (Node 11)
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `apiClient.post<TResponse, TPayload>(edgeFunctionName, payload)` — the standard method for calling edge functions, used by `getAllStageProgress` (line 659), `generateContributions` (line 521), and all other API methods
+    *   `[ ]`   `DialecticApiClient` interface (dialectic.types.ts line 1043) — the interface that the store depends on
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   `ResumePausedNsfJobsPayload` — `{ sessionId: string; stageSlug: string; iterationNumber: number }` — matches the backend `ResumePausedNsfJobsPayload` in `dialectic.interface.ts`
+    *   `[ ]`   `ResumePausedNsfJobsResponse` — `{ resumedCount: number }` — matches the backend response
+    *   `[ ]`   Add `resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>;` to the `DialecticApiClient` interface (line 1043)
+  *   `[ ]`   unit/`dialectic.api.test.ts`
+    *   `[ ]`   Test: `resumePausedNsfJobs` calls `apiClient.post` with `action: 'resumePausedNsfJobs'` and the correct payload
+    *   `[ ]`   Test: on success, returns `{ data: { resumedCount: N }, status: 200 }`
+    *   `[ ]`   Test: on error, returns `{ error: { message: '...' }, status: 500 }`
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new class — method added to existing `DialecticApiClientImpl`
+  *   `[ ]`   `dialectic.api.ts`
+    *   `[ ]`   Add import of `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` from `@paynless/types` (add to existing import block)
+    *   `[ ]`   Add method following the `getAllStageProgress` pattern (line 656):
+      *   `[ ]`   `async resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>`
+      *   `[ ]`   Body: `const response = await this.apiClient.post<ResumePausedNsfJobsResponse, DialecticServiceActionPayload>('dialectic-service', { action: 'resumePausedNsfJobs', payload });`
+      *   `[ ]`   Error logging and return following the `getAllStageProgress` pattern
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: port (API client)
+    *   `[ ]`   Dependencies face inward: depends on `apiClient` (infra) for HTTP communication
+    *   `[ ]`   Provides face outward: consumed by the dialectic store (Node 11) via `api.dialectic().resumePausedNsfJobs(payload)`
+  *   `[ ]`   `requirements`
+    *   `[ ]`   The API method must follow the same pattern as `getAllStageProgress` and `generateContributions` — `POST` to `dialectic-service` with `action` and `payload`
+    *   `[ ]`   The frontend payload and response types must mirror the backend types
+    *   `[ ]`   The method must be declared on the `DialecticApiClient` interface so the store depends on the interface, not the implementation
+    *   `[ ]`   Error handling must follow the existing pattern — log errors, return `ApiResponse` with error details
+  *   `[ ]`   **Commit** `feat(be,api) dialectic-service resume handler, routing, and API client method for NSF job resume`
+    *   `[ ]`   New handler: `resumePausedNsfJobs.ts` in `dialectic-service/`
+    *   `[ ]`   Modified: `dialectic.interface.ts` — new payload, response, and action types
+    *   `[ ]`   Modified: `index.ts` — routing case, `ActionHandlers` interface, `defaultHandlers` entry
+    *   `[ ]`   New frontend types: `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` in `dialectic.types.ts`
+    *   `[ ]`   Modified: `DialecticApiClient` interface and `DialecticApiClientImpl` — new `resumePausedNsfJobs` method
+
+### Node 9
+*   `[ ]`   [FE] packages/utils/src/`type_guards` **Recognize `contribution_generation_paused_nsf` in `isDialecticLifecycleEventType` and add event type string to frontend types**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add `'contribution_generation_paused_nsf'` to the `DialecticNotificationTypes` string union in `packages/types/src/dialectic.types.ts` so the frontend type system recognizes the new event
+    *   `[ ]`   Update `isDialecticLifecycleEventType` in `packages/utils/src/type_guards.ts` to accept the `'paused_nsf'` suffix on the `contribution_generation_` prefix, so notifications arriving via Realtime are correctly identified and routed to the lifecycle event pipeline in `notificationStore`
+  *   `[ ]`   `role`
+    *   `[ ]`   Port — type validation gate between incoming Realtime notifications and the dialectic lifecycle event handler
+  *   `[ ]`   `module`
+    *   `[ ]`   Type guard — `isDialecticLifecycleEventType` is the gatekeeper at `notificationStore.ts` line 70; if it returns `false`, the notification is silently dropped and never reaches `_handleDialecticLifecycleEvent`
+    *   `[ ]`   Boundary: validates a string is a known dialectic event type
+  *   `[ ]`   `deps`
+    *   `[ ]`   `DialecticNotificationTypes` from `@paynless/types` — the string union that the guard narrows to; must include `'contribution_generation_paused_nsf'` before the guard can match it
+    *   `[ ]`   No reverse dependency introduced
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   The guard function is pure — no injected dependencies, no side effects
+    *   `[ ]`   Confirm no concrete imports from higher or lateral layers
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   Add `'contribution_generation_paused_nsf'` to the `DialecticNotificationTypes` string union (line 827) — this is the type-level representation of the event string
+  *   `[ ]`   interface/tests/`type_guards.test.ts`
+    *   `[ ]`   Contract: `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` must return `true` — add to the existing `'should return true for valid dialectic event types'` test block (line 151)
+  *   `[ ]`   unit/`type_guards.test.ts`
+    *   `[ ]`   Test: `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` returns `true` (add assertion to existing valid-types test at line 151)
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new functions or objects — modification to an existing guard function
+  *   `[ ]`   `type_guards.ts`
+    *   `[ ]`   In the `contribution_generation_` prefix suffix check (line 210–215), add `|| suffix === 'paused_nsf'` to the return expression
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: port (shared utility)
+    *   `[ ]`   Dependencies face inward: depends on `DialecticNotificationTypes` (type-only, domain)
+    *   `[ ]`   Provides face outward: consumed by `notificationStore.ts` (Node 10) at line 70 to gate lifecycle event routing
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` must return `true` so the notification store routes the event
+    *   `[ ]`   All existing type guard tests must continue to pass — no regression on existing event types
+    *   `[ ]`   `DialecticNotificationTypes` must include the new string literal so TypeScript's type narrowing works correctly downstream
+
+### Node 10
+*   `[ ]`   [STORE] packages/store/src/`notificationStore` **Route `contribution_generation_paused_nsf` notifications to dialectic store lifecycle handler**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add a `ContributionGenerationPausedNsfPayload` interface to the frontend type system in `packages/types/src/dialectic.types.ts` and add it to the `DialecticLifecycleEvent` union so the notification store can construct and forward the typed event
+    *   `[ ]`   Add a `case 'contribution_generation_paused_nsf'` to the payload extraction switch in `handleIncomingNotification` (line 289) so that incoming NSF pause notifications are extracted, validated, and forwarded to `_handleDialecticLifecycleEvent`
+  *   `[ ]`   `role`
+    *   `[ ]`   Application — notification routing bridge between Supabase Realtime and the dialectic store
+  *   `[ ]`   `module`
+    *   `[ ]`   Notification store — the `handleIncomingNotification` method's switch statement (lines 289–529) performs per-type payload extraction for all lifecycle events
+    *   `[ ]`   Boundary: receives a `Notification` from Realtime, extracts typed fields from `notification.data`, constructs a `DialecticLifecycleEvent`, forwards to `_handleDialecticLifecycleEvent`
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 9 (type guard) — `isDialecticLifecycleEventType` must recognize `'contribution_generation_paused_nsf'` before this case is reachable; `DialecticNotificationTypes` must include the string
+    *   `[ ]`   `DialecticLifecycleEvent` from `@paynless/types` — must include `ContributionGenerationPausedNsfPayload` so the constructed event can be assigned to `eventPayload`
+    *   `[ ]`   `useDialecticStore.getState()._handleDialecticLifecycleEvent` — existing consumer, no change
+    *   `[ ]`   No reverse dependency introduced
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `notification.data`: `NotificationData | null` — the raw JSONB payload from the notifications table row
+    *   `[ ]`   `notification.type`: `string` — already narrowed to `DialecticNotificationTypes` by the `isDialecticLifecycleEventType` check at line 70
+    *   `[ ]`   Confirm no concrete imports from higher or lateral layers
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   `ContributionGenerationPausedNsfPayload` — `{ type: 'contribution_generation_paused_nsf'; sessionId: string; projectId: string; stageSlug: string; iterationNumber: number }` — mirrors the backend payload shape from `notification.service.types.ts` (Node 2), follows the existing frontend payload pattern (e.g., `ContributionGenerationCompletePayload` at line 906)
+    *   `[ ]`   Add `ContributionGenerationPausedNsfPayload` to the `DialecticLifecycleEvent` union (line 1004)
+  *   `[ ]`   unit/`notificationStore.test.ts` (or existing test file for notification store)
+    *   `[ ]`   Test: when `handleIncomingNotification` receives a notification with `type: 'contribution_generation_paused_nsf'`, `is_internal_event: true`, and `data: { type: 'contribution_generation_paused_nsf', sessionId: 'x', projectId: 'y', stageSlug: 'thesis', iterationNumber: 1 }`, the dialectic store's `_handleDialecticLifecycleEvent` is called with a correctly shaped `ContributionGenerationPausedNsfPayload`
+    *   `[ ]`   Test: when `data` is missing `sessionId`, `stageSlug`, or `iterationNumber`, the event is NOT forwarded — `eventPayload` remains `null` and a warning is logged
+    *   `[ ]`   Test: when `data` is missing `projectId`, the event is NOT forwarded
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new functions or components — modification to the existing `switch (type)` block in `handleIncomingNotification`
+  *   `[ ]`   `notificationStore.ts`
+    *   `[ ]`   Add `case 'contribution_generation_paused_nsf':` to the switch block (after the `contribution_generation_complete` case at line 325), with field extraction and validation following the existing pattern:
+      *   `[ ]`   Guard: `typeof data['sessionId'] === 'string' && typeof data['projectId'] === 'string' && typeof data['stageSlug'] === 'string' && typeof data['iterationNumber'] === 'number'`
+      *   `[ ]`   Construct payload: `eventPayload = { type, sessionId: data['sessionId'], projectId: data['projectId'], stageSlug: data['stageSlug'], iterationNumber: data['iterationNumber'] }`
+      *   `[ ]`   `break;`
+    *   `[ ]`   The existing forwarding logic at line 531 (`if (eventPayload) { useDialecticStore.getState()._handleDialecticLifecycleEvent?.(eventPayload); }`) handles the rest — no additional changes needed
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: application (state management / notification routing)
+    *   `[ ]`   Dependencies face inward: consumes `DialecticLifecycleEvent` (types), `isDialecticLifecycleEventType` (port)
+    *   `[ ]`   Provides face outward: forwards constructed events to `dialecticStore._handleDialecticLifecycleEvent` (Node 11)
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `contribution_generation_paused_nsf` notifications must be extracted, validated, and forwarded to `_handleDialecticLifecycleEvent` using the same pattern as all other lifecycle events
+    *   `[ ]`   Invalid payloads (missing required fields) must be logged and dropped — not forwarded with partial data
+    *   `[ ]`   All existing notification routing must continue to work — no regression on existing event types
+    *   `[ ]`   The `ContributionGenerationPausedNsfPayload` frontend type must mirror the backend type shape from `notification.service.types.ts`
+
+### Node 11
+*   `[ ]`   [STORE] packages/store/src/`dialecticStore` **NSF pause notification handler, resume action via API layer, and progress re-hydration trigger**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Handle the `contribution_generation_paused_nsf` lifecycle event (routed by `notificationStore` via Node 10) by clearing `generatingSessions` for the affected session and triggering `hydrateAllStageProgress` so the progress tracker durably reflects the `paused_nsf` state — NO ephemeral in-memory `nsfPausedContext` state
+    *   `[ ]`   Provide a `resumePausedNsfJobs` action that calls `api.dialectic().resumePausedNsfJobs(payload)` (Node 8) and triggers `hydrateAllStageProgress` on success so the progress tracker refreshes to show resumed jobs
+    *   `[ ]`   The source of truth for whether jobs are paused is the progress tracker (via `selectUnifiedProjectProgress` → `paused_nsf` stage/step status from Nodes 5–6), NOT ephemeral store state
+  *   `[ ]`   `role`
+    *   `[ ]`   State management — bridges backend notifications to progress re-hydration and provides the resume action via the API layer
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic store — extends the existing `_handleDialecticLifecycleEvent` router and adds the resume action
+    *   `[ ]`   Boundary: receives lifecycle event → clears generating state → re-hydrates progress; receives resume action from UI → calls API → re-hydrates progress
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 8 (API layer) — `api.dialectic().resumePausedNsfJobs` must exist so the store can call the backend through the API layer
+    *   `[ ]`   Node 10 (notificationStore) — must route the notification and forward the constructed `ContributionGenerationPausedNsfPayload` to `_handleDialecticLifecycleEvent`
+    *   `[ ]`   Existing `_handleDialecticLifecycleEvent` router (line 1481) — must add a new `case` for `'contribution_generation_paused_nsf'`
+    *   `[ ]`   Existing `generatingSessions` state — the pause handler must clear the affected session so the button transitions from "Generating..." to the paused state
+    *   `[ ]`   Existing `hydrateAllStageProgress` action (line 2707) — called to refresh progress data from the backend after pause/resume events
+    *   `[ ]`   `api` — the API client instance, available via the store's existing infrastructure pattern (same as `generateContributions` at line 1906)
+    *   `[ ]`   No reverse dependency — the store is consumed by UI components and selectors (Nodes 12–14)
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `api.dialectic().resumePausedNsfJobs`: from `@paynless/api` via the store's existing API infrastructure (same pattern as `api.dialectic().generateContributions` at line 1906)
+    *   `[ ]`   `ContributionGenerationPausedNsfPayload`: from `@paynless/types` (added in Node 10)
+    *   `[ ]`   `hydrateAllStageProgress`: existing store action at line 2707
+    *   `[ ]`   Existing store state shape: `generatingSessions`, `contributionGenerationStatus`, `generatingForStageSlug`
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   Add `resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload) => Promise<ApiResponse<ResumePausedNsfJobsResponse>>` to `DialecticActions` (line 665) — uses the same `ResumePausedNsfJobsPayload` and `ResumePausedNsfJobsResponse` types defined in Node 8
+    *   `[ ]`   Add `_handleContributionGenerationPausedNsf: (event: ContributionGenerationPausedNsfPayload) => void` to `DialecticActions` (line 755, alongside existing private handlers)
+    *   `[ ]`   NO `nsfPausedContext` in `DialecticStateValues` — the paused state is read from the progress tracker via selectors (Node 12)
+  *   `[ ]`   unit/`dialecticStore.nsf.test.ts`
+    *   `[ ]`   Test: `_handleContributionGenerationPausedNsf` clears the affected session from `generatingSessions` and resets `contributionGenerationStatus` and `generatingForStageSlug`
+    *   `[ ]`   Test: `_handleContributionGenerationPausedNsf` calls `hydrateAllStageProgress` with `{ sessionId, iterationNumber, userId, projectId }` from the payload so the progress tracker refreshes to show `paused_nsf`
+    *   `[ ]`   Test: `_handleDialecticLifecycleEvent` routes `type: 'contribution_generation_paused_nsf'` to `_handleContributionGenerationPausedNsf`
+    *   `[ ]`   Test: `resumePausedNsfJobs` calls `api.dialectic().resumePausedNsfJobs(payload)` with correct `{ sessionId, stageSlug, iterationNumber }`
+    *   `[ ]`   Test: on successful API response, `resumePausedNsfJobs` calls `hydrateAllStageProgress` to refresh progress data
+    *   `[ ]`   Test: on API failure, `resumePausedNsfJobs` shows a toast error and does NOT call `hydrateAllStageProgress`
+    *   `[ ]`   Test: on API failure, user can retry — the action does not leave the store in a broken state
+  *   `[ ]`   `construction`
+    *   `[ ]`   `_handleContributionGenerationPausedNsf` is a private handler method, not directly callable from outside the store
+    *   `[ ]`   `resumePausedNsfJobs` is a public action exposed on the store interface
+    *   `[ ]`   NO `nsfPausedContext` state variable — paused state is derived from the progress tracker
+  *   `[ ]`   `dialecticStore.ts`
+    *   `[ ]`   Add `_handleContributionGenerationPausedNsf(payload: ContributionGenerationPausedNsfPayload)` handler:
+      *   `[ ]`   Clear the session from `generatingSessions`: `set(state => { state.contributionGenerationStatus = 'idle'; state.generatingForStageSlug = null; })`
+      *   `[ ]`   Trigger progress re-hydration: `get().hydrateAllStageProgress({ sessionId: payload.sessionId, iterationNumber: payload.iterationNumber, userId: get().currentProjectDetail?.user_id ?? '', projectId: payload.projectId })`
+    *   `[ ]`   Add routing case in `_handleDialecticLifecycleEvent` (line 1484): when `type` is `'contribution_generation_paused_nsf'`, call `handlers._handleContributionGenerationPausedNsf(payload)`
+    *   `[ ]`   Add `resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload)` action:
+      *   `[ ]`   Call `api.dialectic().resumePausedNsfJobs(payload)` — NOT `supabase.rpc()` directly
+      *   `[ ]`   On success: call `get().hydrateAllStageProgress(...)` to refresh progress, return the API response
+      *   `[ ]`   On failure: show toast error, return the API error response — progress tracker still shows `paused_nsf` so the user can retry
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: application (state management)
+    *   `[ ]`   Dependencies face inward: consumes API layer (`api.dialectic()`) and types — does NOT depend on Supabase client directly for resume
+    *   `[ ]`   Provides face outward: consumed by UI components (Nodes 13–14) and selectors (Node 12)
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `contribution_generation_paused_nsf` lifecycle event must be routed to the correct handler via the existing `_handleDialecticLifecycleEvent` switch
+    *   `[ ]`   The pause handler must clear `generatingSessions` / `contributionGenerationStatus` / `generatingForStageSlug` so the UI button exits "Generating..." state
+    *   `[ ]`   The pause handler must trigger `hydrateAllStageProgress` so the progress tracker fetches fresh data showing `paused_nsf` step/stage statuses — this is the durable hydration mechanism
+    *   `[ ]`   The resume action must call through the API layer: store → `api.dialectic().resumePausedNsfJobs()` → edge function → RPC — NOT directly to `supabase.rpc()`
+    *   `[ ]`   After successful resume, `hydrateAllStageProgress` must be called to refresh progress — the progress tracker is the source of truth for UI state transitions
+    *   `[ ]`   Resume failure must leave the progress tracker unchanged (still showing `paused_nsf`) — the user can retry
+
+### Node 12
+*   `[ ]`   [STORE] packages/store/src/`dialecticStore.selectors` **Handle `paused_nsf` in `selectUnifiedProjectProgress` and add `paused_nsf` to `UnifiedProjectStatus`**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add `'paused_nsf'` to the `UnifiedProjectStatus` type union in `packages/types/src/dialectic.types.ts` so the frontend progress display system can represent paused steps and stages
+    *   `[ ]`   Update the step status mapping in `selectUnifiedProjectProgress` (line 870) to map `'paused_nsf'` raw step status to `'paused_nsf'` `UnifiedProjectStatus` — currently unmapped statuses default to `'not_started'`, which would silently hide the paused state
+    *   `[ ]`   Update the stage status derivation in `selectUnifiedProjectProgress` to set `stageStatus` to `'paused_nsf'` when any step is paused and none have failed
+  *   `[ ]`   `role`
+    *   `[ ]`   Application — progress data transformation layer between raw backend progress and UI display
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic store selectors — extends `selectUnifiedProjectProgress` to handle the new status
+    *   `[ ]`   Boundary: receives raw step statuses from hydrated progress → transforms to `UnifiedProjectStatus` values for UI consumption
+  *   `[ ]`   `deps`
+    *   `[ ]`   Nodes 5–6 (backend progress) — the backend must return `paused_nsf` as a valid step/stage status before the selector encounters it
+    *   `[ ]`   Node 11 (store) — `hydrateAllStageProgress` must have been triggered so the store contains fresh progress data with `paused_nsf` statuses
+    *   `[ ]`   `UnifiedProjectStatus` type (dialectic.types.ts line 575) — must be extended with `'paused_nsf'`
+    *   `[ ]`   No reverse dependency introduced — consumed by UI components (Nodes 13–14)
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `selectUnifiedProjectProgress` (line 803): the main progress selector that transforms raw step statuses into `UnifiedProjectStatus` values
+    *   `[ ]`   Step status mapping (line 870): `raw === 'failed' ? 'failed' : raw === 'completed' ? 'completed' : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress' : 'not_started'` — does not handle `paused_nsf`
+    *   `[ ]`   Stage status derivation (line 876): `if (stepStatus === 'failed') stageStatus = 'failed';` — does not handle `paused_nsf`
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   Add `'paused_nsf'` to `UnifiedProjectStatus` (line 575): `'not_started' | 'in_progress' | 'completed' | 'failed' | 'paused_nsf'`
+  *   `[ ]`   unit/`dialecticStore.selectors.test.ts`
+    *   `[ ]`   Test: when a step's raw status is `'paused_nsf'`, `selectUnifiedProjectProgress` maps it to `UnifiedProjectStatus` `'paused_nsf'`
+    *   `[ ]`   Test: when any step is `'paused_nsf'` and none are `'failed'`, the stage status is `'paused_nsf'`
+    *   `[ ]`   Test: when a step is `'paused_nsf'` and another is `'failed'`, the stage status is `'failed'` (failure takes priority)
+    *   `[ ]`   Test: existing `'in_progress'`, `'completed'`, `'failed'`, `'not_started'` step/stage mappings continue to work unchanged
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new functions — modifications to existing `selectUnifiedProjectProgress` selector
+  *   `[ ]`   `dialecticStore.selectors.ts`
+    *   `[ ]`   Update step status mapping (line 870): add `raw === 'paused_nsf' ? 'paused_nsf'` to the ternary chain — `raw === 'failed' ? 'failed' : raw === 'completed' ? 'completed' : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress' : raw === 'paused_nsf' ? 'paused_nsf' : 'not_started'`
+    *   `[ ]`   Update stage status derivation (line 876): add `paused_nsf` check after `failed`: `if (stepStatus === 'failed') stageStatus = 'failed'; else if (stepStatus === 'paused_nsf' && stageStatus !== 'failed') stageStatus = 'paused_nsf';`
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: application (state derivation)
+    *   `[ ]`   Dependencies face inward: consumes hydrated progress data (store state) and `UnifiedProjectStatus` type (domain)
+    *   `[ ]`   Provides face outward: consumed by `StageDAGProgressDialog` (Node 13) and `GenerateContributionButton` (Node 14) via the selector
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `paused_nsf` raw step status must map to `paused_nsf` `UnifiedProjectStatus` — NOT `not_started`, NOT `failed`
+    *   `[ ]`   `paused_nsf` stage status must be set when any step is paused and no steps have failed
+    *   `[ ]`   `failed` still takes priority over `paused_nsf` at the stage level
+    *   `[ ]`   All existing status mappings must be preserved
+
+### Node 13
+*   `[ ]`   [UI] apps/web/src/components/dialectic/`StageDAGProgressDialog` **Add `paused_nsf` color to `STATUS_FILL` map**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add a `paused_nsf` entry to the `STATUS_FILL` record (line 15) so that DAG nodes with `paused_nsf` status render with a distinct visual color instead of falling back to `undefined`
+  *   `[ ]`   `role`
+    *   `[ ]`   UI / presentation — visual mapping for the new status in the DAG progress display
+  *   `[ ]`   `module`
+    *   `[ ]`   DAG progress dialog — extends the status-to-color mapping
+    *   `[ ]`   Boundary: receives `UnifiedProjectStatus` per step → maps to fill color for SVG rendering
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 12 (selectors) — `selectUnifiedProjectProgress` must return `paused_nsf` as a valid `UnifiedProjectStatus` for steps/stages before this color is used
+    *   `[ ]`   `UnifiedProjectStatus` from `@paynless/types` — must include `'paused_nsf'` (added in Node 12)
+    *   `[ ]`   No reverse dependency — this is a leaf UI component
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `STATUS_FILL` record (line 15): `Record<UnifiedProjectStatus, string>` — maps each status to a hex color
+    *   `[ ]`   Once `UnifiedProjectStatus` includes `paused_nsf`, TypeScript will enforce a compile error until `STATUS_FILL` has a matching entry
+  *   `[ ]`   unit/`StageDAGProgressDialog.test.ts`
+    *   `[ ]`   Test: when a step has status `paused_nsf`, the rendered DAG node uses the `paused_nsf` fill color (amber/orange: `'#f97316'`)
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new components — single-line addition to the existing `STATUS_FILL` record
+  *   `[ ]`   `StageDAGProgressDialog.tsx`
+    *   `[ ]`   Add `paused_nsf: '#f97316',` to the `STATUS_FILL` record (line 15, after `failed: '#ef4444'`) — orange to visually distinguish from yellow (`in_progress`) and red (`failed`), signaling "attention needed but recoverable"
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: UI / presentation
+    *   `[ ]`   Dependencies face inward: consumes `UnifiedProjectStatus` type
+    *   `[ ]`   No outward-facing provides — leaf component
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `paused_nsf` must have a distinct color from `in_progress` (yellow) and `failed` (red) — orange (`#f97316`) conveys "needs attention but recoverable"
+    *   `[ ]`   TypeScript must compile without error — `STATUS_FILL` must be exhaustive for all `UnifiedProjectStatus` values
+
+### Node 14
+*   `[ ]`   [UI] apps/web/src/components/dialectic/`GenerateContributionButton` **Per-stage balance threshold gate, paused-NSF detection from progress tracker, and resume-via-same-button UX**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add a per-stage balance threshold check that disables the Generate button when the user's wallet balance is below the minimum required for the active stage — this is the UX gate, the first line of defense against NSF
+    *   `[ ]`   Detect when jobs are paused due to NSF by reading `stageStatus === 'paused_nsf'` from `selectUnifiedProjectProgress` (Node 12) — NOT from ephemeral in-memory state — and adjust the button to show "Add Funds to Resume" (disabled, balance too low) or "Resume {stageName}" (enabled, balance sufficient)
+    *   `[ ]`   When the user clicks "Resume", call `resumePausedNsfJobs` from the store (Node 11) instead of `generateContributions` — same button, different action based on progress-derived context
+  *   `[ ]`   `role`
+    *   `[ ]`   UI / presentation — the user-facing control for initiating, gating, and resuming dialectic generation
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic contribution generation UI — extends the existing `GenerateContributionButton` component
+    *   `[ ]`   Boundary: reads wallet balance + progress selector → renders button with appropriate text/disabled state → dispatches generate or resume action on click
+  *   `[ ]`   `deps`
+    *   `[ ]`   Node 11 (store) — `resumePausedNsfJobs` action must exist on the dialectic store
+    *   `[ ]`   Node 12 (selectors) — `selectUnifiedProjectProgress` must return `stageStatus: 'paused_nsf'` for paused stages — this is the source of truth for detecting the paused state
+    *   `[ ]`   `selectUnifiedProjectProgress` from `@paynless/store` (already imported at line 3) — provides `stagesDetail[].stageStatus` which may be `'paused_nsf'`
+    *   `[ ]`   `useWalletStore` / `selectActiveChatWalletInfo` (already imported, line 9–10) — the `activeWalletInfo` object must include a `balance` field. **Discovery potential**: verify the wallet info type includes a numeric `balance` property; if not, this requires a type extension in the wallet store which would be a separate node.
+    *   `[ ]`   `useDialecticStore` (already imported) — used for `resumePausedNsfJobs` action
+    *   `[ ]`   `@paynless/types` — for `getDisplayName` (already imported) and `STAGE_BALANCE_THRESHOLDS` constant (new)
+    *   `[ ]`   No reverse dependency — this is a leaf UI component
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `activeWalletInfo.balance`: `number` — current wallet token balance
+    *   `[ ]`   `selectUnifiedProjectProgress(state)`: returns `UnifiedProjectProgress` — `stagesDetail[].stageStatus` is checked for `'paused_nsf'` to detect the paused state for the active stage
+    *   `[ ]`   `resumePausedNsfJobs`: action from dialectic store (Node 11)
+    *   `[ ]`   `activeStage.slug`: `string` — used to look up threshold and match against progress data
+    *   `[ ]`   `STAGE_BALANCE_THRESHOLDS`: `Record<string, number>` — per-stage minimum balance constants
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   `STAGE_BALANCE_THRESHOLDS` constant in `@paynless/types`: `{ thesis: 200000, antithesis: 400000, synthesis: 1000000, parenthesis: 250000, paralysis: 250000 }` — values provided by product owner based on observed stage token costs. Keyed by stage slug string.
+    *   `[ ]`   Verify `activeWalletInfo` type includes a numeric `balance` field — if missing, this is a **discovery** requiring a type/selector extension in the wallet store (separate node)
+  *   `[ ]`   unit/`GenerateContributionButton.nsf.test.ts`
+    *   `[ ]`   Test: when `activeWalletInfo.balance` is below `STAGE_BALANCE_THRESHOLDS[activeStage.slug]` and active stage is NOT `paused_nsf`, button is disabled and shows "Insufficient Balance"
+    *   `[ ]`   Test: when `activeWalletInfo.balance` meets threshold and active stage is NOT `paused_nsf`, button is enabled and shows "Generate {displayName}" (existing behavior preserved)
+    *   `[ ]`   Test: when active stage `stageStatus === 'paused_nsf'` (from progress selector) AND balance is below threshold, button is disabled and shows "Add Funds to Resume"
+    *   `[ ]`   Test: when active stage `stageStatus === 'paused_nsf'` (from progress selector) AND balance meets threshold, button is enabled and shows "Resume {displayName}"
+    *   `[ ]`   Test: clicking "Resume {displayName}" calls `resumePausedNsfJobs` with `{ sessionId, stageSlug, iterationNumber }` derived from the active session/stage context — NOT `generateContributions`
+    *   `[ ]`   Test: clicking "Generate {displayName}" calls `generateContributions` — NOT `resumePausedNsfJobs` — existing behavior preserved
+    *   `[ ]`   Test: clicking "Resume" opens the `StageDAGProgressDialog` so the user can monitor resumed generation
+    *   `[ ]`   Test: button state priority order is correct — `isSessionGenerating` > `!areAnyModelsSelected` > `!isWalletReady` > `!activeStage/!activeSession` > `!isStageReady` > `hasPausedNsf && !balanceMeetsThreshold` > `hasPausedNsf && balanceMeetsThreshold` > `!balanceMeetsThreshold` > `didGenerationFail` > `contributionsExist` > default
+  *   `[ ]`   `construction`
+    *   `[ ]`   No new component — all changes within the existing `GenerateContributionButton` component
+    *   `[ ]`   New store subscriptions: `selectUnifiedProjectProgress` (already imported), `resumePausedNsfJobs` action
+    *   `[ ]`   New derived state: `balanceMeetsThreshold` (boolean), `hasPausedNsfJobs` (boolean — derived from progress selector, NOT ephemeral state), `isResumeMode` (boolean)
+  *   `[ ]`   `GenerateContributionButton.tsx`
+    *   `[ ]`   Import `STAGE_BALANCE_THRESHOLDS` from `@paynless/types`
+    *   `[ ]`   Add store action: `const resumePausedNsfJobs = useDialecticStore((state) => state.resumePausedNsfJobs);`
+    *   `[ ]`   Read progress: `const unifiedProgress = useDialecticStore(selectUnifiedProjectProgress);` (selector already imported)
+    *   `[ ]`   Compute `hasPausedNsfJobs`: derive from progress selector — `const activeStageProgress = unifiedProgress?.stagesDetail?.find(s => s.stageSlug === activeStage?.slug); const hasPausedNsfJobs = activeStageProgress?.stageStatus === 'paused_nsf';` — this is durable, survives refresh/navigation because it comes from hydrated backend data
+    *   `[ ]`   Compute `balanceMeetsThreshold`: `const stageThreshold = activeStage ? STAGE_BALANCE_THRESHOLDS[activeStage.slug] ?? 0 : 0; const balanceMeetsThreshold = (activeWalletInfo.balance ?? 0) >= stageThreshold;`
+    *   `[ ]`   Compute `isResumeMode`: `const isResumeMode = hasPausedNsfJobs && balanceMeetsThreshold;`
+    *   `[ ]`   Update `isDisabled` (line 137): add `(hasPausedNsfJobs && !balanceMeetsThreshold)` for paused-but-broke, and `(!hasPausedNsfJobs && !balanceMeetsThreshold)` for the UX gate. The full disabled expression becomes: `isSessionGenerating || !areAnyModelsSelected || !activeStage || !activeSession || !isStageReady || !isWalletReady || (hasPausedNsfJobs && !balanceMeetsThreshold) || (!hasPausedNsfJobs && !balanceMeetsThreshold && !isResumeMode)`
+    *   `[ ]`   Update `getButtonText` (line 144): insert new cases BEFORE the existing `didGenerationFail` check (line 156), AFTER the `!isStageReady` check (line 154): `if (hasPausedNsfJobs && !balanceMeetsThreshold) return "Add Funds to Resume";` then `if (hasPausedNsfJobs && balanceMeetsThreshold) return \`Resume ${displayName}\`;` then `if (!balanceMeetsThreshold) return "Insufficient Balance";`
+    *   `[ ]`   Update `handleClick` (line 96): after the existing guard clause (lines 97–109), before the existing payload construction (line 119), insert: `if (isResumeMode && activeStage && activeSession) { toast.success("Resuming generation..."); setDagDialogOpen(true); await resumePausedNsfJobs({ sessionId: activeSession.id, stageSlug: activeStage.slug, iterationNumber: currentIterationNumber }); return; }`
+  *   `[ ]`   integration/`GenerateContributionButton.integration.test.ts`
+    *   `[ ]`   Test: render with progress showing `stageStatus: 'paused_nsf'` and low balance → button shows "Add Funds to Resume" and is disabled
+    *   `[ ]`   Test: render with progress showing `stageStatus: 'paused_nsf'` and sufficient balance → button shows "Resume {stageName}" and is enabled → click → verify `resumePausedNsfJobs` called with correct params
+    *   `[ ]`   Test: render with progress showing no `paused_nsf` and low balance → button shows "Insufficient Balance" and is disabled
+    *   `[ ]`   Test: render with progress showing no `paused_nsf` and sufficient balance → button shows "Generate {stageName}" and is enabled (existing behavior preserved)
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: UI / presentation
+    *   `[ ]`   Dependencies face inward: consumes store (selectors, actions) and types (constants)
+    *   `[ ]`   No outward-facing provides — this is a leaf component
+  *   `[ ]`   `requirements`
+    *   `[ ]`   Paused state detection MUST come from `selectUnifiedProjectProgress` → `stageStatus === 'paused_nsf'` — this is durable across refresh, navigation, and tab close because it is hydrated from the backend on mount via `useStageRunProgressHydration`
+    *   `[ ]`   The Generate button must be disabled when wallet balance is below the per-stage threshold, showing "Insufficient Balance" — UX gate preventing users from starting generations they cannot afford
+    *   `[ ]`   When NSF pause is active and balance is insufficient, button shows "Add Funds to Resume" (disabled) — directing the user toward the payment resolution path
+    *   `[ ]`   When NSF pause is active and balance is sufficient, button shows "Resume {displayName}" (enabled) — the user clicks the SAME button they originally used to Generate
+    *   `[ ]`   Clicking "Resume" calls `resumePausedNsfJobs` (NOT `generateContributions`) — this restores original job statuses via the API → edge function → RPC path and the DAG resumes naturally through existing trigger infrastructure
+    *   `[ ]`   The DAG progress dialog must open on resume click so the user can monitor resumed generation
+    *   `[ ]`   All existing button states and behaviors must be preserved — new states are inserted into the priority chain without disrupting existing logic
+    *   `[ ]`   Balance thresholds: thesis=200,000 / antithesis=400,000 / synthesis=1,000,000 / parenthesis=250,000 / paralysis=250,000
+    *   `[ ]`   **Frontend NSF workflow note**: The full UX flow (catch NSF notification → redirect to payment portal → catch return → enable Resume) is a known future requirement but is NOT in scope for this node. This node implements the button states and resume action only. The notification-to-portal redirect flow will be a separate checklist item.
+  *   `[ ]`   **Commit** `feat(ui,store) apps/web + packages/store + packages/utils + packages/types NSF protection with durable progress-based pause detection, API-layer resume, frontend notification pipeline, per-stage balance gate, and single-notification UX flow`
+    *   `[ ]`   New frontend types: `ContributionGenerationPausedNsfPayload`, `STAGE_BALANCE_THRESHOLDS`, `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` in `packages/types/src/dialectic.types.ts`
+    *   `[ ]`   Updated: `DialecticNotificationTypes` union, `DialecticLifecycleEvent` union, `UnifiedProjectStatus`, `DialecticActions` in `packages/types/src/dialectic.types.ts`
+    *   `[ ]`   Updated: `isDialecticLifecycleEventType` in `packages/utils/src/type_guards.ts` — recognizes `paused_nsf` suffix
+    *   `[ ]`   Updated: `notificationStore.ts` — new `case 'contribution_generation_paused_nsf'` for payload extraction and routing
+    *   `[ ]`   Updated: `dialecticStore.ts` — `_handleContributionGenerationPausedNsf` handler with progress re-hydration, `resumePausedNsfJobs` action via API layer
+    *   `[ ]`   Updated: `dialecticStore.selectors.ts` — `paused_nsf` handling in `selectUnifiedProjectProgress`
+    *   `[ ]`   Modified: `StageDAGProgressDialog.tsx` — `paused_nsf` color in `STATUS_FILL`
+    *   `[ ]`   Modified: `GenerateContributionButton.tsx` — balance threshold gate, progress-based paused NSF detection, resume-via-same-button UX
+    *   `[ ]`   New tests: type guard tests, notification store routing tests, dialectic store NSF handler/action tests, selector paused_nsf mapping tests, DAG dialog color test, button state transition tests
+
+    
+# ToDo
+
+    - Regenerate individual specific documents on demand without regenerating inputs or other sibling documents 
+    -- User reports that a single document failed and they liked the other documents, but had to regenerate the entire stage
+    -- User requests option to only regenerate the exact document that failed
+    -- Initial investigation shows this should be possible, all the deps are met, we just need a means to dispatch a job for only the exact document that errored or otherwise wasn't produced so that the user does't have to rerun the entire stage to get a single document
+    -- Added bonus, this lets users "roll the dice" to get a different/better/alternative version of an existing document if they want to try again 
+    -- FOR CONSIDERATION: This is a powerful feature but implies a branch in the work
+    --- User generates stage, all succeeds
+    --- User advances stages, decides they want to fix an oversight in a prior stage
+    --- User regenerates a prior document
+    --- Now subsequent documents derived from the original are invalid
+    --- Is this a true branch/iteration, or do we highlight the downstream products so that those can be regenerated from the new input that was produced? 
+    --- If we "only" highlight downstream products, all downstream products are invalid, because the header_context used to generate them would be invalid 
+    --- PROPOSED: Implement regeneration prior to stage advancement, disable regeneration for documents who have downstream documents, set up future sprint for branching/iteration to support hints to regenerate downstream documents if a user regenerates upstream documents
+    --- BLOCKER: Some stages are fundamentally dependent on all prior outputs, like synthesis, and the entire stage needs to be rerun if thesis/antithesis documents are regenerated
+
+    - Set baseline values for each stage "Generate" action and encourage users to top up their account if they are at risk of NSF
+    -- Pause the work mid-stream if NSF and encourage user to top up to continue 
+
+    - New user sign in banner doesn't display, throws console error  
+    -- Chase, diagnose, fix 
+
+   - Generating spinner stays present until page refresh 
+   -- Needs to react to actual progress 
+   -- Stop the spinner when a condition changes 
+
+   - Checklist does not correctly find documents when multiple agents are chosen 
+
+   - Refactor EMCAS to break apart the functions, segment out the tests
+   -- Move gatherArtifacts call to processSimpleJob
+   -- Decide where to measure & RAG
+
+   - Switch to stream-to-buffer instead of chunking
+   -- This lets us render the buffer in real time to show document progress 
+
+   - Build test fixtures for major function groups 
+   -- Provide standard mock factories and objects 
+      
+   - Support user-provided API keys for their preferred providers 
+
+   - Regenerate existing document from user feedback & edits 
+
+   - Have an additional user input panel where they user can build their own hybrid versions from the ones provided 
+   AND/OR
+   - Let the user pick/rate their preferred version and drop the others 
+
+   - Use a gentle color schema to differentiate model outputs visually / at a glance 
+
+   - When doc loads for the first time, position at top 
+
+   - Search across documents for key terms 
+
+   - Collect user satisfaction evaluation after each generation "How would you feel if you couldn't use this again?" 
+
+   - Add optional outputs for selected stages
+   -- A "landing page" output for the proposal stage
+   --- Landing page
+   --- Hero banner
+   --- Call to action
+   --- Email sign up 
+   -- A "financial analysis" output for the "refinement" stage
+   --- 1/3/5 year 
+   --- Conservative / base / aggressive
+   --- IS, BS, CF 
+   -- A "generate next set of work" for the implementation stage 
+
+   - DynamicProgressBar uses formal names instead of friendly names
+   - SessionContributionsDisplayCard uses formal names instead of friendly names 
+   - SessionInfoCard uses formal names instead of friendly names 

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -815,12 +815,12 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[✅]`   All existing status derivation behavior must be preserved for non-superseded jobs
     *   `[✅]`   A step with only superseded jobs and no successors must show `not_started`
 
-*   `[✅]`   [BE] dialectic-service/`regenerateDocument` **Clone failed/completed EXECUTE jobs as new `pending` jobs for targeted document regeneration**
+*   `[✅]`   [BE] dialectic-service/`regenerateDocument` **Look up and clone EXECUTE jobs by document identity for targeted document regeneration**
   *   `[✅]`   `objective`
-    *   `[✅]`   Accept a request specifying session, stage, iteration, and a list of `{ jobId, modelId }` pairs identifying which EXECUTE jobs to regenerate
+    *   `[✅]`   Accept a request specifying session, stage, iteration, and a list of `{ documentKey, modelId }` pairs identifying which documents to regenerate
+    *   `[✅]`   For each `{ documentKey, modelId }`, query `dialectic_generation_jobs` to find the matching EXECUTE job by `session_id`, `stage_slug`, `iteration_number`, `user_id`, `job_type = 'EXECUTE'`, and JSONB payload fields matching `documentKey` and `modelId`; exclude already-`superseded` jobs; order by `created_at DESC`; take first
     *   `[✅]`   Validate that the stage matches the session's current stage (active-stage-only gate)
-    *   `[✅]`   Validate that each referenced job belongs to the correct session/stage/iteration and is an EXECUTE job
-    *   `[✅]`   Mark each original job as `superseded`
+    *   `[✅]`   Mark each matched original job as `superseded`
     *   `[✅]`   Clone each original job's row: copy `payload`, `stage_slug`, `iteration_number`, `session_id`, `user_id`, `max_retries`, `job_type`; set `status: 'pending'`, `attempt_count: 0`, `parent_job_id: null`, `prerequisite_job_id: null`, `started_at: null`, `completed_at: null`, `results: null`, `error_details: null`, `target_contribution_id: null`
     *   `[✅]`   Insert the cloned row — the existing `on_new_job_created` trigger fires and the worker picks it up
     *   `[✅]`   Return the array of new job IDs
@@ -828,10 +828,10 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[✅]`   Backend logic — edge function handler for document regeneration
   *   `[✅]`   `module`
     *   `[✅]`   Dialectic service — new handler function within the `dialectic-service` edge function
-    *   `[✅]`   Boundary: receives validated request → marks originals superseded → inserts cloned jobs → returns new job IDs
+    *   `[✅]`   Boundary: receives document identity → resolves EXECUTE job → marks original superseded → inserts cloned job → returns new job IDs
   *   `[✅]`   `deps`
     *   `[✅]`   DB migration node — `superseded` status must exist
-    *   `[✅]`   `dialectic_generation_jobs` table — read original job, update to `superseded`, insert clone
+    *   `[✅]`   `dialectic_generation_jobs` table — query by JSONB payload fields to find EXECUTE job, update to `superseded`, insert clone
     *   `[✅]`   `dialectic_sessions` table — validate `current_stage_id` matches requested `stageSlug`
     *   `[✅]`   `dialectic_stages` table — resolve `current_stage_id` to slug
     *   `[✅]`   Supabase admin client — for DB operations
@@ -840,38 +840,37 @@ A user clicks a regenerate button on any document in the stage run checklist, se
   *   `[✅]`   `context_slice`
     *   `[✅]`   `dbClient: SupabaseClient` — admin client for DB reads/writes
     *   `[✅]`   `user: User` — authenticated user from request
-    *   `[✅]`   `payload: RegenerateDocumentPayload` — `{ sessionId, stageSlug, iterationNumber, jobs: Array<{ jobId: string; modelId: string }> }`
+    *   `[✅]`   `payload: RegenerateDocumentPayload` — `{ sessionId, stageSlug, iterationNumber, documents: Array<{ documentKey: string; modelId: string }> }`
   *   `[✅]`   interface/`dialectic.interface.ts`
-    *   `[✅]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; jobs: Array<{ jobId: string; modelId: string }> }`
+    *   `[✅]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; documents: Array<{ documentKey: string; modelId: string }> }`
     *   `[✅]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
     *   `[✅]`   `RegenerateDocumentAction`: `{ action: 'regenerateDocument'; payload: RegenerateDocumentPayload }`
     *   `[✅]`   Add `RegenerateDocumentAction` to the `DialecticServiceRequest` union
     *   `[✅]`   Add `regenerateDocument` to `ActionHandlers` interface
   *   `[✅]`   interface/tests/`regenerateDocument.interface.test.ts`
-    *   `[✅]`   Test: `RegenerateDocumentPayload` requires `sessionId`, `stageSlug`, `iterationNumber`, and `jobs` array
+    *   `[✅]`   Test: `RegenerateDocumentPayload` requires `sessionId`, `stageSlug`, `iterationNumber`, and `documents` array with `documentKey` and `modelId` per entry
     *   `[✅]`   Test: `RegenerateDocumentResponse` has `jobIds` string array
   *   `[✅]`   interface/guards/`regenerateDocument.interface.guards.ts`
-    *   `[✅]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — validates all required fields and jobs array structure
+    *   `[✅]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — validates all required fields and documents array structure
   *   `[✅]`   unit/`regenerateDocument.test.ts`
-    *   `[✅]`   Test: valid request with one job → original marked `superseded`, clone inserted as `pending` with correct payload copy, returns new job ID
-    *   `[✅]`   Test: valid request with multiple jobs → all originals marked `superseded`, all clones inserted, returns array of new job IDs
+    *   `[✅]`   Test: valid request with one document → handler finds matching EXECUTE job by JSONB payload query, marks it `superseded`, clone inserted as `pending` with correct payload copy, returns new job ID
+    *   `[✅]`   Test: valid request with multiple documents → all matching EXECUTE jobs found, marked `superseded`, clones inserted, returns array of new job IDs
     *   `[✅]`   Test: stage mismatch (requested stage ≠ session's current stage) → returns 400 error, no jobs modified
-    *   `[✅]`   Test: job not found → returns 404 error
-    *   `[✅]`   Test: job belongs to different session → returns 403 error
-    *   `[✅]`   Test: job is not an EXECUTE job → returns 400 error
-    *   `[✅]`   Test: user does not own the job → returns 403 error
+    *   `[✅]`   Test: no matching EXECUTE job found for a `{ documentKey, modelId }` pair → returns 404 error with descriptive message identifying which document/model had no job
+    *   `[✅]`   Test: multiple EXECUTE jobs match (original + prior retries) → selects most recent non-superseded one by `created_at DESC`
+    *   `[✅]`   Test: user does not own the matched job → returns 403 error
     *   `[✅]`   Test: cloned job has `parent_job_id: null`, `prerequisite_job_id: null`, `attempt_count: 0`, `status: 'pending'`
     *   `[✅]`   Test: cloned job preserves original's `payload`, `stage_slug`, `iteration_number`, `session_id`, `job_type`, `max_retries`
   *   `[✅]`   `construction`
     *   `[✅]`   Single exported async function `regenerateDocument(dbClient, payload, user)`
     *   `[✅]`   Returns `{ success: boolean; data?: RegenerateDocumentResponse; error?: { message: string; status?: number } }`
-    *   `[✅]`   No DI beyond `dbClient` and `user` — this is a thin data-copy operation
+    *   `[✅]`   No DI beyond `dbClient` and `user` — this is a thin lookup-and-copy operation
   *   `[✅]`   `regenerateDocument.ts`
     *   `[✅]`   Validate payload fields
     *   `[✅]`   Fetch session and verify `current_stage.slug === payload.stageSlug`
-    *   `[✅]`   For each job in `payload.jobs`:
-      *   `[✅]`   Fetch original job by ID
-      *   `[✅]`   Validate ownership (`user_id === user.id`), session match, stage match, iteration match, `job_type === 'EXECUTE'`
+    *   `[✅]`   For each document in `payload.documents`:
+      *   `[✅]`   Query `dialectic_generation_jobs` for EXECUTE jobs matching `session_id`, `stage_slug`, `iteration_number`, `user_id`, `job_type = 'EXECUTE'`, and JSONB payload fields for `documentKey` and `modelId`; exclude `status = 'superseded'`; order by `created_at DESC`; take first
+      *   `[✅]`   Validate ownership (`user_id === user.id`)
       *   `[✅]`   Update original job: `SET status = 'superseded'`
       *   `[✅]`   Insert clone row with fields copied from original, reset fields as specified in objective
     *   `[✅]`   Return `{ success: true, data: { jobIds } }`
@@ -880,6 +879,9 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[✅]`   Dependencies face inward: reads/writes `dialectic_generation_jobs`, reads `dialectic_sessions` and `dialectic_stages`
     *   `[✅]`   Provides face outward: consumed by `dialectic-service/index.ts` router
   *   `[✅]`   `requirements`
+    *   `[✅]`   The handler resolves EXECUTE jobs server-side — the frontend never needs to know EXECUTE job IDs, only `documentKey` and `modelId`
+    *   `[✅]`   JSONB query must match the document identity fields as stored in the EXECUTE job's payload by the planner — verify actual payload structure during implementation
+    *   `[✅]`   When multiple EXECUTE jobs match (original + prior superseded retries), select the most recent non-superseded one
     *   `[✅]`   Original job must be marked `superseded` BEFORE clone is inserted to prevent race conditions with progress tracking
     *   `[✅]`   Clone must have `parent_job_id: null` to prevent interference with original PLAN completion tracking
     *   `[✅]`   Clone must have `prerequisite_job_id: null` — the document's prerequisites are already met (they were met when the original ran)
@@ -930,101 +932,101 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[✅]`   Handler receives `adminClient` (not `userClient`) as `dbClient` — consistent with other handlers like `resumePausedNsfJobs`
     *   `[✅]`   Follows exact same routing pattern as `resumePausedNsfJobs` case block
 
-*   `[ ]`   [API] packages/api/`dialectic.api` **`regenerateDocument` API client method**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add a `regenerateDocument` method to `DialecticApiClient` that calls the `dialectic-service` edge function with action `'regenerateDocument'`
-    *   `[ ]`   Follow the same pattern as `resumePausedNsfJobs` method
-  *   `[ ]`   `role`
-    *   `[ ]`   API client — typed HTTP adapter for the edge function
-  *   `[ ]`   `module`
-    *   `[ ]`   `@paynless/api` — dialectic API client class
-    *   `[ ]`   Boundary: accepts typed payload → posts to edge function → returns typed response
-  *   `[ ]`   `deps`
-    *   `[ ]`   Edge function router node (above) — `regenerateDocument` action must be routable
-    *   `[ ]`   `apiClient.post` — existing HTTP post method on the base API client
-    *   `[ ]`   No reverse dependency introduced
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `this.apiClient.post<RegenerateDocumentResponse, DialecticServiceActionPayload>('dialectic-service', { action: 'regenerateDocument', payload })`
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; jobs: Array<{ jobId: string; modelId: string }> }` — mirrors the backend interface
-    *   `[ ]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
-  *   `[ ]`   interface/tests/`dialectic.types.test.ts`
-    *   `[ ]`   Test: `RegenerateDocumentPayload` shape contract
-    *   `[ ]`   Test: `RegenerateDocumentResponse` shape contract
-  *   `[ ]`   interface/guards/`type_guards.ts`
-    *   `[ ]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — if needed by consumers
-    *   `[ ]`   `isRegenerateDocumentResponse(value: unknown): value is RegenerateDocumentResponse`
-  *   `[ ]`   unit/`dialectic.api.test.ts`
-    *   `[ ]`   Test: `regenerateDocument` calls `apiClient.post` with `{ action: 'regenerateDocument', payload }` and correct typing
-    *   `[ ]`   Test: successful response returns `{ data: { jobIds: [...] }, error: null }`
-    *   `[ ]`   Test: error response returns `{ data: null, error: { message, status } }`
-  *   `[ ]`   `construction`
-    *   `[ ]`   New `async regenerateDocument(payload: RegenerateDocumentPayload): Promise<ApiResponse<RegenerateDocumentResponse>>` method on `DialecticApiClient`
-    *   `[ ]`   Follows identical pattern to `resumePausedNsfJobs` method at line 686
-  *   `[ ]`   `dialectic.api.ts`
-    *   `[ ]`   Add import for `RegenerateDocumentPayload`, `RegenerateDocumentResponse` from types
-    *   `[ ]`   Add `regenerateDocument` method to `DialecticApiClient` class
-  *   `[ ]`   `dialectic.api.mock.ts`
-    *   `[ ]`   Add `regenerateDocument` mock method returning default success response
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: adapter (API client)
-    *   `[ ]`   Dependencies face inward: uses types from `@paynless/types`, posts to edge function
-    *   `[ ]`   Provides face outward: consumed by `@paynless/store` dialectic store action
-  *   `[ ]`   `requirements`
-    *   `[ ]`   Must follow the same pattern as `resumePausedNsfJobs` — post to `dialectic-service` with typed action payload
-    *   `[ ]`   Must return `ApiResponse<RegenerateDocumentResponse>` with standard error handling
-    *   `[ ]`   Mock must be updated for store tests
+*   `[✅]`   [API] packages/api/`dialectic.api` **`regenerateDocument` API client method**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add a `regenerateDocument` method to `DialecticApiClient` that calls the `dialectic-service` edge function with action `'regenerateDocument'`
+    *   `[✅]`   Follow the same pattern as `resumePausedNsfJobs` method
+  *   `[✅]`   `role`
+    *   `[✅]`   API client — typed HTTP adapter for the edge function
+  *   `[✅]`   `module`
+    *   `[✅]`   `@paynless/api` — dialectic API client class
+    *   `[✅]`   Boundary: accepts typed payload → posts to edge function → returns typed response
+  *   `[✅]`   `deps`
+    *   `[✅]`   Edge function router node (above) — `regenerateDocument` action must be routable
+    *   `[✅]`   `apiClient.post` — existing HTTP post method on the base API client
+    *   `[✅]`   No reverse dependency introduced
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `this.apiClient.post<RegenerateDocumentResponse, DialecticServiceActionPayload>('dialectic-service', { action: 'regenerateDocument', payload })`
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; documents: Array<{ documentKey: string; modelId: string }> }` — mirrors the backend interface
+    *   `[✅]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
+  *   `[✅]`   interface/tests/`dialectic.types.test.ts`
+    *   `[✅]`   Test: `RegenerateDocumentPayload` shape contract
+    *   `[✅]`   Test: `RegenerateDocumentResponse` shape contract
+  *   `[✅]`   interface/guards/`type_guards.ts`
+    *   `[✅]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — if needed by consumers
+    *   `[✅]`   `isRegenerateDocumentResponse(value: unknown): value is RegenerateDocumentResponse`
+  *   `[✅]`   unit/`dialectic.api.test.ts`
+    *   `[✅]`   Test: `regenerateDocument` calls `apiClient.post` with `{ action: 'regenerateDocument', payload }` and correct typing
+    *   `[✅]`   Test: successful response returns `{ data: { jobIds: [...] }, error: null }`
+    *   `[✅]`   Test: error response returns `{ data: null, error: { message, status } }`
+  *   `[✅]`   `construction`
+    *   `[✅]`   New `async regenerateDocument(payload: RegenerateDocumentPayload): Promise<ApiResponse<RegenerateDocumentResponse>>` method on `DialecticApiClient`
+    *   `[✅]`   Follows identical pattern to `resumePausedNsfJobs` method at line 686
+  *   `[✅]`   `dialectic.api.ts`
+    *   `[✅]`   Add import for `RegenerateDocumentPayload`, `RegenerateDocumentResponse` from types
+    *   `[✅]`   Add `regenerateDocument` method to `DialecticApiClient` class
+  *   `[✅]`   `dialectic.api.mock.ts`
+    *   `[✅]`   Add `regenerateDocument` mock method returning default success response
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: adapter (API client)
+    *   `[✅]`   Dependencies face inward: uses types from `@paynless/types`, posts to edge function
+    *   `[✅]`   Provides face outward: consumed by `@paynless/store` dialectic store action
+  *   `[✅]`   `requirements`
+    *   `[✅]`   Must follow the same pattern as `resumePausedNsfJobs` — post to `dialectic-service` with typed action payload
+    *   `[✅]`   Must return `ApiResponse<RegenerateDocumentResponse>` with standard error handling
+    *   `[✅]`   Mock must be updated for store tests
 
-*   `[ ]`   [STORE] packages/store/`dialecticStore` **`regenerateDocument` action with progress re-hydration**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Provide a `regenerateDocument` store action that calls `api.dialectic().regenerateDocument(payload)` and triggers progress re-hydration so the UI reflects the new job's lifecycle
-    *   `[ ]`   Track the new job IDs in `generatingSessions` so the generating state is correctly reflected
-    *   `[ ]`   Set `generatingForStageSlug` so the checklist shows generating spinners for the affected documents
-  *   `[ ]`   `role`
-    *   `[ ]`   State management — bridges UI action to API call and progress refresh
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic store — extends existing actions
-    *   `[ ]`   Boundary: receives regenerate action from UI → calls API → tracks jobs → re-hydrates progress
-  *   `[ ]`   `deps`
-    *   `[ ]`   API client node (above) — `api.dialectic().regenerateDocument` must exist
-    *   `[ ]`   Existing `hydrateAllStageProgress` action — called after successful API response to refresh progress data
-    *   `[ ]`   Existing `generatingSessions` state — tracks active job IDs per session
-    *   `[ ]`   Existing `generatingForStageSlug` state — identifies which stage is actively generating
-    *   `[ ]`   Existing `contributionGenerationStatus` state — set to `'generating'` during regeneration
-    *   `[ ]`   `api` — the API client instance, available via the store's existing infrastructure pattern (same as `generateContributions` at line 1906)
-    *   `[ ]`   No reverse dependency introduced — the store is consumed by UI components
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `api.dialectic().regenerateDocument`: from `@paynless/api` via the store's existing API infrastructure
-    *   `[ ]`   `RegenerateDocumentPayload`, `RegenerateDocumentResponse`: from `@paynless/types`
-    *   `[ ]`   `hydrateAllStageProgress`: existing store action
-    *   `[ ]`   Existing store state: `generatingSessions`, `contributionGenerationStatus`, `generatingForStageSlug`
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   Add `regenerateDocument: (payload: RegenerateDocumentPayload) => Promise<ApiResponse<RegenerateDocumentResponse>>` to `DialecticActions` (alongside existing actions like `generateContributions`)
-  *   `[ ]`   unit/`dialecticStore.regenerateDocument.test.ts`
-    *   `[ ]`   Test: `regenerateDocument` calls `api.dialectic().regenerateDocument(payload)` with correct `{ sessionId, stageSlug, iterationNumber, jobs }`
-    *   `[ ]`   Test: on successful API response, `regenerateDocument` adds returned job IDs to `generatingSessions[sessionId]`
-    *   `[ ]`   Test: on successful API response, `regenerateDocument` sets `contributionGenerationStatus` to `'generating'` and `generatingForStageSlug` to `payload.stageSlug`
-    *   `[ ]`   Test: on successful API response, `regenerateDocument` calls `hydrateAllStageProgress` to refresh progress data
-    *   `[ ]`   Test: on API failure, `regenerateDocument` does NOT modify `generatingSessions` or `contributionGenerationStatus`
-    *   `[ ]`   Test: on API failure, `regenerateDocument` returns the error response
-  *   `[ ]`   `construction`
-    *   `[ ]`   `regenerateDocument` is a public action exposed on the store interface
-    *   `[ ]`   Follows the same pattern as `generateContributions` for job tracking and status management
-  *   `[ ]`   `dialecticStore.ts`
-    *   `[ ]`   Add `regenerateDocument(payload: RegenerateDocumentPayload)` action:
-      *   `[ ]`   Set `contributionGenerationStatus = 'generating'`, `generatingForStageSlug = payload.stageSlug`
-      *   `[ ]`   Call `api.dialectic().regenerateDocument(payload)`
-      *   `[ ]`   On success: add returned `jobIds` to `generatingSessions[payload.sessionId]`, call `get().hydrateAllStageProgress(...)`, return response
-      *   `[ ]`   On failure: reset `contributionGenerationStatus = 'idle'`, reset `generatingForStageSlug = null`, return error response
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: application (state management)
-    *   `[ ]`   Dependencies face inward: consumes API layer (`api.dialectic()`) and types
-    *   `[ ]`   Provides face outward: consumed by UI component (StageRunChecklist regenerate button)
-  *   `[ ]`   `requirements`
-    *   `[ ]`   The action must call through the API layer: store → `api.dialectic().regenerateDocument()` → edge function — NOT directly to Supabase
-    *   `[ ]`   After successful regeneration, `hydrateAllStageProgress` must be called to refresh progress — the progress tracker is the source of truth for UI state transitions
-    *   `[ ]`   Job IDs must be tracked in `generatingSessions` so lifecycle events from the worker are correctly processed by existing `_handleDialecticLifecycleEvent` handlers
-    *   `[ ]`   `generatingForStageSlug` must be set so the StageRunChecklist shows generating spinners for affected documents
+*   `[✅]`   [STORE] packages/store/`dialecticStore` **`regenerateDocument` action with progress re-hydration**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Provide a `regenerateDocument` store action that calls `api.dialectic().regenerateDocument(payload)` and triggers progress re-hydration so the UI reflects the new job's lifecycle
+    *   `[✅]`   Track the new job IDs in `generatingSessions` so the generating state is correctly reflected
+    *   `[✅]`   Set `generatingForStageSlug` so the checklist shows generating spinners for the affected documents
+  *   `[✅]`   `role`
+    *   `[✅]`   State management — bridges UI action to API call and progress refresh
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic store — extends existing actions
+    *   `[✅]`   Boundary: receives regenerate action from UI → calls API → tracks jobs → re-hydrates progress
+  *   `[✅]`   `deps`
+    *   `[✅]`   API client node (above) — `api.dialectic().regenerateDocument` must exist
+    *   `[✅]`   Existing `hydrateAllStageProgress` action — called after successful API response to refresh progress data
+    *   `[✅]`   Existing `generatingSessions` state — tracks active job IDs per session
+    *   `[✅]`   Existing `generatingForStageSlug` state — identifies which stage is actively generating
+    *   `[✅]`   Existing `contributionGenerationStatus` state — set to `'generating'` during regeneration
+    *   `[✅]`   `api` — the API client instance, available via the store's existing infrastructure pattern (same as `generateContributions` at line 1906)
+    *   `[✅]`   No reverse dependency introduced — the store is consumed by UI components
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `api.dialectic().regenerateDocument`: from `@paynless/api` via the store's existing API infrastructure
+    *   `[✅]`   `RegenerateDocumentPayload`, `RegenerateDocumentResponse`: from `@paynless/types`
+    *   `[✅]`   `hydrateAllStageProgress`: existing store action
+    *   `[✅]`   Existing store state: `generatingSessions`, `contributionGenerationStatus`, `generatingForStageSlug`
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   Add `regenerateDocument: (payload: RegenerateDocumentPayload) => Promise<ApiResponse<RegenerateDocumentResponse>>` to `DialecticActions` (alongside existing actions like `generateContributions`)
+  *   `[✅]`   unit/`dialecticStore.regenerateDocument.test.ts`
+    *   `[✅]`   Test: `regenerateDocument` calls `api.dialectic().regenerateDocument(payload)` with correct `{ sessionId, stageSlug, iterationNumber, documents }`
+    *   `[✅]`   Test: on successful API response, `regenerateDocument` adds returned job IDs to `generatingSessions[sessionId]`
+    *   `[✅]`   Test: on successful API response, `regenerateDocument` sets `contributionGenerationStatus` to `'generating'` and `generatingForStageSlug` to `payload.stageSlug`
+    *   `[✅]`   Test: on successful API response, `regenerateDocument` calls `hydrateAllStageProgress` to refresh progress data
+    *   `[✅]`   Test: on API failure, `regenerateDocument` does NOT modify `generatingSessions` or `contributionGenerationStatus`
+    *   `[✅]`   Test: on API failure, `regenerateDocument` returns the error response
+  *   `[✅]`   `construction`
+    *   `[✅]`   `regenerateDocument` is a public action exposed on the store interface
+    *   `[✅]`   Follows the same pattern as `generateContributions` for job tracking and status management
+  *   `[✅]`   `dialecticStore.ts`
+    *   `[✅]`   Add `regenerateDocument(payload: RegenerateDocumentPayload)` action:
+      *   `[✅]`   Set `contributionGenerationStatus = 'generating'`, `generatingForStageSlug = payload.stageSlug`
+      *   `[✅]`   Call `api.dialectic().regenerateDocument(payload)`
+      *   `[✅]`   On success: add returned `jobIds` to `generatingSessions[payload.sessionId]`, call `get().hydrateAllStageProgress(...)`, return response
+      *   `[✅]`   On failure: reset `contributionGenerationStatus = 'idle'`, reset `generatingForStageSlug = null`, return error response
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: application (state management)
+    *   `[✅]`   Dependencies face inward: consumes API layer (`api.dialectic()`) and types
+    *   `[✅]`   Provides face outward: consumed by UI component (StageRunChecklist regenerate button)
+  *   `[✅]`   `requirements`
+    *   `[✅]`   The action must call through the API layer: store → `api.dialectic().regenerateDocument()` → edge function — NOT directly to Supabase
+    *   `[✅]`   After successful regeneration, `hydrateAllStageProgress` must be called to refresh progress — the progress tracker is the source of truth for UI state transitions
+    *   `[✅]`   Job IDs must be tracked in `generatingSessions` so lifecycle events from the worker are correctly processed by existing `_handleDialecticLifecycleEvent` handlers
+    *   `[✅]`   `generatingForStageSlug` must be set so the StageRunChecklist shows generating spinners for affected documents
 
 *   `[ ]`   [UI] apps/web/`StageRunChecklist` **Per-document regenerate button with model selection dialog**
   *   `[ ]`   `objective`
@@ -1034,7 +1036,7 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[ ]`   On click, show a model-selection confirmation dialog listing all models for that document with checkboxes
     *   `[ ]`   Pre-check models whose status is `Failed` or `Not started`; leave `Completed` models unchecked (user must actively opt in to re-roll a successful document)
     *   `[ ]`   Disable the regenerate button when the document's stage is not the session's current stage
-    *   `[ ]`   On confirmation, call the `regenerateDocument` store action with the selected `{ jobId, modelId }` pairs
+    *   `[ ]`   On confirmation, call the `regenerateDocument` store action with the selected `{ documentKey, modelId }` pairs
   *   `[ ]`   `role`
     *   `[ ]`   UI / presentation — user-facing regeneration trigger
   *   `[ ]`   `module`
@@ -1054,11 +1056,9 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[ ]`   `activeSessionDetail` — for `current_stage_id` and `iteration_count`
     *   `[ ]`   `activeStageSlug` — to determine if the current stage matches the session's current stage
     *   `[ ]`   `perModelLabels` — already computed per document row, provides model status for pre-checking
-    *   `[ ]`   `entry.jobId` — the original EXECUTE job ID per model (needed for the payload)
-    *   `[ ]`   Note: `entry.jobId` in `StageDocumentEntry` currently holds the first rendered entry's job ID, which is a RENDER job ID, not an EXECUTE job ID. The dialog needs the EXECUTE job ID. This may require enriching `perModelLabels` or `StageDocumentEntry` with per-model EXECUTE job IDs from `stageRunProgress` descriptors.
+    *   `[ ]`   `entry.documentKey` — the document identity per model (the backend resolves the EXECUTE job ID server-side)
   *   `[ ]`   interface/`StageRunChecklist types`
-    *   `[ ]`   Extend `PerModelLabel` to include `jobId: string | null` — the EXECUTE job ID for that model's document, sourced from the rendered document descriptor's `job_id` field (which tracks the EXECUTE job, not the RENDER job)
-    *   `[ ]`   `RegenerateDocumentDialogProps`: `{ open: boolean; documentKey: string; stageSlug: string; perModelLabels: PerModelLabel[]; onConfirm: (selectedJobs: Array<{ jobId: string; modelId: string }>) => void; onCancel: () => void }`
+    *   `[ ]`   `RegenerateDocumentDialogProps`: `{ open: boolean; documentKey: string; stageSlug: string; perModelLabels: PerModelLabel[]; onConfirm: (selectedDocuments: Array<{ documentKey: string; modelId: string }>) => void; onCancel: () => void }`
   *   `[ ]`   unit/`StageRunChecklist.test.tsx`
     *   `[ ]`   Test: completed document renders green clickable icon-button (not static circle)
     *   `[ ]`   Test: failed document renders red clickable icon-button
@@ -1081,7 +1081,7 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[ ]`   Replace static `<span>` circles (lines 538-554) with `<button>` elements that open the dialog on click
     *   `[ ]`   Preserve `Loader2` spinner for generating/continuing states as non-clickable
     *   `[ ]`   Implement `RegenerateDocumentDialog` with checkboxes per model, pre-fill logic, confirm/cancel
-    *   `[ ]`   Enrich `perModelLabels` computation (in `computeStageRunChecklistData`) to include the EXECUTE `jobId` per model by reading from `stageRunProgress` document descriptors
+    *   `[ ]`   On confirm: map selected `perModelLabels` entries to `{ documentKey, modelId }` pairs for the payload
     *   `[ ]`   On confirm: construct `RegenerateDocumentPayload` and call `regenerateDocument`
   *   `[ ]`   `directionality`
     *   `[ ]`   Layer: UI / presentation

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -274,103 +274,103 @@ A user cannot begin a set of work when they have NSF. If a user reaches NSF whil
     *   `[✅]`   All existing step status derivation behavior must be preserved
 
 ### Node 6
-*   `[ ]`   [BE] supabase/functions/dialectic-service/`getAllStageProgress` **Handle `paused_nsf` step status in stage progress computation**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Update the step-counting loop in `getAllStageProgress.ts` to count `paused_nsf` steps so that stage status correctly reflects when any step is paused due to NSF
-    *   `[ ]`   Update stage status derivation priority: `failed` > `paused_nsf` > `completed` > `in_progress` > `not_started`
-  *   `[ ]`   `role`
-    *   `[ ]`   Infrastructure — stage progress aggregation within the dialectic-service edge function
-  *   `[ ]`   `module`
-    *   `[ ]`   Progress tracking — stage-level aggregation from step statuses
-    *   `[ ]`   Boundary: receives step statuses from `deriveStepStatuses`, computes stage-level progress and status for the `GetAllStageProgressResponse`
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 5 (`deriveStepStatuses`) — must return `paused_nsf` as a valid `UnifiedStageStatus` before this node can count it
-    *   `[ ]`   `StageProgressEntry` interface (dialectic.interface.ts line 689) — `status` field is `UnifiedStageStatus`, which already includes `paused_nsf` after Node 5
-    *   `[ ]`   No reverse dependency introduced — this is consumed by the frontend via the API layer
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   Step-counting loop (line 841): iterates `steps`, gets status from `stepStatusMap`, counts `completedSteps` and `failedSteps`
-    *   `[ ]`   Stage status derivation (line 848): priority logic that produces `stageStatus: UnifiedStageStatus`
-    *   `[ ]`   No new injected dependencies
-  *   `[ ]`   unit/`getAllStageProgress.test.ts`
-    *   `[ ]`   Test: when any step has status `paused_nsf`, stage status is `paused_nsf`
-    *   `[ ]`   Test: when steps have mix of `paused_nsf` and `completed`, stage status is `paused_nsf`
-    *   `[ ]`   Test: when steps have mix of `paused_nsf` and `failed`, stage status is `failed` (failure takes priority at stage level)
-    *   `[ ]`   Test: existing tests for `in_progress`, `completed`, `failed`, `not_started` stage statuses continue to pass
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new functions — modification to existing step-counting and stage status derivation logic
-  *   `[ ]`   `getAllStageProgress.ts`
-    *   `[ ]`   Add `let pausedNsfSteps: number = 0;` alongside `completedSteps` and `failedSteps` (line 838)
-    *   `[ ]`   In the step-counting loop (line 841), add: `if (status === "paused_nsf") pausedNsfSteps += 1;`
-    *   `[ ]`   In stage status derivation (line 848), insert `paused_nsf` check after `failed` and before `completed`: `if (failedSteps > 0) { stageStatus = "failed"; } else if (pausedNsfSteps > 0) { stageStatus = "paused_nsf"; } else if (completedSteps === totalSteps && failedSteps === 0) { ...existing... }`
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: infrastructure (progress aggregation)
-    *   `[ ]`   Dependencies face inward: consumes `deriveStepStatuses` output and `UnifiedStageStatus` type
-    *   `[ ]`   Provides face outward: returns `GetAllStageProgressResponse` consumed by the API layer → frontend
-  *   `[ ]`   `requirements`
-    *   `[ ]`   Stage status must be `paused_nsf` when any step is `paused_nsf` and no steps have failed
-    *   `[ ]`   `failed` stage status still takes priority over `paused_nsf` — a failed step is more severe
-    *   `[ ]`   `paused_nsf` step count must not be counted as `completedSteps` or `failedSteps`
-    *   `[ ]`   All existing stage progress computation behavior must be preserved
-  *   `[ ]`   **Commit** `fix(be) supabase/functions/dialectic-service paused_nsf status in progress derivation and stage aggregation`
-    *   `[ ]`   Updated type: `UnifiedStageStatus` in `dialectic.interface.ts` — added `paused_nsf`
-    *   `[ ]`   Modified: `deriveStepStatuses.ts` — maps `paused_nsf` job status to `paused_nsf` step status
-    *   `[ ]`   Modified: `getAllStageProgress.ts` — counts paused steps, derives `paused_nsf` stage status
+*   `[✅]`   [BE] supabase/functions/dialectic-service/`getAllStageProgress` **Handle `paused_nsf` step status in stage progress computation**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Update the step-counting loop in `getAllStageProgress.ts` to count `paused_nsf` steps so that stage status correctly reflects when any step is paused due to NSF
+    *   `[✅]`   Update stage status derivation priority: `failed` > `paused_nsf` > `completed` > `in_progress` > `not_started`
+  *   `[✅]`   `role`
+    *   `[✅]`   Infrastructure — stage progress aggregation within the dialectic-service edge function
+  *   `[✅]`   `module`
+    *   `[✅]`   Progress tracking — stage-level aggregation from step statuses
+    *   `[✅]`   Boundary: receives step statuses from `deriveStepStatuses`, computes stage-level progress and status for the `GetAllStageProgressResponse`
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 5 (`deriveStepStatuses`) — must return `paused_nsf` as a valid `UnifiedStageStatus` before this node can count it
+    *   `[✅]`   `StageProgressEntry` interface (dialectic.interface.ts line 689) — `status` field is `UnifiedStageStatus`, which already includes `paused_nsf` after Node 5
+    *   `[✅]`   No reverse dependency introduced — this is consumed by the frontend via the API layer
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   Step-counting loop (line 841): iterates `steps`, gets status from `stepStatusMap`, counts `completedSteps` and `failedSteps`
+    *   `[✅]`   Stage status derivation (line 848): priority logic that produces `stageStatus: UnifiedStageStatus`
+    *   `[✅]`   No new injected dependencies
+  *   `[✅]`   unit/`getAllStageProgress.test.ts`
+    *   `[✅]`   Test: when any step has status `paused_nsf`, stage status is `paused_nsf`
+    *   `[✅]`   Test: when steps have mix of `paused_nsf` and `completed`, stage status is `paused_nsf`
+    *   `[✅]`   Test: when steps have mix of `paused_nsf` and `failed`, stage status is `failed` (failure takes priority at stage level)
+    *   `[✅]`   Test: existing tests for `in_progress`, `completed`, `failed`, `not_started` stage statuses continue to pass
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new functions — modification to existing step-counting and stage status derivation logic
+  *   `[✅]`   `getAllStageProgress.ts`
+    *   `[✅]`   Add `let pausedNsfSteps: number = 0;` alongside `completedSteps` and `failedSteps` (line 838)
+    *   `[✅]`   In the step-counting loop (line 841), add: `if (status === "paused_nsf") pausedNsfSteps += 1;`
+    *   `[✅]`   In stage status derivation (line 848), insert `paused_nsf` check after `failed` and before `completed`: `if (failedSteps > 0) { stageStatus = "failed"; } else if (pausedNsfSteps > 0) { stageStatus = "paused_nsf"; } else if (completedSteps === totalSteps && failedSteps === 0) { ...existing... }`
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: infrastructure (progress aggregation)
+    *   `[✅]`   Dependencies face inward: consumes `deriveStepStatuses` output and `UnifiedStageStatus` type
+    *   `[✅]`   Provides face outward: returns `GetAllStageProgressResponse` consumed by the API layer → frontend
+  *   `[✅]`   `requirements`
+    *   `[✅]`   Stage status must be `paused_nsf` when any step is `paused_nsf` and no steps have failed
+    *   `[✅]`   `failed` stage status still takes priority over `paused_nsf` — a failed step is more severe
+    *   `[✅]`   `paused_nsf` step count must not be counted as `completedSteps` or `failedSteps`
+    *   `[✅]`   All existing stage progress computation behavior must be preserved
+  *   `[✅]`   **Commit** `fix(be) supabase/functions/dialectic-service paused_nsf status in progress derivation and stage aggregation`
+    *   `[✅]`   Updated type: `UnifiedStageStatus` in `dialectic.interface.ts` — added `paused_nsf`
+    *   `[✅]`   Modified: `deriveStepStatuses.ts` — maps `paused_nsf` job status to `paused_nsf` step status
+    *   `[✅]`   Modified: `getAllStageProgress.ts` — counts paused steps, derives `paused_nsf` stage status
 
 ### Node 7
-*   `[ ]`   [BE] supabase/functions/dialectic-service/`resumePausedNsfJobs` **Resume handler, routing, and `ActionHandlers` wiring for the `resumePausedNsfJobs` action**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Create a `resumePausedNsfJobs` handler in the dialectic-service edge function that receives `sessionId`, `stageSlug`, `iterationNumber` from an authenticated request, calls the `resume_paused_nsf_jobs` RPC via `adminClient`, and returns the count of resumed jobs
-    *   `[ ]`   Add a `resumePausedNsfJobs` routing case to the `handleRequest` switch in `index.ts` and register it in `defaultHandlers` and the `ActionHandlers` interface
-    *   `[ ]`   Add the corresponding `ResumePausedNsfJobsAction` to the `DialecticServiceRequest` union so the request type-checks
-  *   `[ ]`   `role`
-    *   `[ ]`   Backend / adapter — the edge function handler that bridges an authenticated API request to the database RPC
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic service — resume handler within the existing action-routed edge function
-    *   `[ ]`   Boundary: receives authenticated request → validates payload → calls `adminClient.rpc('resume_paused_nsf_jobs')` → returns result
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 1 (migration) — `resume_paused_nsf_jobs` RPC must exist in the database
-    *   `[ ]`   `adminClient` (Supabase admin client) — available in the `handleRequest` scope via `index.ts`
-    *   `[ ]`   `ActionHandlers` interface (index.ts line 158) — must be extended with the new handler signature
-    *   `[ ]`   `DialecticServiceRequest` union (dialectic.interface.ts line 601) — must include the new action type
-    *   `[ ]`   `defaultHandlers` (index.ts line 637) — must include the new handler
-    *   `[ ]`   No reverse dependency introduced — this is consumed by the API layer (Node 8)
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   Existing routing pattern in `handleRequest` (index.ts line 284): `switch (action) { case "getAllStageProgress": ... }` — the new case follows this pattern
-    *   `[ ]`   `adminClient`: `SupabaseClient` — used for `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number })`
-    *   `[ ]`   `userForJson`: `User` — used for ownership verification (the RPC itself verifies ownership, but auth check gates access)
-  *   `[ ]`   interface/`dialectic.interface.ts`
-    *   `[ ]`   `ResumePausedNsfJobsPayload` — `{ sessionId: string; stageSlug: string; iterationNumber: number }` — matches the parameters of the `resume_paused_nsf_jobs` RPC
-    *   `[ ]`   `ResumePausedNsfJobsAction` — `{ action: "resumePausedNsfJobs"; payload: ResumePausedNsfJobsPayload }` — follows the existing discriminated union pattern
-    *   `[ ]`   Add `ResumePausedNsfJobsAction` to the `DialecticServiceRequest` union (line 601)
-    *   `[ ]`   `ResumePausedNsfJobsResponse` — `{ resumedCount: number }` — returned by the handler on success
-  *   `[ ]`   unit/`resumePausedNsfJobs.test.ts`
-    *   `[ ]`   Test: handler calls `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number })` with correct parameters
-    *   `[ ]`   Test: handler returns `{ resumedCount: N }` on success where N is the RPC return value
-    *   `[ ]`   Test: handler returns 401 error when user is not authenticated
-    *   `[ ]`   Test: handler returns 500 error when RPC fails and logs the error
-  *   `[ ]`   `construction`
-    *   `[ ]`   Single exported async function: `handleResumePausedNsfJobs(payload: ResumePausedNsfJobsPayload, adminClient: SupabaseClient, user: User): Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>`
-    *   `[ ]`   Follows existing handler signature pattern from `ActionHandlers`
-  *   `[ ]`   `resumePausedNsfJobs.ts`
-    *   `[ ]`   Import `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` from `./dialectic.interface.ts`
-    *   `[ ]`   Call `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id: payload.sessionId, p_stage_slug: payload.stageSlug, p_iteration_number: payload.iterationNumber })`
-    *   `[ ]`   On success: return `{ status: 200, data: { resumedCount: data } }`
-    *   `[ ]`   On error: return `{ status: 500, error: { message: error.message, status: 500, code: 'RESUME_FAILED' } }`
-  *   `[ ]`   `index.ts`
-    *   `[ ]`   Add `import { handleResumePausedNsfJobs } from './resumePausedNsfJobs.ts';` at the top
-    *   `[ ]`   Add `resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload, adminClient: SupabaseClient, user: User) => Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>;` to the `ActionHandlers` interface (line 158)
-    *   `[ ]`   Add `case "resumePausedNsfJobs":` to the switch in `handleRequest`, following the same pattern as `getAllStageProgress` (line 586): auth check → extract payload → call handler → return response
-    *   `[ ]`   Add `resumePausedNsfJobs: handleResumePausedNsfJobs,` to `defaultHandlers` (line 637)
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: adapter (edge function handler)
-    *   `[ ]`   Dependencies face inward: depends on `adminClient` (infra) and `resume_paused_nsf_jobs` RPC (infra)
-    *   `[ ]`   Provides face outward: consumed by the API layer (Node 8) via HTTP POST to `dialectic-service`
-  *   `[ ]`   `requirements`
-    *   `[ ]`   The handler must require authentication — unauthenticated requests must be rejected
-    *   `[ ]`   The handler must call the `resume_paused_nsf_jobs` RPC with the correct parameters
-    *   `[ ]`   The handler must return the count of resumed jobs on success
-    *   `[ ]`   RPC failures must be returned as 500 errors with the error message — not silently swallowed
-    *   `[ ]`   The routing case, handler signature, and `defaultHandlers` entry must follow the existing patterns exactly
+*   `[✅]`   [BE] supabase/functions/dialectic-service/`resumePausedNsfJobs` **Resume handler, routing, and `ActionHandlers` wiring for the `resumePausedNsfJobs` action**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Create a `resumePausedNsfJobs` handler in the dialectic-service edge function that receives `sessionId`, `stageSlug`, `iterationNumber` from an authenticated request, calls the `resume_paused_nsf_jobs` RPC via `adminClient`, and returns the count of resumed jobs
+    *   `[✅]`   Add a `resumePausedNsfJobs` routing case to the `handleRequest` switch in `index.ts` and register it in `defaultHandlers` and the `ActionHandlers` interface
+    *   `[✅]`   Add the corresponding `ResumePausedNsfJobsAction` to the `DialecticServiceRequest` union so the request type-checks
+  *   `[✅]`   `role`
+    *   `[✅]`   Backend / adapter — the edge function handler that bridges an authenticated API request to the database RPC
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic service — resume handler within the existing action-routed edge function
+    *   `[✅]`   Boundary: receives authenticated request → validates payload → calls `adminClient.rpc('resume_paused_nsf_jobs')` → returns result
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 1 (migration) — `resume_paused_nsf_jobs` RPC must exist in the database
+    *   `[✅]`   `adminClient` (Supabase admin client) — available in the `handleRequest` scope via `index.ts`
+    *   `[✅]`   `ActionHandlers` interface (index.ts line 158) — must be extended with the new handler signature
+    *   `[✅]`   `DialecticServiceRequest` union (dialectic.interface.ts line 601) — must include the new action type
+    *   `[✅]`   `defaultHandlers` (index.ts line 637) — must include the new handler
+    *   `[✅]`   No reverse dependency introduced — this is consumed by the API layer (Node 8)
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   Existing routing pattern in `handleRequest` (index.ts line 284): `switch (action) { case "getAllStageProgress": ... }` — the new case follows this pattern
+    *   `[✅]`   `adminClient`: `SupabaseClient` — used for `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number })`
+    *   `[✅]`   `userForJson`: `User` — used for ownership verification (the RPC itself verifies ownership, but auth check gates access)
+  *   `[✅]`   interface/`dialectic.interface.ts`
+    *   `[✅]`   `ResumePausedNsfJobsPayload` — `{ sessionId: string; stageSlug: string; iterationNumber: number }` — matches the parameters of the `resume_paused_nsf_jobs` RPC
+    *   `[✅]`   `ResumePausedNsfJobsAction` — `{ action: "resumePausedNsfJobs"; payload: ResumePausedNsfJobsPayload }` — follows the existing discriminated union pattern
+    *   `[✅]`   Add `ResumePausedNsfJobsAction` to the `DialecticServiceRequest` union (line 601)
+    *   `[✅]`   `ResumePausedNsfJobsResponse` — `{ resumedCount: number }` — returned by the handler on success
+  *   `[✅]`   unit/`resumePausedNsfJobs.test.ts`
+    *   `[✅]`   Test: handler calls `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number })` with correct parameters
+    *   `[✅]`   Test: handler returns `{ resumedCount: N }` on success where N is the RPC return value
+    *   `[✅]`   Test: handler returns 401 error when user is not authenticated
+    *   `[✅]`   Test: handler returns 500 error when RPC fails and logs the error
+  *   `[✅]`   `construction`
+    *   `[✅]`   Single exported async function: `handleResumePausedNsfJobs(payload: ResumePausedNsfJobsPayload, adminClient: SupabaseClient, user: User): Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>`
+    *   `[✅]`   Follows existing handler signature pattern from `ActionHandlers`
+  *   `[✅]`   `resumePausedNsfJobs.ts`
+    *   `[✅]`   Import `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` from `./dialectic.interface.ts`
+    *   `[✅]`   Call `adminClient.rpc('resume_paused_nsf_jobs', { p_session_id: payload.sessionId, p_stage_slug: payload.stageSlug, p_iteration_number: payload.iterationNumber })`
+    *   `[✅]`   On success: return `{ status: 200, data: { resumedCount: data } }`
+    *   `[✅]`   On error: return `{ status: 500, error: { message: error.message, status: 500, code: 'RESUME_FAILED' } }`
+  *   `[✅]`   `index.ts`
+    *   `[✅]`   Add `import { handleResumePausedNsfJobs } from './resumePausedNsfJobs.ts';` at the top
+    *   `[✅]`   Add `resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload, adminClient: SupabaseClient, user: User) => Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>;` to the `ActionHandlers` interface (line 158)
+    *   `[✅]`   Add `case "resumePausedNsfJobs":` to the switch in `handleRequest`, following the same pattern as `getAllStageProgress` (line 586): auth check → extract payload → call handler → return response
+    *   `[✅]`   Add `resumePausedNsfJobs: handleResumePausedNsfJobs,` to `defaultHandlers` (line 637)
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: adapter (edge function handler)
+    *   `[✅]`   Dependencies face inward: depends on `adminClient` (infra) and `resume_paused_nsf_jobs` RPC (infra)
+    *   `[✅]`   Provides face outward: consumed by the API layer (Node 8) via HTTP POST to `dialectic-service`
+  *   `[✅]`   `requirements`
+    *   `[✅]`   The handler must require authentication — unauthenticated requests must be rejected
+    *   `[✅]`   The handler must call the `resume_paused_nsf_jobs` RPC with the correct parameters
+    *   `[✅]`   The handler must return the count of resumed jobs on success
+    *   `[✅]`   RPC failures must be returned as 500 errors with the error message — not silently swallowed
+    *   `[✅]`   The routing case, handler signature, and `defaultHandlers` entry must follow the existing patterns exactly
 
 ### Node 8
 *   `[ ]`   [API] packages/api/src/`dialectic.api` **Add `resumePausedNsfJobs` method to `DialecticApiClient` interface and implementation**

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -1111,24 +1111,6 @@ A user clicks a regenerate button on any document in the stage run checklist, se
 
 # ToDo
 
-    - Regenerate individual specific documents on demand without regenerating inputs or other sibling documents 
-    -- User reports that a single document failed and they liked the other documents, but had to regenerate the entire stage
-    -- User requests option to only regenerate the exact document that failed
-    -- Initial investigation shows this should be possible, all the deps are met, we just need a means to dispatch a job for only the exact document that errored or otherwise wasn't produced so that the user does't have to rerun the entire stage to get a single document
-    -- Added bonus, this lets users "roll the dice" to get a different/better/alternative version of an existing document if they want to try again 
-    -- FOR CONSIDERATION: This is a powerful feature but implies a branch in the work
-    --- User generates stage, all succeeds
-    --- User advances stages, decides they want to fix an oversight in a prior stage
-    --- User regenerates a prior document
-    --- Now subsequent documents derived from the original are invalid
-    --- Is this a true branch/iteration, or do we highlight the downstream products so that those can be regenerated from the new input that was produced? 
-    --- If we "only" highlight downstream products, all downstream products are invalid, because the header_context used to generate them would be invalid 
-    --- PROPOSED: Implement regeneration prior to stage advancement, disable regeneration for documents who have downstream documents, set up future sprint for branching/iteration to support hints to regenerate downstream documents if a user regenerates upstream documents
-    --- BLOCKER: Some stages are fundamentally dependent on all prior outputs, like synthesis, and the entire stage needs to be rerun if thesis/antithesis documents are regenerated
-
-    - Set baseline values for each stage "Generate" action and encourage users to top up their account if they are at risk of NSF
-    -- Pause the work mid-stream if NSF and encourage user to top up to continue 
-
     - New user sign in banner doesn't display, throws console error  
     -- Chase, diagnose, fix 
 

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -741,194 +741,194 @@ A user clicks a regenerate button on any document in the stage run checklist, se
 - **Active-stage-only gate**: `generateContributions` already validates `session.current_stage.slug === payload.stageSlug`. The regenerate handler applies the same validation.
 - **Model selection dialog**: The checklist already computes `perModelLabels` with per-model status. Failed/not-started models are pre-checked; completed models are unchecked (user must actively opt in).
 
-*   `[ ]`   [DB] supabase/migrations **`superseded` job status for regenerated document jobs**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Introduce the `superseded` terminal job status so that original jobs replaced by a regeneration clone are marked as replaced rather than remaining `failed`
-    *   `[ ]`   Ensure `superseded` IS treated as a terminal status by `handle_job_completion()` — it should not wake parent jobs or prerequisite chains
-    *   `[ ]`   Ensure `superseded` does NOT appear in worker-invoking trigger WHEN clauses (`on_job_status_change`, `on_new_job_created`) — the worker must never be invoked for superseded jobs
-    *   `[ ]`   Ensure `superseded` is excluded from the NSF pause function `resume_paused_nsf_jobs` — superseded jobs must not be resumed
-  *   `[ ]`   `role`
-    *   `[ ]`   Infrastructure — database schema and trigger layer
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic generation job state machine — extends the terminal status set
-    *   `[ ]`   Boundary: defines the `superseded` status semantics within the existing trigger and completion infrastructure
-  *   `[ ]`   `deps`
-    *   `[ ]`   `handle_job_completion()` function (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 180) — must include `superseded` in the terminal status check at line 204: `IF NEW.status NOT IN ('completed', 'failed', 'retry_loop_failed')` → add `'superseded'`
-    *   `[ ]`   `on_job_status_change` trigger (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 165) — WHEN clause must NOT include `superseded`
-    *   `[ ]`   `on_new_job_created` trigger (defined in `supabase/migrations/20260220213950_conditional_on_new_job_created.sql` line 15) — WHEN clause must NOT include `superseded`
-    *   `[ ]`   `resume_paused_nsf_jobs` RPC (defined in `supabase/migrations/20260302193405_nsf_pause_resume.sql`) — WHERE clause must exclude `superseded` jobs
-    *   `[ ]`   No reverse dependency introduced — this migration only extends existing infrastructure
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   Requires access to `dialectic_generation_jobs` table status values and existing trigger/function definitions
-  *   `[ ]`   interface/`migration SQL`
-    *   `[ ]`   `superseded` added to the terminal status set in `handle_job_completion()` line 204
-    *   `[ ]`   `superseded` added to the terminal status set in `handle_job_completion()` line 209 (re-trigger guard)
-    *   `[ ]`   Sibling terminal count query in `handle_job_completion()` must include `superseded` in its terminal status list
-  *   `[ ]`   `construction`
-    *   `[ ]`   Single migration file with `CREATE OR REPLACE FUNCTION` for `handle_job_completion()` incorporating `superseded`
-    *   `[ ]`   No trigger recreation needed — existing WHEN clauses already exclude unlisted statuses
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: infrastructure (database)
-    *   `[ ]`   Dependencies face inward: modifies only the job state machine
-    *   `[ ]`   Provides face outward: consumed by the worker trigger system and the `regenerateDocument` handler
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `superseded` must be terminal: `handle_job_completion()` must fire for it (to unblock any prerequisite chains if needed) and must not re-trigger on already-terminal rows
-    *   `[ ]`   `superseded` must not invoke the worker: triggers must not include it in their WHEN clauses
-    *   `[ ]`   `superseded` must not be resumed by `resume_paused_nsf_jobs`
-    *   `[ ]`   Existing terminal statuses (`completed`, `failed`, `retry_loop_failed`) must continue to work identically
+*   `[✅]`   [DB] supabase/migrations **`superseded` job status for regenerated document jobs**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Introduce the `superseded` terminal job status so that original jobs replaced by a regeneration clone are marked as replaced rather than remaining `failed`
+    *   `[✅]`   Ensure `superseded` IS treated as a terminal status by `handle_job_completion()` — it should not wake parent jobs or prerequisite chains
+    *   `[✅]`   Ensure `superseded` does NOT appear in worker-invoking trigger WHEN clauses (`on_job_status_change`, `on_new_job_created`) — the worker must never be invoked for superseded jobs
+    *   `[✅]`   Ensure `superseded` is excluded from the NSF pause function `resume_paused_nsf_jobs` — superseded jobs must not be resumed
+  *   `[✅]`   `role`
+    *   `[✅]`   Infrastructure — database schema and trigger layer
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic generation job state machine — extends the terminal status set
+    *   `[✅]`   Boundary: defines the `superseded` status semantics within the existing trigger and completion infrastructure
+  *   `[✅]`   `deps`
+    *   `[✅]`   `handle_job_completion()` function (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 180) — must include `superseded` in the terminal status check at line 204: `IF NEW.status NOT IN ('completed', 'failed', 'retry_loop_failed')` → add `'superseded'`
+    *   `[✅]`   `on_job_status_change` trigger (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 165) — WHEN clause must NOT include `superseded`
+    *   `[✅]`   `on_new_job_created` trigger (defined in `supabase/migrations/20260220213950_conditional_on_new_job_created.sql` line 15) — WHEN clause must NOT include `superseded`
+    *   `[✅]`   `resume_paused_nsf_jobs` RPC (defined in `supabase/migrations/20260302193405_nsf_pause_resume.sql`) — WHERE clause must exclude `superseded` jobs
+    *   `[✅]`   No reverse dependency introduced — this migration only extends existing infrastructure
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   Requires access to `dialectic_generation_jobs` table status values and existing trigger/function definitions
+  *   `[✅]`   interface/`migration SQL`
+    *   `[✅]`   `superseded` added to the terminal status set in `handle_job_completion()` line 204
+    *   `[✅]`   `superseded` added to the terminal status set in `handle_job_completion()` line 209 (re-trigger guard)
+    *   `[✅]`   Sibling terminal count query in `handle_job_completion()` must include `superseded` in its terminal status list
+  *   `[✅]`   `construction`
+    *   `[✅]`   Single migration file with `CREATE OR REPLACE FUNCTION` for `handle_job_completion()` incorporating `superseded`
+    *   `[✅]`   No trigger recreation needed — existing WHEN clauses already exclude unlisted statuses
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: infrastructure (database)
+    *   `[✅]`   Dependencies face inward: modifies only the job state machine
+    *   `[✅]`   Provides face outward: consumed by the worker trigger system and the `regenerateDocument` handler
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `superseded` must be terminal: `handle_job_completion()` must fire for it (to unblock any prerequisite chains if needed) and must not re-trigger on already-terminal rows
+    *   `[✅]`   `superseded` must not invoke the worker: triggers must not include it in their WHEN clauses
+    *   `[✅]`   `superseded` must not be resumed by `resume_paused_nsf_jobs`
+    *   `[✅]`   Existing terminal statuses (`completed`, `failed`, `retry_loop_failed`) must continue to work identically
 
-*   `[ ]`   [BE] dialectic-service/`deriveStepStatuses` **Skip `superseded` jobs in step status derivation**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Ensure `superseded` jobs are completely invisible to progress tracking — they must not contribute to any step status flag (`hasActive`, `hasCompleted`, `hasFailed`, `hasPausedNsf`)
-    *   `[ ]`   The cloned replacement job's status is the only one that matters for the step
-  *   `[ ]`   `role`
-    *   `[ ]`   Backend logic — progress derivation
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic service — step status derivation within `getAllStageProgress`
-    *   `[ ]`   Boundary: receives jobs array → produces step status map; `superseded` jobs must be filtered out before status aggregation
-  *   `[ ]`   `deps`
-    *   `[ ]`   DB migration node (above) — `superseded` status must exist in the database
-    *   `[ ]`   Existing `ACTIVE_STATUSES`, `FAILED_STATUSES`, `PAUSED_NSF_STATUSES` sets in `deriveStepStatuses.ts`
-    *   `[ ]`   No reverse dependency introduced
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `deriveStepStatuses` function at `supabase/functions/dialectic-service/deriveStepStatuses.ts`
-    *   `[ ]`   Job `status` field — must recognize `superseded` as a skip condition
-  *   `[ ]`   interface/`dialectic.interface.ts`
-    *   `[ ]`   No interface changes required — `UnifiedStageStatus` does not need a `superseded` value because superseded jobs produce no status; they are skipped
-  *   `[ ]`   unit/`deriveStepStatuses.test.ts`
-    *   `[ ]`   Test: a step with one `superseded` job and one `completed` job → step status is `completed` (superseded job is invisible)
-    *   `[ ]`   Test: a step with one `superseded` job and one `pending` job → step status is `in_progress` (active clone is visible)
-    *   `[ ]`   Test: a step with only `superseded` jobs and no other jobs → step status is `not_started` (all evidence invisible)
-    *   `[ ]`   Test: a step with one `superseded` job, one `failed` job, and one `completed` job → step status is `failed` (the non-superseded failed job still counts)
-  *   `[ ]`   `construction`
-    *   `[ ]`   Add `const SUPERSEDED_STATUSES: Set<string> = new Set(["superseded"]);` alongside existing status sets
-    *   `[ ]`   Add skip condition at line 57 (after RENDER skip, after continuation skip): `if (SUPERSEDED_STATUSES.has(job.status)) continue;`
-  *   `[ ]`   `deriveStepStatuses.ts`
-    *   `[ ]`   Add `SUPERSEDED_STATUSES` constant
-    *   `[ ]`   Add `continue` guard for superseded jobs in the job iteration loop
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: backend logic (service)
-    *   `[ ]`   Dependencies face inward: reads job status values defined by DB migration
-    *   `[ ]`   Provides face outward: consumed by `getAllStageProgress` → frontend progress hydration
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `superseded` jobs must not set any status flag (`hasActive`, `hasCompleted`, `hasFailed`, `hasPausedNsf`)
-    *   `[ ]`   All existing status derivation behavior must be preserved for non-superseded jobs
-    *   `[ ]`   A step with only superseded jobs and no successors must show `not_started`
+*   `[✅]`   [BE] dialectic-service/`deriveStepStatuses` **Skip `superseded` jobs in step status derivation**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Ensure `superseded` jobs are completely invisible to progress tracking — they must not contribute to any step status flag (`hasActive`, `hasCompleted`, `hasFailed`, `hasPausedNsf`)
+    *   `[✅]`   The cloned replacement job's status is the only one that matters for the step
+  *   `[✅]`   `role`
+    *   `[✅]`   Backend logic — progress derivation
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic service — step status derivation within `getAllStageProgress`
+    *   `[✅]`   Boundary: receives jobs array → produces step status map; `superseded` jobs must be filtered out before status aggregation
+  *   `[✅]`   `deps`
+    *   `[✅]`   DB migration node (above) — `superseded` status must exist in the database
+    *   `[✅]`   Existing `ACTIVE_STATUSES`, `FAILED_STATUSES`, `PAUSED_NSF_STATUSES` sets in `deriveStepStatuses.ts`
+    *   `[✅]`   No reverse dependency introduced
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `deriveStepStatuses` function at `supabase/functions/dialectic-service/deriveStepStatuses.ts`
+    *   `[✅]`   Job `status` field — must recognize `superseded` as a skip condition
+  *   `[✅]`   interface/`dialectic.interface.ts`
+    *   `[✅]`   No interface changes required — `UnifiedStageStatus` does not need a `superseded` value because superseded jobs produce no status; they are skipped
+  *   `[✅]`   unit/`deriveStepStatuses.test.ts`
+    *   `[✅]`   Test: a step with one `superseded` job and one `completed` job → step status is `completed` (superseded job is invisible)
+    *   `[✅]`   Test: a step with one `superseded` job and one `pending` job → step status is `in_progress` (active clone is visible)
+    *   `[✅]`   Test: a step with only `superseded` jobs and no other jobs → step status is `not_started` (all evidence invisible)
+    *   `[✅]`   Test: a step with one `superseded` job, one `failed` job, and one `completed` job → step status is `failed` (the non-superseded failed job still counts)
+  *   `[✅]`   `construction`
+    *   `[✅]`   Add `const SUPERSEDED_STATUSES: Set<string> = new Set(["superseded"]);` alongside existing status sets
+    *   `[✅]`   Add skip condition at line 57 (after RENDER skip, after continuation skip): `if (SUPERSEDED_STATUSES.has(job.status)) continue;`
+  *   `[✅]`   `deriveStepStatuses.ts`
+    *   `[✅]`   Add `SUPERSEDED_STATUSES` constant
+    *   `[✅]`   Add `continue` guard for superseded jobs in the job iteration loop
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: backend logic (service)
+    *   `[✅]`   Dependencies face inward: reads job status values defined by DB migration
+    *   `[✅]`   Provides face outward: consumed by `getAllStageProgress` → frontend progress hydration
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `superseded` jobs must not set any status flag (`hasActive`, `hasCompleted`, `hasFailed`, `hasPausedNsf`)
+    *   `[✅]`   All existing status derivation behavior must be preserved for non-superseded jobs
+    *   `[✅]`   A step with only superseded jobs and no successors must show `not_started`
 
-*   `[ ]`   [BE] dialectic-service/`regenerateDocument` **Clone failed/completed EXECUTE jobs as new `pending` jobs for targeted document regeneration**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Accept a request specifying session, stage, iteration, and a list of `{ jobId, modelId }` pairs identifying which EXECUTE jobs to regenerate
-    *   `[ ]`   Validate that the stage matches the session's current stage (active-stage-only gate)
-    *   `[ ]`   Validate that each referenced job belongs to the correct session/stage/iteration and is an EXECUTE job
-    *   `[ ]`   Mark each original job as `superseded`
-    *   `[ ]`   Clone each original job's row: copy `payload`, `stage_slug`, `iteration_number`, `session_id`, `user_id`, `max_retries`, `job_type`; set `status: 'pending'`, `attempt_count: 0`, `parent_job_id: null`, `prerequisite_job_id: null`, `started_at: null`, `completed_at: null`, `results: null`, `error_details: null`, `target_contribution_id: null`
-    *   `[ ]`   Insert the cloned row — the existing `on_new_job_created` trigger fires and the worker picks it up
-    *   `[ ]`   Return the array of new job IDs
-  *   `[ ]`   `role`
-    *   `[ ]`   Backend logic — edge function handler for document regeneration
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic service — new handler function within the `dialectic-service` edge function
-    *   `[ ]`   Boundary: receives validated request → marks originals superseded → inserts cloned jobs → returns new job IDs
-  *   `[ ]`   `deps`
-    *   `[ ]`   DB migration node — `superseded` status must exist
-    *   `[ ]`   `dialectic_generation_jobs` table — read original job, update to `superseded`, insert clone
-    *   `[ ]`   `dialectic_sessions` table — validate `current_stage_id` matches requested `stageSlug`
-    *   `[ ]`   `dialectic_stages` table — resolve `current_stage_id` to slug
-    *   `[ ]`   Supabase admin client — for DB operations
-    *   `[ ]`   Authenticated user — for authorization (job's `user_id` must match requesting user)
-    *   `[ ]`   No reverse dependency introduced
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `dbClient: SupabaseClient` — admin client for DB reads/writes
-    *   `[ ]`   `user: User` — authenticated user from request
-    *   `[ ]`   `payload: RegenerateDocumentPayload` — `{ sessionId, stageSlug, iterationNumber, jobs: Array<{ jobId: string; modelId: string }> }`
-  *   `[ ]`   interface/`dialectic.interface.ts`
-    *   `[ ]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; jobs: Array<{ jobId: string; modelId: string }> }`
-    *   `[ ]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
-    *   `[ ]`   `RegenerateDocumentAction`: `{ action: 'regenerateDocument'; payload: RegenerateDocumentPayload }`
-    *   `[ ]`   Add `RegenerateDocumentAction` to the `DialecticServiceRequest` union
-    *   `[ ]`   Add `regenerateDocument` to `ActionHandlers` interface
-  *   `[ ]`   interface/tests/`regenerateDocument.interface.test.ts`
-    *   `[ ]`   Test: `RegenerateDocumentPayload` requires `sessionId`, `stageSlug`, `iterationNumber`, and `jobs` array
-    *   `[ ]`   Test: `RegenerateDocumentResponse` has `jobIds` string array
-  *   `[ ]`   interface/guards/`regenerateDocument.interface.guards.ts`
-    *   `[ ]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — validates all required fields and jobs array structure
-  *   `[ ]`   unit/`regenerateDocument.test.ts`
-    *   `[ ]`   Test: valid request with one job → original marked `superseded`, clone inserted as `pending` with correct payload copy, returns new job ID
-    *   `[ ]`   Test: valid request with multiple jobs → all originals marked `superseded`, all clones inserted, returns array of new job IDs
-    *   `[ ]`   Test: stage mismatch (requested stage ≠ session's current stage) → returns 400 error, no jobs modified
-    *   `[ ]`   Test: job not found → returns 404 error
-    *   `[ ]`   Test: job belongs to different session → returns 403 error
-    *   `[ ]`   Test: job is not an EXECUTE job → returns 400 error
-    *   `[ ]`   Test: user does not own the job → returns 403 error
-    *   `[ ]`   Test: cloned job has `parent_job_id: null`, `prerequisite_job_id: null`, `attempt_count: 0`, `status: 'pending'`
-    *   `[ ]`   Test: cloned job preserves original's `payload`, `stage_slug`, `iteration_number`, `session_id`, `job_type`, `max_retries`
-  *   `[ ]`   `construction`
-    *   `[ ]`   Single exported async function `regenerateDocument(dbClient, payload, user)`
-    *   `[ ]`   Returns `{ success: boolean; data?: RegenerateDocumentResponse; error?: { message: string; status?: number } }`
-    *   `[ ]`   No DI beyond `dbClient` and `user` — this is a thin data-copy operation
-  *   `[ ]`   `regenerateDocument.ts`
-    *   `[ ]`   Validate payload fields
-    *   `[ ]`   Fetch session and verify `current_stage.slug === payload.stageSlug`
-    *   `[ ]`   For each job in `payload.jobs`:
-      *   `[ ]`   Fetch original job by ID
-      *   `[ ]`   Validate ownership (`user_id === user.id`), session match, stage match, iteration match, `job_type === 'EXECUTE'`
-      *   `[ ]`   Update original job: `SET status = 'superseded'`
-      *   `[ ]`   Insert clone row with fields copied from original, reset fields as specified in objective
-    *   `[ ]`   Return `{ success: true, data: { jobIds } }`
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: backend logic (service handler)
-    *   `[ ]`   Dependencies face inward: reads/writes `dialectic_generation_jobs`, reads `dialectic_sessions` and `dialectic_stages`
-    *   `[ ]`   Provides face outward: consumed by `dialectic-service/index.ts` router
-  *   `[ ]`   `requirements`
-    *   `[ ]`   Original job must be marked `superseded` BEFORE clone is inserted to prevent race conditions with progress tracking
-    *   `[ ]`   Clone must have `parent_job_id: null` to prevent interference with original PLAN completion tracking
-    *   `[ ]`   Clone must have `prerequisite_job_id: null` — the document's prerequisites are already met (they were met when the original ran)
-    *   `[ ]`   Active-stage-only gate: reject requests where `stageSlug` does not match `session.current_stage.slug`
-    *   `[ ]`   The clone's `payload` must be an exact copy of the original's `payload` — the worker uses payload fields to determine what to generate and where to store results
+*   `[✅]`   [BE] dialectic-service/`regenerateDocument` **Clone failed/completed EXECUTE jobs as new `pending` jobs for targeted document regeneration**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Accept a request specifying session, stage, iteration, and a list of `{ jobId, modelId }` pairs identifying which EXECUTE jobs to regenerate
+    *   `[✅]`   Validate that the stage matches the session's current stage (active-stage-only gate)
+    *   `[✅]`   Validate that each referenced job belongs to the correct session/stage/iteration and is an EXECUTE job
+    *   `[✅]`   Mark each original job as `superseded`
+    *   `[✅]`   Clone each original job's row: copy `payload`, `stage_slug`, `iteration_number`, `session_id`, `user_id`, `max_retries`, `job_type`; set `status: 'pending'`, `attempt_count: 0`, `parent_job_id: null`, `prerequisite_job_id: null`, `started_at: null`, `completed_at: null`, `results: null`, `error_details: null`, `target_contribution_id: null`
+    *   `[✅]`   Insert the cloned row — the existing `on_new_job_created` trigger fires and the worker picks it up
+    *   `[✅]`   Return the array of new job IDs
+  *   `[✅]`   `role`
+    *   `[✅]`   Backend logic — edge function handler for document regeneration
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic service — new handler function within the `dialectic-service` edge function
+    *   `[✅]`   Boundary: receives validated request → marks originals superseded → inserts cloned jobs → returns new job IDs
+  *   `[✅]`   `deps`
+    *   `[✅]`   DB migration node — `superseded` status must exist
+    *   `[✅]`   `dialectic_generation_jobs` table — read original job, update to `superseded`, insert clone
+    *   `[✅]`   `dialectic_sessions` table — validate `current_stage_id` matches requested `stageSlug`
+    *   `[✅]`   `dialectic_stages` table — resolve `current_stage_id` to slug
+    *   `[✅]`   Supabase admin client — for DB operations
+    *   `[✅]`   Authenticated user — for authorization (job's `user_id` must match requesting user)
+    *   `[✅]`   No reverse dependency introduced
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `dbClient: SupabaseClient` — admin client for DB reads/writes
+    *   `[✅]`   `user: User` — authenticated user from request
+    *   `[✅]`   `payload: RegenerateDocumentPayload` — `{ sessionId, stageSlug, iterationNumber, jobs: Array<{ jobId: string; modelId: string }> }`
+  *   `[✅]`   interface/`dialectic.interface.ts`
+    *   `[✅]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; jobs: Array<{ jobId: string; modelId: string }> }`
+    *   `[✅]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
+    *   `[✅]`   `RegenerateDocumentAction`: `{ action: 'regenerateDocument'; payload: RegenerateDocumentPayload }`
+    *   `[✅]`   Add `RegenerateDocumentAction` to the `DialecticServiceRequest` union
+    *   `[✅]`   Add `regenerateDocument` to `ActionHandlers` interface
+  *   `[✅]`   interface/tests/`regenerateDocument.interface.test.ts`
+    *   `[✅]`   Test: `RegenerateDocumentPayload` requires `sessionId`, `stageSlug`, `iterationNumber`, and `jobs` array
+    *   `[✅]`   Test: `RegenerateDocumentResponse` has `jobIds` string array
+  *   `[✅]`   interface/guards/`regenerateDocument.interface.guards.ts`
+    *   `[✅]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — validates all required fields and jobs array structure
+  *   `[✅]`   unit/`regenerateDocument.test.ts`
+    *   `[✅]`   Test: valid request with one job → original marked `superseded`, clone inserted as `pending` with correct payload copy, returns new job ID
+    *   `[✅]`   Test: valid request with multiple jobs → all originals marked `superseded`, all clones inserted, returns array of new job IDs
+    *   `[✅]`   Test: stage mismatch (requested stage ≠ session's current stage) → returns 400 error, no jobs modified
+    *   `[✅]`   Test: job not found → returns 404 error
+    *   `[✅]`   Test: job belongs to different session → returns 403 error
+    *   `[✅]`   Test: job is not an EXECUTE job → returns 400 error
+    *   `[✅]`   Test: user does not own the job → returns 403 error
+    *   `[✅]`   Test: cloned job has `parent_job_id: null`, `prerequisite_job_id: null`, `attempt_count: 0`, `status: 'pending'`
+    *   `[✅]`   Test: cloned job preserves original's `payload`, `stage_slug`, `iteration_number`, `session_id`, `job_type`, `max_retries`
+  *   `[✅]`   `construction`
+    *   `[✅]`   Single exported async function `regenerateDocument(dbClient, payload, user)`
+    *   `[✅]`   Returns `{ success: boolean; data?: RegenerateDocumentResponse; error?: { message: string; status?: number } }`
+    *   `[✅]`   No DI beyond `dbClient` and `user` — this is a thin data-copy operation
+  *   `[✅]`   `regenerateDocument.ts`
+    *   `[✅]`   Validate payload fields
+    *   `[✅]`   Fetch session and verify `current_stage.slug === payload.stageSlug`
+    *   `[✅]`   For each job in `payload.jobs`:
+      *   `[✅]`   Fetch original job by ID
+      *   `[✅]`   Validate ownership (`user_id === user.id`), session match, stage match, iteration match, `job_type === 'EXECUTE'`
+      *   `[✅]`   Update original job: `SET status = 'superseded'`
+      *   `[✅]`   Insert clone row with fields copied from original, reset fields as specified in objective
+    *   `[✅]`   Return `{ success: true, data: { jobIds } }`
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: backend logic (service handler)
+    *   `[✅]`   Dependencies face inward: reads/writes `dialectic_generation_jobs`, reads `dialectic_sessions` and `dialectic_stages`
+    *   `[✅]`   Provides face outward: consumed by `dialectic-service/index.ts` router
+  *   `[✅]`   `requirements`
+    *   `[✅]`   Original job must be marked `superseded` BEFORE clone is inserted to prevent race conditions with progress tracking
+    *   `[✅]`   Clone must have `parent_job_id: null` to prevent interference with original PLAN completion tracking
+    *   `[✅]`   Clone must have `prerequisite_job_id: null` — the document's prerequisites are already met (they were met when the original ran)
+    *   `[✅]`   Active-stage-only gate: reject requests where `stageSlug` does not match `session.current_stage.slug`
+    *   `[✅]`   The clone's `payload` must be an exact copy of the original's `payload` — the worker uses payload fields to determine what to generate and where to store results
 
-*   `[ ]`   [BE] dialectic-service/`index` **Route `regenerateDocument` action to handler**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add `regenerateDocument` as a routable action in the dialectic-service edge function entry point
-    *   `[ ]`   Wire the action to the `regenerateDocument` handler with authentication required
-  *   `[ ]`   `role`
-    *   `[ ]`   Infrastructure — edge function router
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic service entry point — action dispatch
-    *   `[ ]`   Boundary: receives HTTP request → authenticates → routes to handler → returns response
-  *   `[ ]`   `deps`
-    *   `[ ]`   `regenerateDocument` handler (node above) — must exist as an importable function
-    *   `[ ]`   `RegenerateDocumentPayload` type from `dialectic.interface.ts`
-    *   `[ ]`   Existing `ActionHandlers` interface — must include `regenerateDocument` (added in the handler node's interface section)
-    *   `[ ]`   Existing `actionsRequiringAuth` array — must include `'regenerateDocument'`
-    *   `[ ]`   Existing `DialecticServiceRequest` union — must include `RegenerateDocumentAction` (added in the handler node's interface section)
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `handlers.regenerateDocument` — the handler function
-    *   `[ ]`   `adminClient` — passed to handler as `dbClient`
-    *   `[ ]`   `userForJson` — authenticated user
-    *   `[ ]`   `requestBody.payload` — typed as `RegenerateDocumentPayload`
-  *   `[ ]`   unit/`index.test.ts`
-    *   `[ ]`   Test: `regenerateDocument` action routes to handler with correct arguments
-    *   `[ ]`   Test: `regenerateDocument` action without authentication returns 401
-    *   `[ ]`   Test: handler success → returns 200 with `{ jobIds }` response
-    *   `[ ]`   Test: handler error → returns error status with error message
-  *   `[ ]`   `construction`
-    *   `[ ]`   Import `regenerateDocument` from `./regenerateDocument.ts`
-    *   `[ ]`   Add `'regenerateDocument'` to `actionsRequiringAuth` array
-    *   `[ ]`   Add `case "regenerateDocument"` to the action switch with standard auth guard pattern
-    *   `[ ]`   Wire `regenerateDocument` into `defaultHandlers` object
-  *   `[ ]`   `index.ts`
-    *   `[ ]`   Add import for `regenerateDocument` handler
-    *   `[ ]`   Add `'regenerateDocument'` to `actionsRequiringAuth` array (line 269)
-    *   `[ ]`   Add case block in switch statement (before `default:` case, after `resumePausedNsfJobs` case at line 602)
-    *   `[ ]`   Add `regenerateDocument` to `defaultHandlers` object
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: infrastructure (edge function entry point)
-    *   `[ ]`   Dependencies face inward: imports handler function, uses types from interface
-    *   `[ ]`   Provides face outward: HTTP endpoint consumed by API client
-  *   `[ ]`   `requirements`
-    *   `[ ]`   Authentication is required — unauthenticated requests return 401
-    *   `[ ]`   Handler receives `adminClient` (not `userClient`) as `dbClient` — consistent with other handlers like `resumePausedNsfJobs`
-    *   `[ ]`   Follows exact same routing pattern as `resumePausedNsfJobs` case block
+*   `[✅]`   [BE] dialectic-service/`index` **Route `regenerateDocument` action to handler**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add `regenerateDocument` as a routable action in the dialectic-service edge function entry point
+    *   `[✅]`   Wire the action to the `regenerateDocument` handler with authentication required
+  *   `[✅]`   `role`
+    *   `[✅]`   Infrastructure — edge function router
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic service entry point — action dispatch
+    *   `[✅]`   Boundary: receives HTTP request → authenticates → routes to handler → returns response
+  *   `[✅]`   `deps`
+    *   `[✅]`   `regenerateDocument` handler (node above) — must exist as an importable function
+    *   `[✅]`   `RegenerateDocumentPayload` type from `dialectic.interface.ts`
+    *   `[✅]`   Existing `ActionHandlers` interface — must include `regenerateDocument` (added in the handler node's interface section)
+    *   `[✅]`   Existing `actionsRequiringAuth` array — must include `'regenerateDocument'`
+    *   `[✅]`   Existing `DialecticServiceRequest` union — must include `RegenerateDocumentAction` (added in the handler node's interface section)
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `handlers.regenerateDocument` — the handler function
+    *   `[✅]`   `adminClient` — passed to handler as `dbClient`
+    *   `[✅]`   `userForJson` — authenticated user
+    *   `[✅]`   `requestBody.payload` — typed as `RegenerateDocumentPayload`
+  *   `[✅]`   unit/`index.test.ts`
+    *   `[✅]`   Test: `regenerateDocument` action routes to handler with correct arguments
+    *   `[✅]`   Test: `regenerateDocument` action without authentication returns 401
+    *   `[✅]`   Test: handler success → returns 200 with `{ jobIds }` response
+    *   `[✅]`   Test: handler error → returns error status with error message
+  *   `[✅]`   `construction`
+    *   `[✅]`   Import `regenerateDocument` from `./regenerateDocument.ts`
+    *   `[✅]`   Add `'regenerateDocument'` to `actionsRequiringAuth` array
+    *   `[✅]`   Add `case "regenerateDocument"` to the action switch with standard auth guard pattern
+    *   `[✅]`   Wire `regenerateDocument` into `defaultHandlers` object
+  *   `[✅]`   `index.ts`
+    *   `[✅]`   Add import for `regenerateDocument` handler
+    *   `[✅]`   Add `'regenerateDocument'` to `actionsRequiringAuth` array (line 269)
+    *   `[✅]`   Add case block in switch statement (before `default:` case, after `resumePausedNsfJobs` case at line 602)
+    *   `[✅]`   Add `regenerateDocument` to `defaultHandlers` object
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: infrastructure (edge function entry point)
+    *   `[✅]`   Dependencies face inward: imports handler function, uses types from interface
+    *   `[✅]`   Provides face outward: HTTP endpoint consumed by API client
+  *   `[✅]`   `requirements`
+    *   `[✅]`   Authentication is required — unauthenticated requests return 401
+    *   `[✅]`   Handler receives `adminClient` (not `userClient`) as `dbClient` — consistent with other handlers like `resumePausedNsfJobs`
+    *   `[✅]`   Follows exact same routing pattern as `resumePausedNsfJobs` case block
 
 *   `[ ]`   [API] packages/api/`dialectic.api` **`regenerateDocument` API client method**
   *   `[ ]`   `objective`

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -1028,86 +1028,86 @@ A user clicks a regenerate button on any document in the stage run checklist, se
     *   `[✅]`   Job IDs must be tracked in `generatingSessions` so lifecycle events from the worker are correctly processed by existing `_handleDialecticLifecycleEvent` handlers
     *   `[✅]`   `generatingForStageSlug` must be set so the StageRunChecklist shows generating spinners for affected documents
 
-*   `[ ]`   [UI] apps/web/`StageRunChecklist` **Per-document regenerate button with model selection dialog**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Replace the static status circle indicators with clickable icon-buttons that trigger document regeneration
-    *   `[ ]`   Color the icon-button based on document status: green for completed, red for failed, amber for not started — preserving the existing visual language
-    *   `[ ]`   Keep the `Loader2` spinner for `generating`/`continuing` states as non-clickable (cannot regenerate mid-generation)
-    *   `[ ]`   On click, show a model-selection confirmation dialog listing all models for that document with checkboxes
-    *   `[ ]`   Pre-check models whose status is `Failed` or `Not started`; leave `Completed` models unchecked (user must actively opt in to re-roll a successful document)
-    *   `[ ]`   Disable the regenerate button when the document's stage is not the session's current stage
-    *   `[ ]`   On confirmation, call the `regenerateDocument` store action with the selected `{ documentKey, modelId }` pairs
-  *   `[ ]`   `role`
-    *   `[ ]`   UI / presentation — user-facing regeneration trigger
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic UI — StageRunChecklist component within the stage sidebar
-    *   `[ ]`   Boundary: reads document status from store selectors → presents regeneration UI → dispatches store action
-  *   `[ ]`   `deps`
-    *   `[ ]`   Store node (above) — `regenerateDocument` action must exist on the store
-    *   `[ ]`   `RegenerateDocumentPayload` type from `@paynless/types`
-    *   `[ ]`   Existing `perModelLabels` computed in `computeStageRunChecklistData` — provides `modelId`, `displayName`, `statusLabel` per model per document
-    *   `[ ]`   Existing `StageDocumentRow` type — provides `entry` (with `documentKey`, `status`, `jobId`, `stepKey`) and `perModelLabels`
-    *   `[ ]`   Existing store selectors: `selectActiveContextSessionId`, `selectActiveStageSlug`
-    *   `[ ]`   Session's `current_stage_id` — to determine if the document's stage is the active stage (for the gate)
-    *   `[ ]`   `useDialecticStore` — for accessing store state and actions
-    *   `[ ]`   No reverse dependency introduced — leaf component
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `regenerateDocument: state.regenerateDocument` — store action
-    *   `[ ]`   `activeSessionDetail` — for `current_stage_id` and `iteration_count`
-    *   `[ ]`   `activeStageSlug` — to determine if the current stage matches the session's current stage
-    *   `[ ]`   `perModelLabels` — already computed per document row, provides model status for pre-checking
-    *   `[ ]`   `entry.documentKey` — the document identity per model (the backend resolves the EXECUTE job ID server-side)
-  *   `[ ]`   interface/`StageRunChecklist types`
-    *   `[ ]`   `RegenerateDocumentDialogProps`: `{ open: boolean; documentKey: string; stageSlug: string; perModelLabels: PerModelLabel[]; onConfirm: (selectedDocuments: Array<{ documentKey: string; modelId: string }>) => void; onCancel: () => void }`
-  *   `[ ]`   unit/`StageRunChecklist.test.tsx`
-    *   `[ ]`   Test: completed document renders green clickable icon-button (not static circle)
-    *   `[ ]`   Test: failed document renders red clickable icon-button
-    *   `[ ]`   Test: not-started document renders amber clickable icon-button
-    *   `[ ]`   Test: generating document renders non-clickable spinner (existing behavior preserved)
-    *   `[ ]`   Test: clicking icon-button opens model selection dialog with correct model list
-    *   `[ ]`   Test: dialog pre-checks failed models, leaves completed models unchecked
-    *   `[ ]`   Test: confirming dialog with selected models calls `regenerateDocument` with correct payload
-    *   `[ ]`   Test: icon-button is disabled when document's stage ≠ session's current stage
-    *   `[ ]`   Test: canceling dialog does not call `regenerateDocument`
-  *   `[ ]`   `construction`
-    *   `[ ]`   `RegenerateDocumentDialog` — small inline component or extracted component for the model selection confirmation
-    *   `[ ]`   Replace `<span>` circle elements with `<button>` icon-buttons retaining the same color classes
-    *   `[ ]`   Add state for dialog open/close and selected document context
-    *   `[ ]`   Wire dialog confirm to `regenerateDocument` store action
-  *   `[ ]`   `StageRunChecklist.tsx`
-    *   `[ ]`   Add `regenerateDocument` from store to component's store subscription
-    *   `[ ]`   Add `activeSessionDetail` to determine current stage for the gate
-    *   `[ ]`   Add state: `regenerateDialogOpen`, `regenerateDialogContext` (documentKey, stageSlug, perModelLabels)
-    *   `[ ]`   Replace static `<span>` circles (lines 538-554) with `<button>` elements that open the dialog on click
-    *   `[ ]`   Preserve `Loader2` spinner for generating/continuing states as non-clickable
-    *   `[ ]`   Implement `RegenerateDocumentDialog` with checkboxes per model, pre-fill logic, confirm/cancel
-    *   `[ ]`   On confirm: map selected `perModelLabels` entries to `{ documentKey, modelId }` pairs for the payload
-    *   `[ ]`   On confirm: construct `RegenerateDocumentPayload` and call `regenerateDocument`
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: UI / presentation
-    *   `[ ]`   Dependencies face inward: consumes store (selectors, actions) and types
-    *   `[ ]`   No outward-facing provides — this is a leaf component
-  *   `[ ]`   `requirements`
-    *   `[ ]`   Visual language must be preserved: green = completed, red = failed, amber = not started, blue spinner = generating
-    *   `[ ]`   The regenerate button must be visually distinguishable as clickable (not just a colored dot) — an icon-button with the status color
-    *   `[ ]`   The model selection dialog must pre-check only failed/not-started models — completed models require active user opt-in
-    *   `[ ]`   Active-stage-only gate: the button is disabled (or hidden) for documents on stages that are not the session's current stage
-    *   `[ ]`   The dialog must show model display names (not IDs) — these are already available in `perModelLabels.displayName`
-    *   `[ ]`   If only one model is selected for the session, skip the dialog and regenerate directly (single-model fast path)
-    *   `[ ]`   The user must be able to cancel without side effects
-  *   `[ ]`   **Commit** `feat(be,api,store,ui) Regenerate individual documents — superseded job status, EXECUTE job cloning, API client, store action, and per-document regenerate button with model selection`
-    *   `[ ]`   New migration: `superseded` terminal job status in `handle_job_completion()`
-    *   `[ ]`   Updated: `deriveStepStatuses.ts` — skip `superseded` jobs in status derivation
-    *   `[ ]`   New handler: `regenerateDocument.ts` in `dialectic-service` — clone EXECUTE jobs, mark originals superseded
-    *   `[ ]`   Updated: `dialectic-service/index.ts` — route `regenerateDocument` action
-    *   `[ ]`   Updated: `dialectic.interface.ts` — `RegenerateDocumentPayload`, `RegenerateDocumentResponse`, `RegenerateDocumentAction`, `ActionHandlers`
-    *   `[ ]`   New API method: `regenerateDocument()` in `packages/api/src/dialectic.api.ts`
-    *   `[ ]`   Updated: `dialectic.api.mock.ts` — mock for `regenerateDocument`
-    *   `[ ]`   New frontend types: `RegenerateDocumentPayload`, `RegenerateDocumentResponse` in `packages/types/src/dialectic.types.ts`
-    *   `[ ]`   Updated: `DialecticActions` in `packages/types/src/dialectic.types.ts` — `regenerateDocument` action signature
-    *   `[ ]`   New store action: `regenerateDocument` in `packages/store/src/dialecticStore.ts`
-    *   `[ ]`   Updated: `StageRunChecklist.tsx` — per-document regenerate icon-buttons, model selection dialog, active-stage gate
-    *   `[ ]`   New tests: migration validation, `deriveStepStatuses` superseded tests, `regenerateDocument` handler unit tests, API client tests, store action tests, StageRunChecklist UI tests
+*   `[✅]`   [UI] apps/web/`StageRunChecklist` **Per-document regenerate button with model selection dialog**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Replace the static status circle indicators with clickable icon-buttons that trigger document regeneration
+    *   `[✅]`   Color the icon-button based on document status: green for completed, red for failed, amber for not started — preserving the existing visual language
+    *   `[✅]`   Keep the `Loader2` spinner for `generating`/`continuing` states as non-clickable (cannot regenerate mid-generation)
+    *   `[✅]`   On click, show a model-selection confirmation dialog listing all models for that document with checkboxes
+    *   `[✅]`   Pre-check models whose status is `Failed` or `Not started`; leave `Completed` models unchecked (user must actively opt in to re-roll a successful document)
+    *   `[✅]`   Disable the regenerate button when the document's stage is not the session's current stage
+    *   `[✅]`   On confirmation, call the `regenerateDocument` store action with the selected `{ documentKey, modelId }` pairs
+  *   `[✅]`   `role`
+    *   `[✅]`   UI / presentation — user-facing regeneration trigger
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic UI — StageRunChecklist component within the stage sidebar
+    *   `[✅]`   Boundary: reads document status from store selectors → presents regeneration UI → dispatches store action
+  *   `[✅]`   `deps`
+    *   `[✅]`   Store node (above) — `regenerateDocument` action must exist on the store
+    *   `[✅]`   `RegenerateDocumentPayload` type from `@paynless/types`
+    *   `[✅]`   Existing `perModelLabels` computed in `computeStageRunChecklistData` — provides `modelId`, `displayName`, `statusLabel` per model per document
+    *   `[✅]`   Existing `StageDocumentRow` type — provides `entry` (with `documentKey`, `status`, `jobId`, `stepKey`) and `perModelLabels`
+    *   `[✅]`   Existing store selectors: `selectActiveContextSessionId`, `selectActiveStageSlug`
+    *   `[✅]`   Session's `current_stage_id` — to determine if the document's stage is the active stage (for the gate)
+    *   `[✅]`   `useDialecticStore` — for accessing store state and actions
+    *   `[✅]`   No reverse dependency introduced — leaf component
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `regenerateDocument: state.regenerateDocument` — store action
+    *   `[✅]`   `activeSessionDetail` — for `current_stage_id` and `iteration_count`
+    *   `[✅]`   `activeStageSlug` — to determine if the current stage matches the session's current stage
+    *   `[✅]`   `perModelLabels` — already computed per document row, provides model status for pre-checking
+    *   `[✅]`   `entry.documentKey` — the document identity per model (the backend resolves the EXECUTE job ID server-side)
+  *   `[✅]`   interface/`StageRunChecklist types`
+    *   `[✅]`   `RegenerateDocumentDialogProps`: `{ open: boolean; documentKey: string; stageSlug: string; perModelLabels: PerModelLabel[]; onConfirm: (selectedDocuments: Array<{ documentKey: string; modelId: string }>) => void; onCancel: () => void }`
+  *   `[✅]`   unit/`StageRunChecklist.test.tsx`
+    *   `[✅]`   Test: completed document renders green clickable icon-button (not static circle)
+    *   `[✅]`   Test: failed document renders red clickable icon-button
+    *   `[✅]`   Test: not-started document renders amber clickable icon-button
+    *   `[✅]`   Test: generating document renders non-clickable spinner (existing behavior preserved)
+    *   `[✅]`   Test: clicking icon-button opens model selection dialog with correct model list
+    *   `[✅]`   Test: dialog pre-checks failed models, leaves completed models unchecked
+    *   `[✅]`   Test: confirming dialog with selected models calls `regenerateDocument` with correct payload
+    *   `[✅]`   Test: icon-button is disabled when document's stage ≠ session's current stage
+    *   `[✅]`   Test: canceling dialog does not call `regenerateDocument`
+  *   `[✅]`   `construction`
+    *   `[✅]`   `RegenerateDocumentDialog` — small inline component or extracted component for the model selection confirmation
+    *   `[✅]`   Replace `<span>` circle elements with `<button>` icon-buttons retaining the same color classes
+    *   `[✅]`   Add state for dialog open/close and selected document context
+    *   `[✅]`   Wire dialog confirm to `regenerateDocument` store action
+  *   `[✅]`   `StageRunChecklist.tsx`
+    *   `[✅]`   Add `regenerateDocument` from store to component's store subscription
+    *   `[✅]`   Add `activeSessionDetail` to determine current stage for the gate
+    *   `[✅]`   Add state: `regenerateDialogOpen`, `regenerateDialogContext` (documentKey, stageSlug, perModelLabels)
+    *   `[✅]`   Replace static `<span>` circles (lines 538-554) with `<button>` elements that open the dialog on click
+    *   `[✅]`   Preserve `Loader2` spinner for generating/continuing states as non-clickable
+    *   `[✅]`   Implement `RegenerateDocumentDialog` with checkboxes per model, pre-fill logic, confirm/cancel
+    *   `[✅]`   On confirm: map selected `perModelLabels` entries to `{ documentKey, modelId }` pairs for the payload
+    *   `[✅]`   On confirm: construct `RegenerateDocumentPayload` and call `regenerateDocument`
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: UI / presentation
+    *   `[✅]`   Dependencies face inward: consumes store (selectors, actions) and types
+    *   `[✅]`   No outward-facing provides — this is a leaf component
+  *   `[✅]`   `requirements`
+    *   `[✅]`   Visual language must be preserved: green = completed, red = failed, amber = not started, blue spinner = generating
+    *   `[✅]`   The regenerate button must be visually distinguishable as clickable (not just a colored dot) — an icon-button with the status color
+    *   `[✅]`   The model selection dialog must pre-check only failed/not-started models — completed models require active user opt-in
+    *   `[✅]`   Active-stage-only gate: the button is disabled (or hidden) for documents on stages that are not the session's current stage
+    *   `[✅]`   The dialog must show model display names (not IDs) — these are already available in `perModelLabels.displayName`
+    *   `[✅]`   If only one model is selected for the session, skip the dialog and regenerate directly (single-model fast path)
+    *   `[✅]`   The user must be able to cancel without side effects
+  *   `[✅]`   **Commit** `feat(be,api,store,ui) Regenerate individual documents — superseded job status, EXECUTE job cloning, API client, store action, and per-document regenerate button with model selection`
+    *   `[✅]`   New migration: `superseded` terminal job status in `handle_job_completion()`
+    *   `[✅]`   Updated: `deriveStepStatuses.ts` — skip `superseded` jobs in status derivation
+    *   `[✅]`   New handler: `regenerateDocument.ts` in `dialectic-service` — clone EXECUTE jobs, mark originals superseded
+    *   `[✅]`   Updated: `dialectic-service/index.ts` — route `regenerateDocument` action
+    *   `[✅]`   Updated: `dialectic.interface.ts` — `RegenerateDocumentPayload`, `RegenerateDocumentResponse`, `RegenerateDocumentAction`, `ActionHandlers`
+    *   `[✅]`   New API method: `regenerateDocument()` in `packages/api/src/dialectic.api.ts`
+    *   `[✅]`   Updated: `dialectic.api.mock.ts` — mock for `regenerateDocument`
+    *   `[✅]`   New frontend types: `RegenerateDocumentPayload`, `RegenerateDocumentResponse` in `packages/types/src/dialectic.types.ts`
+    *   `[✅]`   Updated: `DialecticActions` in `packages/types/src/dialectic.types.ts` — `regenerateDocument` action signature
+    *   `[✅]`   New store action: `regenerateDocument` in `packages/store/src/dialecticStore.ts`
+    *   `[✅]`   Updated: `StageRunChecklist.tsx` — per-document regenerate icon-buttons, model selection dialog, active-stage gate
+    *   `[✅]`   New tests: migration validation, `deriveStepStatuses` superseded tests, `regenerateDocument` handler unit tests, API client tests, store action tests, StageRunChecklist UI tests
 
 # ToDo
 

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -228,50 +228,50 @@ A user cannot begin a set of work when they have NSF. If a user reaches NSF whil
     *   `[✅]`   Modified: `index.ts` catch block — NSF detection branch routing to `pauseJobsForNsf`
 
 ### Node 5
-*   `[ ]`   [BE] supabase/functions/dialectic-service/`deriveStepStatuses` **Map `paused_nsf` job status to `paused_nsf` step status in progress derivation**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Extend `UnifiedStageStatus` in `dialectic.interface.ts` to include `'paused_nsf'` so the progress tracking type system can represent paused jobs
-    *   `[ ]`   Add a `PAUSED_NSF_STATUSES` set (containing `'paused_nsf'`) to `deriveStepStatuses.ts` and add a check after `ACTIVE_STATUSES` so that steps with paused jobs are reported as `'paused_nsf'` instead of falling through to `'not_started'`
-    *   `[ ]`   Priority order for step status derivation: `hasActive` → `in_progress` > `hasPausedNsf` → `paused_nsf` > `hasFailed` → `failed` > `hasCompleted` → `completed` > `not_started`
-  *   `[ ]`   `role`
-    *   `[ ]`   Infrastructure — progress derivation layer within the dialectic-service edge function
-  *   `[ ]`   `module`
-    *   `[ ]`   Progress tracking — step status derivation from raw job statuses
-    *   `[ ]`   Boundary: receives raw job rows, returns `Map<string, UnifiedStageStatus>` — the first backend consumer of `paused_nsf` job status for progress reporting
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 1 (migration) — `paused_nsf` must be a valid job status in the database before jobs can have this status
-    *   `[ ]`   `ACTIVE_STATUSES` set (line 9) — must NOT include `paused_nsf`; paused jobs are not active
-    *   `[ ]`   `FAILED_STATUSES` set (line 17) — must NOT include `paused_nsf`; paused jobs are not failed
-    *   `[ ]`   No reverse dependency introduced — this is consumed by `getAllStageProgress` (Node 6)
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `deriveStepStatuses` function (line 28): iterates `jobs`, classifies by status set membership, derives per-step status
-    *   `[ ]`   `UnifiedStageStatus` type (dialectic.interface.ts line 673): the return value type for step statuses
-    *   `[ ]`   No injected dependencies — pure function
-  *   `[ ]`   interface/`dialectic.interface.ts`
-    *   `[ ]`   Add `'paused_nsf'` to the `UnifiedStageStatus` union (line 673): `| "not_started" | "in_progress" | "completed" | "failed" | "paused_nsf"`
-  *   `[ ]`   unit/`deriveStepStatuses.test.ts`
-    *   `[ ]`   Test: when all jobs for a step have status `paused_nsf`, step status is `paused_nsf`
-    *   `[ ]`   Test: when a step has both `paused_nsf` and `completed` jobs, step status is `paused_nsf` (paused takes priority over completed)
-    *   `[ ]`   Test: when a step has both `paused_nsf` and active jobs (e.g. `pending`), step status is `in_progress` (active takes priority over paused)
-    *   `[ ]`   Test: when a step has both `paused_nsf` and `failed` jobs, step status is `paused_nsf` (paused takes priority over failed — the pause is recoverable, failure is secondary)
-    *   `[ ]`   Test: existing tests for `in_progress`, `completed`, `failed`, `not_started` continue to pass unchanged
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new functions — modification to existing `deriveStepStatuses`
-  *   `[ ]`   `deriveStepStatuses.ts`
-    *   `[ ]`   Add `const PAUSED_NSF_STATUSES: Set<string> = new Set(["paused_nsf"]);` after `FAILED_STATUSES` (line 17)
-    *   `[ ]`   Add `stepKeyToHasPausedNsf` map alongside existing `stepKeyToHasActive`, `stepKeyToHasCompleted`, `stepKeyToHasFailed` (line 44)
-    *   `[ ]`   In the job iteration loop (line 46), add a check: `else if (PAUSED_NSF_STATUSES.has(job.status)) { stepKeyToHasPausedNsf.set(stepKey, true); }` — after the `ACTIVE_STATUSES` check and before the `completed` check
-    *   `[ ]`   In the step status derivation (line 80), insert `hasPausedNsf` check after `hasActive` and before `hasFailed`: `if (hasActive) { result.set(sk, "in_progress"); } else if (hasPausedNsf) { result.set(sk, "paused_nsf"); } else if (hasFailed) { result.set(sk, "failed"); } else { result.set(sk, "completed"); }`
-    *   `[ ]`   Add `for (const stepKey of stepKeyToHasPausedNsf.keys()) stepsWithJobs.add(stepKey);` to the `stepsWithJobs` population (line 63)
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: infrastructure (progress derivation)
-    *   `[ ]`   Dependencies face inward: depends on job data (infra) and `UnifiedStageStatus` type (domain)
-    *   `[ ]`   Provides face outward: consumed by `getAllStageProgress` (Node 6) which passes step statuses to the frontend
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `paused_nsf` job status must map to `paused_nsf` step status — not `in_progress`, not `failed`, not `not_started`
-    *   `[ ]`   Active statuses must still take priority over `paused_nsf` (in the unlikely case both exist for a step)
-    *   `[ ]`   `paused_nsf` must take priority over `failed` — the pause is recoverable and should be presented as such
-    *   `[ ]`   All existing step status derivation behavior must be preserved
+*   `[✅]`   [BE] supabase/functions/dialectic-service/`deriveStepStatuses` **Map `paused_nsf` job status to `paused_nsf` step status in progress derivation**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Extend `UnifiedStageStatus` in `dialectic.interface.ts` to include `'paused_nsf'` so the progress tracking type system can represent paused jobs
+    *   `[✅]`   Add a `PAUSED_NSF_STATUSES` set (containing `'paused_nsf'`) to `deriveStepStatuses.ts` and add a check after `ACTIVE_STATUSES` so that steps with paused jobs are reported as `'paused_nsf'` instead of falling through to `'not_started'`
+    *   `[✅]`   Priority order for step status derivation: `hasActive` → `in_progress` > `hasPausedNsf` → `paused_nsf` > `hasFailed` → `failed` > `hasCompleted` → `completed` > `not_started`
+  *   `[✅]`   `role`
+    *   `[✅]`   Infrastructure — progress derivation layer within the dialectic-service edge function
+  *   `[✅]`   `module`
+    *   `[✅]`   Progress tracking — step status derivation from raw job statuses
+    *   `[✅]`   Boundary: receives raw job rows, returns `Map<string, UnifiedStageStatus>` — the first backend consumer of `paused_nsf` job status for progress reporting
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 1 (migration) — `paused_nsf` must be a valid job status in the database before jobs can have this status
+    *   `[✅]`   `ACTIVE_STATUSES` set (line 9) — must NOT include `paused_nsf`; paused jobs are not active
+    *   `[✅]`   `FAILED_STATUSES` set (line 17) — must NOT include `paused_nsf`; paused jobs are not failed
+    *   `[✅]`   No reverse dependency introduced — this is consumed by `getAllStageProgress` (Node 6)
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `deriveStepStatuses` function (line 28): iterates `jobs`, classifies by status set membership, derives per-step status
+    *   `[✅]`   `UnifiedStageStatus` type (dialectic.interface.ts line 673): the return value type for step statuses
+    *   `[✅]`   No injected dependencies — pure function
+  *   `[✅]`   interface/`dialectic.interface.ts`
+    *   `[✅]`   Add `'paused_nsf'` to the `UnifiedStageStatus` union (line 673): `| "not_started" | "in_progress" | "completed" | "failed" | "paused_nsf"`
+  *   `[✅]`   unit/`deriveStepStatuses.test.ts`
+    *   `[✅]`   Test: when all jobs for a step have status `paused_nsf`, step status is `paused_nsf`
+    *   `[✅]`   Test: when a step has both `paused_nsf` and `completed` jobs, step status is `paused_nsf` (paused takes priority over completed)
+    *   `[✅]`   Test: when a step has both `paused_nsf` and active jobs (e.g. `pending`), step status is `in_progress` (active takes priority over paused)
+    *   `[✅]`   Test: when a step has both `paused_nsf` and `failed` jobs, step status is `paused_nsf` (paused takes priority over failed — the pause is recoverable, failure is secondary)
+    *   `[✅]`   Test: existing tests for `in_progress`, `completed`, `failed`, `not_started` continue to pass unchanged
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new functions — modification to existing `deriveStepStatuses`
+  *   `[✅]`   `deriveStepStatuses.ts`
+    *   `[✅]`   Add `const PAUSED_NSF_STATUSES: Set<string> = new Set(["paused_nsf"]);` after `FAILED_STATUSES` (line 17)
+    *   `[✅]`   Add `stepKeyToHasPausedNsf` map alongside existing `stepKeyToHasActive`, `stepKeyToHasCompleted`, `stepKeyToHasFailed` (line 44)
+    *   `[✅]`   In the job iteration loop (line 46), add a check: `else if (PAUSED_NSF_STATUSES.has(job.status)) { stepKeyToHasPausedNsf.set(stepKey, true); }` — after the `ACTIVE_STATUSES` check and before the `completed` check
+    *   `[✅]`   In the step status derivation (line 80), insert `hasPausedNsf` check after `hasActive` and before `hasFailed`: `if (hasActive) { result.set(sk, "in_progress"); } else if (hasPausedNsf) { result.set(sk, "paused_nsf"); } else if (hasFailed) { result.set(sk, "failed"); } else { result.set(sk, "completed"); }`
+    *   `[✅]`   Add `for (const stepKey of stepKeyToHasPausedNsf.keys()) stepsWithJobs.add(stepKey);` to the `stepsWithJobs` population (line 63)
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: infrastructure (progress derivation)
+    *   `[✅]`   Dependencies face inward: depends on job data (infra) and `UnifiedStageStatus` type (domain)
+    *   `[✅]`   Provides face outward: consumed by `getAllStageProgress` (Node 6) which passes step statuses to the frontend
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `paused_nsf` job status must map to `paused_nsf` step status — not `in_progress`, not `failed`, not `not_started`
+    *   `[✅]`   Active statuses must still take priority over `paused_nsf` (in the unlikely case both exist for a step)
+    *   `[✅]`   `paused_nsf` must take priority over `failed` — the pause is recoverable and should be presented as such
+    *   `[✅]`   All existing step status derivation behavior must be preserved
 
 ### Node 6
 *   `[ ]`   [BE] supabase/functions/dialectic-service/`getAllStageProgress` **Handle `paused_nsf` step status in stage progress computation**

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -415,307 +415,700 @@ A user cannot begin a set of work when they have NSF. If a user reaches NSF whil
     *   `[✅]`   The frontend payload and response types must mirror the backend types
     *   `[✅]`   The method must be declared on the `DialecticApiClient` interface so the store depends on the interface, not the implementation
     *   `[✅]`   Error handling must follow the existing pattern — log errors, return `ApiResponse` with error details
-  *   `[ ]`   **Commit** `feat(be,api) dialectic-service resume handler, routing, and API client method for NSF job resume`
-    *   `[ ]`   New handler: `resumePausedNsfJobs.ts` in `dialectic-service/`
-    *   `[ ]`   Modified: `dialectic.interface.ts` — new payload, response, and action types
-    *   `[ ]`   Modified: `index.ts` — routing case, `ActionHandlers` interface, `defaultHandlers` entry
-    *   `[ ]`   New frontend types: `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` in `dialectic.types.ts`
-    *   `[ ]`   Modified: `DialecticApiClient` interface and `DialecticApiClientImpl` — new `resumePausedNsfJobs` method
+  *   `[✅]`   **Commit** `feat(be,api) dialectic-service resume handler, routing, and API client method for NSF job resume`
+    *   `[✅]`   New handler: `resumePausedNsfJobs.ts` in `dialectic-service/`
+    *   `[✅]`   Modified: `dialectic.interface.ts` — new payload, response, and action types
+    *   `[✅]`   Modified: `index.ts` — routing case, `ActionHandlers` interface, `defaultHandlers` entry
+    *   `[✅]`   New frontend types: `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` in `dialectic.types.ts`
+    *   `[✅]`   Modified: `DialecticApiClient` interface and `DialecticApiClientImpl` — new `resumePausedNsfJobs` method
 
 ### Node 9
-*   `[ ]`   [FE] packages/utils/src/`type_guards` **Recognize `contribution_generation_paused_nsf` in `isDialecticLifecycleEventType` and add event type string to frontend types**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add `'contribution_generation_paused_nsf'` to the `DialecticNotificationTypes` string union in `packages/types/src/dialectic.types.ts` so the frontend type system recognizes the new event
-    *   `[ ]`   Update `isDialecticLifecycleEventType` in `packages/utils/src/type_guards.ts` to accept the `'paused_nsf'` suffix on the `contribution_generation_` prefix, so notifications arriving via Realtime are correctly identified and routed to the lifecycle event pipeline in `notificationStore`
-  *   `[ ]`   `role`
-    *   `[ ]`   Port — type validation gate between incoming Realtime notifications and the dialectic lifecycle event handler
-  *   `[ ]`   `module`
-    *   `[ ]`   Type guard — `isDialecticLifecycleEventType` is the gatekeeper at `notificationStore.ts` line 70; if it returns `false`, the notification is silently dropped and never reaches `_handleDialecticLifecycleEvent`
-    *   `[ ]`   Boundary: validates a string is a known dialectic event type
-  *   `[ ]`   `deps`
-    *   `[ ]`   `DialecticNotificationTypes` from `@paynless/types` — the string union that the guard narrows to; must include `'contribution_generation_paused_nsf'` before the guard can match it
-    *   `[ ]`   No reverse dependency introduced
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   The guard function is pure — no injected dependencies, no side effects
-    *   `[ ]`   Confirm no concrete imports from higher or lateral layers
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   Add `'contribution_generation_paused_nsf'` to the `DialecticNotificationTypes` string union (line 827) — this is the type-level representation of the event string
-  *   `[ ]`   interface/tests/`type_guards.test.ts`
-    *   `[ ]`   Contract: `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` must return `true` — add to the existing `'should return true for valid dialectic event types'` test block (line 151)
-  *   `[ ]`   unit/`type_guards.test.ts`
-    *   `[ ]`   Test: `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` returns `true` (add assertion to existing valid-types test at line 151)
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new functions or objects — modification to an existing guard function
-  *   `[ ]`   `type_guards.ts`
-    *   `[ ]`   In the `contribution_generation_` prefix suffix check (line 210–215), add `|| suffix === 'paused_nsf'` to the return expression
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: port (shared utility)
-    *   `[ ]`   Dependencies face inward: depends on `DialecticNotificationTypes` (type-only, domain)
-    *   `[ ]`   Provides face outward: consumed by `notificationStore.ts` (Node 10) at line 70 to gate lifecycle event routing
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` must return `true` so the notification store routes the event
-    *   `[ ]`   All existing type guard tests must continue to pass — no regression on existing event types
-    *   `[ ]`   `DialecticNotificationTypes` must include the new string literal so TypeScript's type narrowing works correctly downstream
+*   `[✅]`   [FE] packages/utils/src/`type_guards` **Recognize `contribution_generation_paused_nsf` in `isDialecticLifecycleEventType` and add event type string to frontend types**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add `'contribution_generation_paused_nsf'` to the `DialecticNotificationTypes` string union in `packages/types/src/dialectic.types.ts` so the frontend type system recognizes the new event
+    *   `[✅]`   Update `isDialecticLifecycleEventType` in `packages/utils/src/type_guards.ts` to accept the `'paused_nsf'` suffix on the `contribution_generation_` prefix, so notifications arriving via Realtime are correctly identified and routed to the lifecycle event pipeline in `notificationStore`
+  *   `[✅]`   `role`
+    *   `[✅]`   Port — type validation gate between incoming Realtime notifications and the dialectic lifecycle event handler
+  *   `[✅]`   `module`
+    *   `[✅]`   Type guard — `isDialecticLifecycleEventType` is the gatekeeper at `notificationStore.ts` line 70; if it returns `false`, the notification is silently dropped and never reaches `_handleDialecticLifecycleEvent`
+    *   `[✅]`   Boundary: validates a string is a known dialectic event type
+  *   `[✅]`   `deps`
+    *   `[✅]`   `DialecticNotificationTypes` from `@paynless/types` — the string union that the guard narrows to; must include `'contribution_generation_paused_nsf'` before the guard can match it
+    *   `[✅]`   No reverse dependency introduced
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   The guard function is pure — no injected dependencies, no side effects
+    *   `[✅]`   Confirm no concrete imports from higher or lateral layers
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   Add `'contribution_generation_paused_nsf'` to the `DialecticNotificationTypes` string union (line 827) — this is the type-level representation of the event string
+  *   `[✅]`   interface/tests/`type_guards.test.ts`
+    *   `[✅]`   Contract: `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` must return `true` — add to the existing `'should return true for valid dialectic event types'` test block (line 151)
+  *   `[✅]`   unit/`type_guards.test.ts`
+    *   `[✅]`   Test: `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` returns `true` (add assertion to existing valid-types test at line 151)
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new functions or objects — modification to an existing guard function
+  *   `[✅]`   `type_guards.ts`
+    *   `[✅]`   In the `contribution_generation_` prefix suffix check (line 210–215), add `|| suffix === 'paused_nsf'` to the return expression
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: port (shared utility)
+    *   `[✅]`   Dependencies face inward: depends on `DialecticNotificationTypes` (type-only, domain)
+    *   `[✅]`   Provides face outward: consumed by `notificationStore.ts` (Node 10) at line 70 to gate lifecycle event routing
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `isDialecticLifecycleEventType('contribution_generation_paused_nsf')` must return `true` so the notification store routes the event
+    *   `[✅]`   All existing type guard tests must continue to pass — no regression on existing event types
+    *   `[✅]`   `DialecticNotificationTypes` must include the new string literal so TypeScript's type narrowing works correctly downstream
 
 ### Node 10
-*   `[ ]`   [STORE] packages/store/src/`notificationStore` **Route `contribution_generation_paused_nsf` notifications to dialectic store lifecycle handler**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add a `ContributionGenerationPausedNsfPayload` interface to the frontend type system in `packages/types/src/dialectic.types.ts` and add it to the `DialecticLifecycleEvent` union so the notification store can construct and forward the typed event
-    *   `[ ]`   Add a `case 'contribution_generation_paused_nsf'` to the payload extraction switch in `handleIncomingNotification` (line 289) so that incoming NSF pause notifications are extracted, validated, and forwarded to `_handleDialecticLifecycleEvent`
-  *   `[ ]`   `role`
-    *   `[ ]`   Application — notification routing bridge between Supabase Realtime and the dialectic store
-  *   `[ ]`   `module`
-    *   `[ ]`   Notification store — the `handleIncomingNotification` method's switch statement (lines 289–529) performs per-type payload extraction for all lifecycle events
-    *   `[ ]`   Boundary: receives a `Notification` from Realtime, extracts typed fields from `notification.data`, constructs a `DialecticLifecycleEvent`, forwards to `_handleDialecticLifecycleEvent`
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 9 (type guard) — `isDialecticLifecycleEventType` must recognize `'contribution_generation_paused_nsf'` before this case is reachable; `DialecticNotificationTypes` must include the string
-    *   `[ ]`   `DialecticLifecycleEvent` from `@paynless/types` — must include `ContributionGenerationPausedNsfPayload` so the constructed event can be assigned to `eventPayload`
-    *   `[ ]`   `useDialecticStore.getState()._handleDialecticLifecycleEvent` — existing consumer, no change
-    *   `[ ]`   No reverse dependency introduced
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `notification.data`: `NotificationData | null` — the raw JSONB payload from the notifications table row
-    *   `[ ]`   `notification.type`: `string` — already narrowed to `DialecticNotificationTypes` by the `isDialecticLifecycleEventType` check at line 70
-    *   `[ ]`   Confirm no concrete imports from higher or lateral layers
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   `ContributionGenerationPausedNsfPayload` — `{ type: 'contribution_generation_paused_nsf'; sessionId: string; projectId: string; stageSlug: string; iterationNumber: number }` — mirrors the backend payload shape from `notification.service.types.ts` (Node 2), follows the existing frontend payload pattern (e.g., `ContributionGenerationCompletePayload` at line 906)
-    *   `[ ]`   Add `ContributionGenerationPausedNsfPayload` to the `DialecticLifecycleEvent` union (line 1004)
-  *   `[ ]`   unit/`notificationStore.test.ts` (or existing test file for notification store)
-    *   `[ ]`   Test: when `handleIncomingNotification` receives a notification with `type: 'contribution_generation_paused_nsf'`, `is_internal_event: true`, and `data: { type: 'contribution_generation_paused_nsf', sessionId: 'x', projectId: 'y', stageSlug: 'thesis', iterationNumber: 1 }`, the dialectic store's `_handleDialecticLifecycleEvent` is called with a correctly shaped `ContributionGenerationPausedNsfPayload`
-    *   `[ ]`   Test: when `data` is missing `sessionId`, `stageSlug`, or `iterationNumber`, the event is NOT forwarded — `eventPayload` remains `null` and a warning is logged
-    *   `[ ]`   Test: when `data` is missing `projectId`, the event is NOT forwarded
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new functions or components — modification to the existing `switch (type)` block in `handleIncomingNotification`
-  *   `[ ]`   `notificationStore.ts`
-    *   `[ ]`   Add `case 'contribution_generation_paused_nsf':` to the switch block (after the `contribution_generation_complete` case at line 325), with field extraction and validation following the existing pattern:
-      *   `[ ]`   Guard: `typeof data['sessionId'] === 'string' && typeof data['projectId'] === 'string' && typeof data['stageSlug'] === 'string' && typeof data['iterationNumber'] === 'number'`
-      *   `[ ]`   Construct payload: `eventPayload = { type, sessionId: data['sessionId'], projectId: data['projectId'], stageSlug: data['stageSlug'], iterationNumber: data['iterationNumber'] }`
-      *   `[ ]`   `break;`
-    *   `[ ]`   The existing forwarding logic at line 531 (`if (eventPayload) { useDialecticStore.getState()._handleDialecticLifecycleEvent?.(eventPayload); }`) handles the rest — no additional changes needed
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: application (state management / notification routing)
-    *   `[ ]`   Dependencies face inward: consumes `DialecticLifecycleEvent` (types), `isDialecticLifecycleEventType` (port)
-    *   `[ ]`   Provides face outward: forwards constructed events to `dialecticStore._handleDialecticLifecycleEvent` (Node 11)
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `contribution_generation_paused_nsf` notifications must be extracted, validated, and forwarded to `_handleDialecticLifecycleEvent` using the same pattern as all other lifecycle events
-    *   `[ ]`   Invalid payloads (missing required fields) must be logged and dropped — not forwarded with partial data
-    *   `[ ]`   All existing notification routing must continue to work — no regression on existing event types
-    *   `[ ]`   The `ContributionGenerationPausedNsfPayload` frontend type must mirror the backend type shape from `notification.service.types.ts`
+*   `[✅]`   [STORE] packages/store/src/`notificationStore` **Route `contribution_generation_paused_nsf` notifications to dialectic store lifecycle handler**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add a `ContributionGenerationPausedNsfPayload` interface to the frontend type system in `packages/types/src/dialectic.types.ts` and add it to the `DialecticLifecycleEvent` union so the notification store can construct and forward the typed event
+    *   `[✅]`   Add a `case 'contribution_generation_paused_nsf'` to the payload extraction switch in `handleIncomingNotification` (line 289) so that incoming NSF pause notifications are extracted, validated, and forwarded to `_handleDialecticLifecycleEvent`
+  *   `[✅]`   `role`
+    *   `[✅]`   Application — notification routing bridge between Supabase Realtime and the dialectic store
+  *   `[✅]`   `module`
+    *   `[✅]`   Notification store — the `handleIncomingNotification` method's switch statement (lines 289–529) performs per-type payload extraction for all lifecycle events
+    *   `[✅]`   Boundary: receives a `Notification` from Realtime, extracts typed fields from `notification.data`, constructs a `DialecticLifecycleEvent`, forwards to `_handleDialecticLifecycleEvent`
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 9 (type guard) — `isDialecticLifecycleEventType` must recognize `'contribution_generation_paused_nsf'` before this case is reachable; `DialecticNotificationTypes` must include the string
+    *   `[✅]`   `DialecticLifecycleEvent` from `@paynless/types` — must include `ContributionGenerationPausedNsfPayload` so the constructed event can be assigned to `eventPayload`
+    *   `[✅]`   `useDialecticStore.getState()._handleDialecticLifecycleEvent` — existing consumer, no change
+    *   `[✅]`   No reverse dependency introduced
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `notification.data`: `NotificationData | null` — the raw JSONB payload from the notifications table row
+    *   `[✅]`   `notification.type`: `string` — already narrowed to `DialecticNotificationTypes` by the `isDialecticLifecycleEventType` check at line 70
+    *   `[✅]`   Confirm no concrete imports from higher or lateral layers
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   `ContributionGenerationPausedNsfPayload` — `{ type: 'contribution_generation_paused_nsf'; sessionId: string; projectId: string; stageSlug: string; iterationNumber: number }` — mirrors the backend payload shape from `notification.service.types.ts` (Node 2), follows the existing frontend payload pattern (e.g., `ContributionGenerationCompletePayload` at line 906)
+    *   `[✅]`   Add `ContributionGenerationPausedNsfPayload` to the `DialecticLifecycleEvent` union (line 1004)
+  *   `[✅]`   unit/`notificationStore.test.ts` (or existing test file for notification store)
+    *   `[✅]`   Test: when `handleIncomingNotification` receives a notification with `type: 'contribution_generation_paused_nsf'`, `is_internal_event: true`, and `data: { type: 'contribution_generation_paused_nsf', sessionId: 'x', projectId: 'y', stageSlug: 'thesis', iterationNumber: 1 }`, the dialectic store's `_handleDialecticLifecycleEvent` is called with a correctly shaped `ContributionGenerationPausedNsfPayload`
+    *   `[✅]`   Test: when `data` is missing `sessionId`, `stageSlug`, or `iterationNumber`, the event is NOT forwarded — `eventPayload` remains `null` and a warning is logged
+    *   `[✅]`   Test: when `data` is missing `projectId`, the event is NOT forwarded
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new functions or components — modification to the existing `switch (type)` block in `handleIncomingNotification`
+  *   `[✅]`   `notificationStore.ts`
+    *   `[✅]`   Add `case 'contribution_generation_paused_nsf':` to the switch block (after the `contribution_generation_complete` case at line 325), with field extraction and validation following the existing pattern:
+      *   `[✅]`   Guard: `typeof data['sessionId'] === 'string' && typeof data['projectId'] === 'string' && typeof data['stageSlug'] === 'string' && typeof data['iterationNumber'] === 'number'`
+      *   `[✅]`   Construct payload: `eventPayload = { type, sessionId: data['sessionId'], projectId: data['projectId'], stageSlug: data['stageSlug'], iterationNumber: data['iterationNumber'] }`
+      *   `[✅]`   `break;`
+    *   `[✅]`   The existing forwarding logic at line 531 (`if (eventPayload) { useDialecticStore.getState()._handleDialecticLifecycleEvent?.(eventPayload); }`) handles the rest — no additional changes needed
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: application (state management / notification routing)
+    *   `[✅]`   Dependencies face inward: consumes `DialecticLifecycleEvent` (types), `isDialecticLifecycleEventType` (port)
+    *   `[✅]`   Provides face outward: forwards constructed events to `dialecticStore._handleDialecticLifecycleEvent` (Node 11)
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `contribution_generation_paused_nsf` notifications must be extracted, validated, and forwarded to `_handleDialecticLifecycleEvent` using the same pattern as all other lifecycle events
+    *   `[✅]`   Invalid payloads (missing required fields) must be logged and dropped — not forwarded with partial data
+    *   `[✅]`   All existing notification routing must continue to work — no regression on existing event types
+    *   `[✅]`   The `ContributionGenerationPausedNsfPayload` frontend type must mirror the backend type shape from `notification.service.types.ts`
 
 ### Node 11
-*   `[ ]`   [STORE] packages/store/src/`dialecticStore` **NSF pause notification handler, resume action via API layer, and progress re-hydration trigger**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Handle the `contribution_generation_paused_nsf` lifecycle event (routed by `notificationStore` via Node 10) by clearing `generatingSessions` for the affected session and triggering `hydrateAllStageProgress` so the progress tracker durably reflects the `paused_nsf` state — NO ephemeral in-memory `nsfPausedContext` state
-    *   `[ ]`   Provide a `resumePausedNsfJobs` action that calls `api.dialectic().resumePausedNsfJobs(payload)` (Node 8) and triggers `hydrateAllStageProgress` on success so the progress tracker refreshes to show resumed jobs
-    *   `[ ]`   The source of truth for whether jobs are paused is the progress tracker (via `selectUnifiedProjectProgress` → `paused_nsf` stage/step status from Nodes 5–6), NOT ephemeral store state
-  *   `[ ]`   `role`
-    *   `[ ]`   State management — bridges backend notifications to progress re-hydration and provides the resume action via the API layer
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic store — extends the existing `_handleDialecticLifecycleEvent` router and adds the resume action
-    *   `[ ]`   Boundary: receives lifecycle event → clears generating state → re-hydrates progress; receives resume action from UI → calls API → re-hydrates progress
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 8 (API layer) — `api.dialectic().resumePausedNsfJobs` must exist so the store can call the backend through the API layer
-    *   `[ ]`   Node 10 (notificationStore) — must route the notification and forward the constructed `ContributionGenerationPausedNsfPayload` to `_handleDialecticLifecycleEvent`
-    *   `[ ]`   Existing `_handleDialecticLifecycleEvent` router (line 1481) — must add a new `case` for `'contribution_generation_paused_nsf'`
-    *   `[ ]`   Existing `generatingSessions` state — the pause handler must clear the affected session so the button transitions from "Generating..." to the paused state
-    *   `[ ]`   Existing `hydrateAllStageProgress` action (line 2707) — called to refresh progress data from the backend after pause/resume events
-    *   `[ ]`   `api` — the API client instance, available via the store's existing infrastructure pattern (same as `generateContributions` at line 1906)
-    *   `[ ]`   No reverse dependency — the store is consumed by UI components and selectors (Nodes 12–14)
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `api.dialectic().resumePausedNsfJobs`: from `@paynless/api` via the store's existing API infrastructure (same pattern as `api.dialectic().generateContributions` at line 1906)
-    *   `[ ]`   `ContributionGenerationPausedNsfPayload`: from `@paynless/types` (added in Node 10)
-    *   `[ ]`   `hydrateAllStageProgress`: existing store action at line 2707
-    *   `[ ]`   Existing store state shape: `generatingSessions`, `contributionGenerationStatus`, `generatingForStageSlug`
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   Add `resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload) => Promise<ApiResponse<ResumePausedNsfJobsResponse>>` to `DialecticActions` (line 665) — uses the same `ResumePausedNsfJobsPayload` and `ResumePausedNsfJobsResponse` types defined in Node 8
-    *   `[ ]`   Add `_handleContributionGenerationPausedNsf: (event: ContributionGenerationPausedNsfPayload) => void` to `DialecticActions` (line 755, alongside existing private handlers)
-    *   `[ ]`   NO `nsfPausedContext` in `DialecticStateValues` — the paused state is read from the progress tracker via selectors (Node 12)
-  *   `[ ]`   unit/`dialecticStore.nsf.test.ts`
-    *   `[ ]`   Test: `_handleContributionGenerationPausedNsf` clears the affected session from `generatingSessions` and resets `contributionGenerationStatus` and `generatingForStageSlug`
-    *   `[ ]`   Test: `_handleContributionGenerationPausedNsf` calls `hydrateAllStageProgress` with `{ sessionId, iterationNumber, userId, projectId }` from the payload so the progress tracker refreshes to show `paused_nsf`
-    *   `[ ]`   Test: `_handleDialecticLifecycleEvent` routes `type: 'contribution_generation_paused_nsf'` to `_handleContributionGenerationPausedNsf`
-    *   `[ ]`   Test: `resumePausedNsfJobs` calls `api.dialectic().resumePausedNsfJobs(payload)` with correct `{ sessionId, stageSlug, iterationNumber }`
-    *   `[ ]`   Test: on successful API response, `resumePausedNsfJobs` calls `hydrateAllStageProgress` to refresh progress data
-    *   `[ ]`   Test: on API failure, `resumePausedNsfJobs` shows a toast error and does NOT call `hydrateAllStageProgress`
-    *   `[ ]`   Test: on API failure, user can retry — the action does not leave the store in a broken state
-  *   `[ ]`   `construction`
-    *   `[ ]`   `_handleContributionGenerationPausedNsf` is a private handler method, not directly callable from outside the store
-    *   `[ ]`   `resumePausedNsfJobs` is a public action exposed on the store interface
-    *   `[ ]`   NO `nsfPausedContext` state variable — paused state is derived from the progress tracker
-  *   `[ ]`   `dialecticStore.ts`
-    *   `[ ]`   Add `_handleContributionGenerationPausedNsf(payload: ContributionGenerationPausedNsfPayload)` handler:
-      *   `[ ]`   Clear the session from `generatingSessions`: `set(state => { state.contributionGenerationStatus = 'idle'; state.generatingForStageSlug = null; })`
-      *   `[ ]`   Trigger progress re-hydration: `get().hydrateAllStageProgress({ sessionId: payload.sessionId, iterationNumber: payload.iterationNumber, userId: get().currentProjectDetail?.user_id ?? '', projectId: payload.projectId })`
-    *   `[ ]`   Add routing case in `_handleDialecticLifecycleEvent` (line 1484): when `type` is `'contribution_generation_paused_nsf'`, call `handlers._handleContributionGenerationPausedNsf(payload)`
-    *   `[ ]`   Add `resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload)` action:
-      *   `[ ]`   Call `api.dialectic().resumePausedNsfJobs(payload)` — NOT `supabase.rpc()` directly
-      *   `[ ]`   On success: call `get().hydrateAllStageProgress(...)` to refresh progress, return the API response
-      *   `[ ]`   On failure: show toast error, return the API error response — progress tracker still shows `paused_nsf` so the user can retry
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: application (state management)
-    *   `[ ]`   Dependencies face inward: consumes API layer (`api.dialectic()`) and types — does NOT depend on Supabase client directly for resume
-    *   `[ ]`   Provides face outward: consumed by UI components (Nodes 13–14) and selectors (Node 12)
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `contribution_generation_paused_nsf` lifecycle event must be routed to the correct handler via the existing `_handleDialecticLifecycleEvent` switch
-    *   `[ ]`   The pause handler must clear `generatingSessions` / `contributionGenerationStatus` / `generatingForStageSlug` so the UI button exits "Generating..." state
-    *   `[ ]`   The pause handler must trigger `hydrateAllStageProgress` so the progress tracker fetches fresh data showing `paused_nsf` step/stage statuses — this is the durable hydration mechanism
-    *   `[ ]`   The resume action must call through the API layer: store → `api.dialectic().resumePausedNsfJobs()` → edge function → RPC — NOT directly to `supabase.rpc()`
-    *   `[ ]`   After successful resume, `hydrateAllStageProgress` must be called to refresh progress — the progress tracker is the source of truth for UI state transitions
-    *   `[ ]`   Resume failure must leave the progress tracker unchanged (still showing `paused_nsf`) — the user can retry
+*   `[✅]`   [STORE] packages/store/src/`dialecticStore` **NSF pause notification handler, resume action via API layer, and progress re-hydration trigger**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Handle the `contribution_generation_paused_nsf` lifecycle event (routed by `notificationStore` via Node 10) by clearing `generatingSessions` for the affected session and triggering `hydrateAllStageProgress` so the progress tracker durably reflects the `paused_nsf` state — NO ephemeral in-memory `nsfPausedContext` state
+    *   `[✅]`   Provide a `resumePausedNsfJobs` action that calls `api.dialectic().resumePausedNsfJobs(payload)` (Node 8) and triggers `hydrateAllStageProgress` on success so the progress tracker refreshes to show resumed jobs
+    *   `[✅]`   The source of truth for whether jobs are paused is the progress tracker (via `selectUnifiedProjectProgress` → `paused_nsf` stage/step status from Nodes 5–6), NOT ephemeral store state
+  *   `[✅]`   `role`
+    *   `[✅]`   State management — bridges backend notifications to progress re-hydration and provides the resume action via the API layer
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic store — extends the existing `_handleDialecticLifecycleEvent` router and adds the resume action
+    *   `[✅]`   Boundary: receives lifecycle event → clears generating state → re-hydrates progress; receives resume action from UI → calls API → re-hydrates progress
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 8 (API layer) — `api.dialectic().resumePausedNsfJobs` must exist so the store can call the backend through the API layer
+    *   `[✅]`   Node 10 (notificationStore) — must route the notification and forward the constructed `ContributionGenerationPausedNsfPayload` to `_handleDialecticLifecycleEvent`
+    *   `[✅]`   Existing `_handleDialecticLifecycleEvent` router (line 1481) — must add a new `case` for `'contribution_generation_paused_nsf'`
+    *   `[✅]`   Existing `generatingSessions` state — the pause handler must clear the affected session so the button transitions from "Generating..." to the paused state
+    *   `[✅]`   Existing `hydrateAllStageProgress` action (line 2707) — called to refresh progress data from the backend after pause/resume events
+    *   `[✅]`   `api` — the API client instance, available via the store's existing infrastructure pattern (same as `generateContributions` at line 1906)
+    *   `[✅]`   No reverse dependency — the store is consumed by UI components and selectors (Nodes 12–14)
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `api.dialectic().resumePausedNsfJobs`: from `@paynless/api` via the store's existing API infrastructure (same pattern as `api.dialectic().generateContributions` at line 1906)
+    *   `[✅]`   `ContributionGenerationPausedNsfPayload`: from `@paynless/types` (added in Node 10)
+    *   `[✅]`   `hydrateAllStageProgress`: existing store action at line 2707
+    *   `[✅]`   Existing store state shape: `generatingSessions`, `contributionGenerationStatus`, `generatingForStageSlug`
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   Add `resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload) => Promise<ApiResponse<ResumePausedNsfJobsResponse>>` to `DialecticActions` (line 665) — uses the same `ResumePausedNsfJobsPayload` and `ResumePausedNsfJobsResponse` types defined in Node 8
+    *   `[✅]`   Add `_handleContributionGenerationPausedNsf: (event: ContributionGenerationPausedNsfPayload) => void` to `DialecticActions` (line 755, alongside existing private handlers)
+    *   `[✅]`   NO `nsfPausedContext` in `DialecticStateValues` — the paused state is read from the progress tracker via selectors (Node 12)
+  *   `[✅]`   unit/`dialecticStore.nsf.test.ts`
+    *   `[✅]`   Test: `_handleContributionGenerationPausedNsf` clears the affected session from `generatingSessions` and resets `contributionGenerationStatus` and `generatingForStageSlug`
+    *   `[✅]`   Test: `_handleContributionGenerationPausedNsf` calls `hydrateAllStageProgress` with `{ sessionId, iterationNumber, userId, projectId }` from the payload so the progress tracker refreshes to show `paused_nsf`
+    *   `[✅]`   Test: `_handleDialecticLifecycleEvent` routes `type: 'contribution_generation_paused_nsf'` to `_handleContributionGenerationPausedNsf`
+    *   `[✅]`   Test: `resumePausedNsfJobs` calls `api.dialectic().resumePausedNsfJobs(payload)` with correct `{ sessionId, stageSlug, iterationNumber }`
+    *   `[✅]`   Test: on successful API response, `resumePausedNsfJobs` calls `hydrateAllStageProgress` to refresh progress data
+    *   `[✅]`   Test: on API failure, `resumePausedNsfJobs` shows a toast error and does NOT call `hydrateAllStageProgress`
+    *   `[✅]`   Test: on API failure, user can retry — the action does not leave the store in a broken state
+  *   `[✅]`   `construction`
+    *   `[✅]`   `_handleContributionGenerationPausedNsf` is a private handler method, not directly callable from outside the store
+    *   `[✅]`   `resumePausedNsfJobs` is a public action exposed on the store interface
+    *   `[✅]`   NO `nsfPausedContext` state variable — paused state is derived from the progress tracker
+  *   `[✅]`   `dialecticStore.ts`
+    *   `[✅]`   Add `_handleContributionGenerationPausedNsf(payload: ContributionGenerationPausedNsfPayload)` handler:
+      *   `[✅]`   Clear the session from `generatingSessions`: `set(state => { state.contributionGenerationStatus = 'idle'; state.generatingForStageSlug = null; })`
+      *   `[✅]`   Trigger progress re-hydration: `get().hydrateAllStageProgress({ sessionId: payload.sessionId, iterationNumber: payload.iterationNumber, userId: get().currentProjectDetail?.user_id ?? '', projectId: payload.projectId })`
+    *   `[✅]`   Add routing case in `_handleDialecticLifecycleEvent` (line 1484): when `type` is `'contribution_generation_paused_nsf'`, call `handlers._handleContributionGenerationPausedNsf(payload)`
+    *   `[✅]`   Add `resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload)` action:
+      *   `[✅]`   Call `api.dialectic().resumePausedNsfJobs(payload)` — NOT `supabase.rpc()` directly
+      *   `[✅]`   On success: call `get().hydrateAllStageProgress(...)` to refresh progress, return the API response
+      *   `[✅]`   On failure: show toast error, return the API error response — progress tracker still shows `paused_nsf` so the user can retry
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: application (state management)
+    *   `[✅]`   Dependencies face inward: consumes API layer (`api.dialectic()`) and types — does NOT depend on Supabase client directly for resume
+    *   `[✅]`   Provides face outward: consumed by UI components (Nodes 13–14) and selectors (Node 12)
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `contribution_generation_paused_nsf` lifecycle event must be routed to the correct handler via the existing `_handleDialecticLifecycleEvent` switch
+    *   `[✅]`   The pause handler must clear `generatingSessions` / `contributionGenerationStatus` / `generatingForStageSlug` so the UI button exits "Generating..." state
+    *   `[✅]`   The pause handler must trigger `hydrateAllStageProgress` so the progress tracker fetches fresh data showing `paused_nsf` step/stage statuses — this is the durable hydration mechanism
+    *   `[✅]`   The resume action must call through the API layer: store → `api.dialectic().resumePausedNsfJobs()` → edge function → RPC — NOT directly to `supabase.rpc()`
+    *   `[✅]`   After successful resume, `hydrateAllStageProgress` must be called to refresh progress — the progress tracker is the source of truth for UI state transitions
+    *   `[✅]`   Resume failure must leave the progress tracker unchanged (still showing `paused_nsf`) — the user can retry
 
 ### Node 12
-*   `[ ]`   [STORE] packages/store/src/`dialecticStore.selectors` **Handle `paused_nsf` in `selectUnifiedProjectProgress` and add `paused_nsf` to `UnifiedProjectStatus`**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add `'paused_nsf'` to the `UnifiedProjectStatus` type union in `packages/types/src/dialectic.types.ts` so the frontend progress display system can represent paused steps and stages
-    *   `[ ]`   Update the step status mapping in `selectUnifiedProjectProgress` (line 870) to map `'paused_nsf'` raw step status to `'paused_nsf'` `UnifiedProjectStatus` — currently unmapped statuses default to `'not_started'`, which would silently hide the paused state
-    *   `[ ]`   Update the stage status derivation in `selectUnifiedProjectProgress` to set `stageStatus` to `'paused_nsf'` when any step is paused and none have failed
-  *   `[ ]`   `role`
-    *   `[ ]`   Application — progress data transformation layer between raw backend progress and UI display
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic store selectors — extends `selectUnifiedProjectProgress` to handle the new status
-    *   `[ ]`   Boundary: receives raw step statuses from hydrated progress → transforms to `UnifiedProjectStatus` values for UI consumption
-  *   `[ ]`   `deps`
-    *   `[ ]`   Nodes 5–6 (backend progress) — the backend must return `paused_nsf` as a valid step/stage status before the selector encounters it
-    *   `[ ]`   Node 11 (store) — `hydrateAllStageProgress` must have been triggered so the store contains fresh progress data with `paused_nsf` statuses
-    *   `[ ]`   `UnifiedProjectStatus` type (dialectic.types.ts line 575) — must be extended with `'paused_nsf'`
-    *   `[ ]`   No reverse dependency introduced — consumed by UI components (Nodes 13–14)
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `selectUnifiedProjectProgress` (line 803): the main progress selector that transforms raw step statuses into `UnifiedProjectStatus` values
-    *   `[ ]`   Step status mapping (line 870): `raw === 'failed' ? 'failed' : raw === 'completed' ? 'completed' : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress' : 'not_started'` — does not handle `paused_nsf`
-    *   `[ ]`   Stage status derivation (line 876): `if (stepStatus === 'failed') stageStatus = 'failed';` — does not handle `paused_nsf`
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   Add `'paused_nsf'` to `UnifiedProjectStatus` (line 575): `'not_started' | 'in_progress' | 'completed' | 'failed' | 'paused_nsf'`
-  *   `[ ]`   unit/`dialecticStore.selectors.test.ts`
-    *   `[ ]`   Test: when a step's raw status is `'paused_nsf'`, `selectUnifiedProjectProgress` maps it to `UnifiedProjectStatus` `'paused_nsf'`
-    *   `[ ]`   Test: when any step is `'paused_nsf'` and none are `'failed'`, the stage status is `'paused_nsf'`
-    *   `[ ]`   Test: when a step is `'paused_nsf'` and another is `'failed'`, the stage status is `'failed'` (failure takes priority)
-    *   `[ ]`   Test: existing `'in_progress'`, `'completed'`, `'failed'`, `'not_started'` step/stage mappings continue to work unchanged
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new functions — modifications to existing `selectUnifiedProjectProgress` selector
-  *   `[ ]`   `dialecticStore.selectors.ts`
-    *   `[ ]`   Update step status mapping (line 870): add `raw === 'paused_nsf' ? 'paused_nsf'` to the ternary chain — `raw === 'failed' ? 'failed' : raw === 'completed' ? 'completed' : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress' : raw === 'paused_nsf' ? 'paused_nsf' : 'not_started'`
-    *   `[ ]`   Update stage status derivation (line 876): add `paused_nsf` check after `failed`: `if (stepStatus === 'failed') stageStatus = 'failed'; else if (stepStatus === 'paused_nsf' && stageStatus !== 'failed') stageStatus = 'paused_nsf';`
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: application (state derivation)
-    *   `[ ]`   Dependencies face inward: consumes hydrated progress data (store state) and `UnifiedProjectStatus` type (domain)
-    *   `[ ]`   Provides face outward: consumed by `StageDAGProgressDialog` (Node 13) and `GenerateContributionButton` (Node 14) via the selector
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `paused_nsf` raw step status must map to `paused_nsf` `UnifiedProjectStatus` — NOT `not_started`, NOT `failed`
-    *   `[ ]`   `paused_nsf` stage status must be set when any step is paused and no steps have failed
-    *   `[ ]`   `failed` still takes priority over `paused_nsf` at the stage level
-    *   `[ ]`   All existing status mappings must be preserved
+*   `[✅]`   [STORE] packages/store/src/`dialecticStore.selectors` **Handle `paused_nsf` in `selectUnifiedProjectProgress` and add `paused_nsf` to `UnifiedProjectStatus`**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add `'paused_nsf'` to the `UnifiedProjectStatus` type union in `packages/types/src/dialectic.types.ts` so the frontend progress display system can represent paused steps and stages
+    *   `[✅]`   Update the step status mapping in `selectUnifiedProjectProgress` (line 870) to map `'paused_nsf'` raw step status to `'paused_nsf'` `UnifiedProjectStatus` — currently unmapped statuses default to `'not_started'`, which would silently hide the paused state
+    *   `[✅]`   Update the stage status derivation in `selectUnifiedProjectProgress` to set `stageStatus` to `'paused_nsf'` when any step is paused and none have failed
+  *   `[✅]`   `role`
+    *   `[✅]`   Application — progress data transformation layer between raw backend progress and UI display
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic store selectors — extends `selectUnifiedProjectProgress` to handle the new status
+    *   `[✅]`   Boundary: receives raw step statuses from hydrated progress → transforms to `UnifiedProjectStatus` values for UI consumption
+  *   `[✅]`   `deps`
+    *   `[✅]`   Nodes 5–6 (backend progress) — the backend must return `paused_nsf` as a valid step/stage status before the selector encounters it
+    *   `[✅]`   Node 11 (store) — `hydrateAllStageProgress` must have been triggered so the store contains fresh progress data with `paused_nsf` statuses
+    *   `[✅]`   `UnifiedProjectStatus` type (dialectic.types.ts line 575) — must be extended with `'paused_nsf'`
+    *   `[✅]`   No reverse dependency introduced — consumed by UI components (Nodes 13–14)
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `selectUnifiedProjectProgress` (line 803): the main progress selector that transforms raw step statuses into `UnifiedProjectStatus` values
+    *   `[✅]`   Step status mapping (line 870): `raw === 'failed' ? 'failed' : raw === 'completed' ? 'completed' : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress' : 'not_started'` — does not handle `paused_nsf`
+    *   `[✅]`   Stage status derivation (line 876): `if (stepStatus === 'failed') stageStatus = 'failed';` — does not handle `paused_nsf`
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   Add `'paused_nsf'` to `UnifiedProjectStatus` (line 575): `'not_started' | 'in_progress' | 'completed' | 'failed' | 'paused_nsf'`
+  *   `[✅]`   unit/`dialecticStore.selectors.test.ts`
+    *   `[✅]`   Test: when a step's raw status is `'paused_nsf'`, `selectUnifiedProjectProgress` maps it to `UnifiedProjectStatus` `'paused_nsf'`
+    *   `[✅]`   Test: when any step is `'paused_nsf'` and none are `'failed'`, the stage status is `'paused_nsf'`
+    *   `[✅]`   Test: when a step is `'paused_nsf'` and another is `'failed'`, the stage status is `'failed'` (failure takes priority)
+    *   `[✅]`   Test: existing `'in_progress'`, `'completed'`, `'failed'`, `'not_started'` step/stage mappings continue to work unchanged
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new functions — modifications to existing `selectUnifiedProjectProgress` selector
+  *   `[✅]`   `dialecticStore.selectors.ts`
+    *   `[✅]`   Update step status mapping (line 870): add `raw === 'paused_nsf' ? 'paused_nsf'` to the ternary chain — `raw === 'failed' ? 'failed' : raw === 'completed' ? 'completed' : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress' : raw === 'paused_nsf' ? 'paused_nsf' : 'not_started'`
+    *   `[✅]`   Update stage status derivation (line 876): add `paused_nsf` check after `failed`: `if (stepStatus === 'failed') stageStatus = 'failed'; else if (stepStatus === 'paused_nsf' && stageStatus !== 'failed') stageStatus = 'paused_nsf';`
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: application (state derivation)
+    *   `[✅]`   Dependencies face inward: consumes hydrated progress data (store state) and `UnifiedProjectStatus` type (domain)
+    *   `[✅]`   Provides face outward: consumed by `StageDAGProgressDialog` (Node 13) and `GenerateContributionButton` (Node 14) via the selector
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `paused_nsf` raw step status must map to `paused_nsf` `UnifiedProjectStatus` — NOT `not_started`, NOT `failed`
+    *   `[✅]`   `paused_nsf` stage status must be set when any step is paused and no steps have failed
+    *   `[✅]`   `failed` still takes priority over `paused_nsf` at the stage level
+    *   `[✅]`   All existing status mappings must be preserved
 
 ### Node 13
-*   `[ ]`   [UI] apps/web/src/components/dialectic/`StageDAGProgressDialog` **Add `paused_nsf` color to `STATUS_FILL` map**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add a `paused_nsf` entry to the `STATUS_FILL` record (line 15) so that DAG nodes with `paused_nsf` status render with a distinct visual color instead of falling back to `undefined`
-  *   `[ ]`   `role`
-    *   `[ ]`   UI / presentation — visual mapping for the new status in the DAG progress display
-  *   `[ ]`   `module`
-    *   `[ ]`   DAG progress dialog — extends the status-to-color mapping
-    *   `[ ]`   Boundary: receives `UnifiedProjectStatus` per step → maps to fill color for SVG rendering
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 12 (selectors) — `selectUnifiedProjectProgress` must return `paused_nsf` as a valid `UnifiedProjectStatus` for steps/stages before this color is used
-    *   `[ ]`   `UnifiedProjectStatus` from `@paynless/types` — must include `'paused_nsf'` (added in Node 12)
-    *   `[ ]`   No reverse dependency — this is a leaf UI component
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `STATUS_FILL` record (line 15): `Record<UnifiedProjectStatus, string>` — maps each status to a hex color
-    *   `[ ]`   Once `UnifiedProjectStatus` includes `paused_nsf`, TypeScript will enforce a compile error until `STATUS_FILL` has a matching entry
-  *   `[ ]`   unit/`StageDAGProgressDialog.test.ts`
-    *   `[ ]`   Test: when a step has status `paused_nsf`, the rendered DAG node uses the `paused_nsf` fill color (amber/orange: `'#f97316'`)
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new components — single-line addition to the existing `STATUS_FILL` record
-  *   `[ ]`   `StageDAGProgressDialog.tsx`
-    *   `[ ]`   Add `paused_nsf: '#f97316',` to the `STATUS_FILL` record (line 15, after `failed: '#ef4444'`) — orange to visually distinguish from yellow (`in_progress`) and red (`failed`), signaling "attention needed but recoverable"
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: UI / presentation
-    *   `[ ]`   Dependencies face inward: consumes `UnifiedProjectStatus` type
-    *   `[ ]`   No outward-facing provides — leaf component
-  *   `[ ]`   `requirements`
-    *   `[ ]`   `paused_nsf` must have a distinct color from `in_progress` (yellow) and `failed` (red) — orange (`#f97316`) conveys "needs attention but recoverable"
-    *   `[ ]`   TypeScript must compile without error — `STATUS_FILL` must be exhaustive for all `UnifiedProjectStatus` values
+*   `[✅]`   [UI] apps/web/src/components/dialectic/`StageDAGProgressDialog` **Add `paused_nsf` color to `STATUS_FILL` map**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add a `paused_nsf` entry to the `STATUS_FILL` record (line 15) so that DAG nodes with `paused_nsf` status render with a distinct visual color instead of falling back to `undefined`
+  *   `[✅]`   `role`
+    *   `[✅]`   UI / presentation — visual mapping for the new status in the DAG progress display
+  *   `[✅]`   `module`
+    *   `[✅]`   DAG progress dialog — extends the status-to-color mapping
+    *   `[✅]`   Boundary: receives `UnifiedProjectStatus` per step → maps to fill color for SVG rendering
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 12 (selectors) — `selectUnifiedProjectProgress` must return `paused_nsf` as a valid `UnifiedProjectStatus` for steps/stages before this color is used
+    *   `[✅]`   `UnifiedProjectStatus` from `@paynless/types` — must include `'paused_nsf'` (added in Node 12)
+    *   `[✅]`   No reverse dependency — this is a leaf UI component
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `STATUS_FILL` record (line 15): `Record<UnifiedProjectStatus, string>` — maps each status to a hex color
+    *   `[✅]`   Once `UnifiedProjectStatus` includes `paused_nsf`, TypeScript will enforce a compile error until `STATUS_FILL` has a matching entry
+  *   `[✅]`   unit/`StageDAGProgressDialog.test.ts`
+    *   `[✅]`   Test: when a step has status `paused_nsf`, the rendered DAG node uses the `paused_nsf` fill color (amber/orange: `'#f97316'`)
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new components — single-line addition to the existing `STATUS_FILL` record
+  *   `[✅]`   `StageDAGProgressDialog.tsx`
+    *   `[✅]`   Add `paused_nsf: '#f97316',` to the `STATUS_FILL` record (line 15, after `failed: '#ef4444'`) — orange to visually distinguish from yellow (`in_progress`) and red (`failed`), signaling "attention needed but recoverable"
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: UI / presentation
+    *   `[✅]`   Dependencies face inward: consumes `UnifiedProjectStatus` type
+    *   `[✅]`   No outward-facing provides — leaf component
+  *   `[✅]`   `requirements`
+    *   `[✅]`   `paused_nsf` must have a distinct color from `in_progress` (yellow) and `failed` (red) — orange (`#f97316`) conveys "needs attention but recoverable"
+    *   `[✅]`   TypeScript must compile without error — `STATUS_FILL` must be exhaustive for all `UnifiedProjectStatus` values
 
 ### Node 14
-*   `[ ]`   [UI] apps/web/src/components/dialectic/`GenerateContributionButton` **Per-stage balance threshold gate, paused-NSF detection from progress tracker, and resume-via-same-button UX**
+*   `[✅]`   [UI] apps/web/src/components/dialectic/`GenerateContributionButton` **Per-stage balance threshold gate, paused-NSF detection from progress tracker, and resume-via-same-button UX**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add a per-stage balance threshold check that disables the Generate button when the user's wallet balance is below the minimum required for the active stage — this is the UX gate, the first line of defense against NSF
+    *   `[✅]`   Detect when jobs are paused due to NSF by reading `stageStatus === 'paused_nsf'` from `selectUnifiedProjectProgress` (Node 12) — NOT from ephemeral in-memory state — and adjust the button to show "Add Funds to Resume" (disabled, balance too low) or "Resume {stageName}" (enabled, balance sufficient)
+    *   `[✅]`   When the user clicks "Resume", call `resumePausedNsfJobs` from the store (Node 11) instead of `generateContributions` — same button, different action based on progress-derived context
+  *   `[✅]`   `role`
+    *   `[✅]`   UI / presentation — the user-facing control for initiating, gating, and resuming dialectic generation
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic contribution generation UI — extends the existing `GenerateContributionButton` component
+    *   `[✅]`   Boundary: reads wallet balance + progress selector → renders button with appropriate text/disabled state → dispatches generate or resume action on click
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 11 (store) — `resumePausedNsfJobs` action must exist on the dialectic store
+    *   `[✅]`   Node 12 (selectors) — `selectUnifiedProjectProgress` must return `stageStatus: 'paused_nsf'` for paused stages — this is the source of truth for detecting the paused state
+    *   `[✅]`   `selectUnifiedProjectProgress` from `@paynless/store` (already imported at line 3) — provides `stagesDetail[].stageStatus` which may be `'paused_nsf'`
+    *   `[✅]`   `useWalletStore` / `selectActiveChatWalletInfo` (already imported, line 9–10) — the `activeWalletInfo` object must include a `balance` field. **Discovery potential**: verify the wallet info type includes a numeric `balance` property; if not, this requires a type extension in the wallet store which would be a separate node.
+    *   `[✅]`   `useDialecticStore` (already imported) — used for `resumePausedNsfJobs` action
+    *   `[✅]`   `@paynless/types` — for `getDisplayName` (already imported) and `STAGE_BALANCE_THRESHOLDS` constant (new)
+    *   `[✅]`   No reverse dependency — this is a leaf UI component
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `activeWalletInfo.balance`: `number` — current wallet token balance
+    *   `[✅]`   `selectUnifiedProjectProgress(state)`: returns `UnifiedProjectProgress` — `stagesDetail[].stageStatus` is checked for `'paused_nsf'` to detect the paused state for the active stage
+    *   `[✅]`   `resumePausedNsfJobs`: action from dialectic store (Node 11)
+    *   `[✅]`   `activeStage.slug`: `string` — used to look up threshold and match against progress data
+    *   `[✅]`   `STAGE_BALANCE_THRESHOLDS`: `Record<string, number>` — per-stage minimum balance constants
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   `STAGE_BALANCE_THRESHOLDS` constant in `@paynless/types`: `{ thesis: 200000, antithesis: 400000, synthesis: 1000000, parenthesis: 250000, paralysis: 250000 }` — values provided by product owner based on observed stage token costs. Keyed by stage slug string.
+    *   `[✅]`   Verify `activeWalletInfo` type includes a numeric `balance` field — if missing, this is a **discovery** requiring a type/selector extension in the wallet store (separate node)
+  *   `[✅]`   unit/`GenerateContributionButton.nsf.test.ts`
+    *   `[✅]`   Test: when `activeWalletInfo.balance` is below `STAGE_BALANCE_THRESHOLDS[activeStage.slug]` and active stage is NOT `paused_nsf`, button is disabled and shows "Insufficient Balance"
+    *   `[✅]`   Test: when `activeWalletInfo.balance` meets threshold and active stage is NOT `paused_nsf`, button is enabled and shows "Generate {displayName}" (existing behavior preserved)
+    *   `[✅]`   Test: when active stage `stageStatus === 'paused_nsf'` (from progress selector) AND balance is below threshold, button is disabled and shows "Add Funds to Resume"
+    *   `[✅]`   Test: when active stage `stageStatus === 'paused_nsf'` (from progress selector) AND balance meets threshold, button is enabled and shows "Resume {displayName}"
+    *   `[✅]`   Test: clicking "Resume {displayName}" calls `resumePausedNsfJobs` with `{ sessionId, stageSlug, iterationNumber }` derived from the active session/stage context — NOT `generateContributions`
+    *   `[✅]`   Test: clicking "Generate {displayName}" calls `generateContributions` — NOT `resumePausedNsfJobs` — existing behavior preserved
+    *   `[✅]`   Test: clicking "Resume" opens the `StageDAGProgressDialog` so the user can monitor resumed generation
+    *   `[✅]`   Test: button state priority order is correct — `isSessionGenerating` > `!areAnyModelsSelected` > `!isWalletReady` > `!activeStage/!activeSession` > `!isStageReady` > `hasPausedNsf && !balanceMeetsThreshold` > `hasPausedNsf && balanceMeetsThreshold` > `!balanceMeetsThreshold` > `didGenerationFail` > `contributionsExist` > default
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new component — all changes within the existing `GenerateContributionButton` component
+    *   `[✅]`   New store subscriptions: `selectUnifiedProjectProgress` (already imported), `resumePausedNsfJobs` action
+    *   `[✅]`   New derived state: `balanceMeetsThreshold` (boolean), `hasPausedNsfJobs` (boolean — derived from progress selector, NOT ephemeral state), `isResumeMode` (boolean)
+  *   `[✅]`   `GenerateContributionButton.tsx`
+    *   `[✅]`   Import `STAGE_BALANCE_THRESHOLDS` from `@paynless/types`
+    *   `[✅]`   Add store action: `const resumePausedNsfJobs = useDialecticStore((state) => state.resumePausedNsfJobs);`
+    *   `[✅]`   Read progress: `const unifiedProgress = useDialecticStore(selectUnifiedProjectProgress);` (selector already imported)
+    *   `[✅]`   Compute `hasPausedNsfJobs`: derive from progress selector — `const activeStageProgress = unifiedProgress?.stagesDetail?.find(s => s.stageSlug === activeStage?.slug); const hasPausedNsfJobs = activeStageProgress?.stageStatus === 'paused_nsf';` — this is durable, survives refresh/navigation because it comes from hydrated backend data
+    *   `[✅]`   Compute `balanceMeetsThreshold`: `const stageThreshold = activeStage ? STAGE_BALANCE_THRESHOLDS[activeStage.slug] ?? 0 : 0; const balanceMeetsThreshold = (activeWalletInfo.balance ?? 0) >= stageThreshold;`
+    *   `[✅]`   Compute `isResumeMode`: `const isResumeMode = hasPausedNsfJobs && balanceMeetsThreshold;`
+    *   `[✅]`   Update `isDisabled` (line 137): add `(hasPausedNsfJobs && !balanceMeetsThreshold)` for paused-but-broke, and `(!hasPausedNsfJobs && !balanceMeetsThreshold)` for the UX gate. The full disabled expression becomes: `isSessionGenerating || !areAnyModelsSelected || !activeStage || !activeSession || !isStageReady || !isWalletReady || (hasPausedNsfJobs && !balanceMeetsThreshold) || (!hasPausedNsfJobs && !balanceMeetsThreshold && !isResumeMode)`
+    *   `[✅]`   Update `getButtonText` (line 144): insert new cases BEFORE the existing `didGenerationFail` check (line 156), AFTER the `!isStageReady` check (line 154): `if (hasPausedNsfJobs && !balanceMeetsThreshold) return "Add Funds to Resume";` then `if (hasPausedNsfJobs && balanceMeetsThreshold) return \`Resume ${displayName}\`;` then `if (!balanceMeetsThreshold) return "Insufficient Balance";`
+    *   `[✅]`   Update `handleClick` (line 96): after the existing guard clause (lines 97–109), before the existing payload construction (line 119), insert: `if (isResumeMode && activeStage && activeSession) { toast.success("Resuming generation..."); setDagDialogOpen(true); await resumePausedNsfJobs({ sessionId: activeSession.id, stageSlug: activeStage.slug, iterationNumber: currentIterationNumber }); return; }`
+  *   `[✅]`   integration/`GenerateContributionButton.integration.test.ts`
+    *   `[✅]`   Test: render with progress showing `stageStatus: 'paused_nsf'` and low balance → button shows "Add Funds to Resume" and is disabled
+    *   `[✅]`   Test: render with progress showing `stageStatus: 'paused_nsf'` and sufficient balance → button shows "Resume {stageName}" and is enabled → click → verify `resumePausedNsfJobs` called with correct params
+    *   `[✅]`   Test: render with progress showing no `paused_nsf` and low balance → button shows "Insufficient Balance" and is disabled
+    *   `[✅]`   Test: render with progress showing no `paused_nsf` and sufficient balance → button shows "Generate {stageName}" and is enabled (existing behavior preserved)
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: UI / presentation
+    *   `[✅]`   Dependencies face inward: consumes store (selectors, actions) and types (constants)
+    *   `[✅]`   No outward-facing provides — this is a leaf component
+  *   `[✅]`   `requirements`
+    *   `[✅]`   Paused state detection MUST come from `selectUnifiedProjectProgress` → `stageStatus === 'paused_nsf'` — this is durable across refresh, navigation, and tab close because it is hydrated from the backend on mount via `useStageRunProgressHydration`
+    *   `[✅]`   The Generate button must be disabled when wallet balance is below the per-stage threshold, showing "Insufficient Balance" — UX gate preventing users from starting generations they cannot afford
+    *   `[✅]`   When NSF pause is active and balance is insufficient, button shows "Add Funds to Resume" (disabled) — directing the user toward the payment resolution path
+    *   `[✅]`   When NSF pause is active and balance is sufficient, button shows "Resume {displayName}" (enabled) — the user clicks the SAME button they originally used to Generate
+    *   `[✅]`   Clicking "Resume" calls `resumePausedNsfJobs` (NOT `generateContributions`) — this restores original job statuses via the API → edge function → RPC path and the DAG resumes naturally through existing trigger infrastructure
+    *   `[✅]`   The DAG progress dialog must open on resume click so the user can monitor resumed generation
+    *   `[✅]`   All existing button states and behaviors must be preserved — new states are inserted into the priority chain without disrupting existing logic
+    *   `[✅]`   Balance thresholds: thesis=200,000 / antithesis=400,000 / synthesis=1,000,000 / parenthesis=250,000 / paralysis=250,000
+    *   `[✅]`   **Frontend NSF workflow note**: The full UX flow (catch NSF notification → redirect to payment portal → catch return → enable Resume) is a known future requirement but is NOT in scope for this node. This node implements the button states and resume action only. The notification-to-portal redirect flow will be a separate checklist item.
+  *   `[✅]`   **Commit** `feat(ui,store) apps/web + packages/store + packages/utils + packages/types NSF protection with durable progress-based pause detection, API-layer resume, frontend notification pipeline, per-stage balance gate, and single-notification UX flow`
+    *   `[✅]`   New frontend types: `ContributionGenerationPausedNsfPayload`, `STAGE_BALANCE_THRESHOLDS`, `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` in `packages/types/src/dialectic.types.ts`
+    *   `[✅]`   Updated: `DialecticNotificationTypes` union, `DialecticLifecycleEvent` union, `UnifiedProjectStatus`, `DialecticActions` in `packages/types/src/dialectic.types.ts`
+    *   `[✅]`   Updated: `isDialecticLifecycleEventType` in `packages/utils/src/type_guards.ts` — recognizes `paused_nsf` suffix
+    *   `[✅]`   Updated: `notificationStore.ts` — new `case 'contribution_generation_paused_nsf'` for payload extraction and routing
+    *   `[✅]`   Updated: `dialecticStore.ts` — `_handleContributionGenerationPausedNsf` handler with progress re-hydration, `resumePausedNsfJobs` action via API layer
+    *   `[✅]`   Updated: `dialecticStore.selectors.ts` — `paused_nsf` handling in `selectUnifiedProjectProgress`
+    *   `[✅]`   Modified: `StageDAGProgressDialog.tsx` — `paused_nsf` color in `STATUS_FILL`
+    *   `[✅]`   Modified: `GenerateContributionButton.tsx` — balance threshold gate, progress-based paused NSF detection, resume-via-same-button UX
+    *   `[✅]`   New tests: type guard tests, notification store routing tests, dialectic store NSF handler/action tests, selector paused_nsf mapping tests, DAG dialog color test, button state transition tests
+
+## Regenerate Individual Document
+
+### Problem Statement
+
+Users cannot regenerate a single failed (or unsatisfactory) document without re-running the entire stage. If one document out of many fails, the user must regenerate all documents for that stage, losing the ones that succeeded. Users also want the ability to "roll the dice" on a document they already have a valid version of.
+
+### Objectives
+
+1. Allow a user to regenerate a specific document for specific model(s) without regenerating sibling documents or inputs.
+2. Present the regeneration action per-document in the stage run checklist, with model selection when multiple models are in use.
+3. Gate regeneration to the session's current stage only — documents from completed stages cannot be regenerated (future: branching/iteration).
+4. Mark the original job as `superseded` so progress tracking correctly reflects the new job's status, not the old failure.
+5. The cloned job is picked up by the existing worker pipeline (trigger on `INSERT ... WHERE status = 'pending'`) with zero changes to the worker.
+
+### Expected Outcome
+
+A user clicks a regenerate button on any document in the stage run checklist, selects which model(s) to regenerate for, and the system clones the original EXECUTE job(s), marks the originals as `superseded`, and inserts the clones as `pending`. The existing worker, RENDER pipeline, notification system, and progress hydration handle the rest. The progress tracker correctly ignores `superseded` jobs and reflects the new job's lifecycle.
+
+### Design Decisions
+
+- **Clone EXECUTE, not PLAN**: The EXECUTE job payload is self-contained (`model_id`, `prompt_template_id`, `output_type`, `canonicalPathParams`, `inputs`, `planner_metadata`). No re-planning is needed.
+- **`parent_job_id: null`** on clones: Prevents interference with the original PLAN job's completion tracking in `handle_job_completion()`.
+- **`superseded` status**: A new terminal status that `deriveStepStatuses` skips entirely, so the old failed job doesn't pollute step status when the clone succeeds.
+- **Active-stage-only gate**: `generateContributions` already validates `session.current_stage.slug === payload.stageSlug`. The regenerate handler applies the same validation.
+- **Model selection dialog**: The checklist already computes `perModelLabels` with per-model status. Failed/not-started models are pre-checked; completed models are unchecked (user must actively opt in).
+
+*   `[ ]`   [DB] supabase/migrations **`superseded` job status for regenerated document jobs**
   *   `[ ]`   `objective`
-    *   `[ ]`   Add a per-stage balance threshold check that disables the Generate button when the user's wallet balance is below the minimum required for the active stage — this is the UX gate, the first line of defense against NSF
-    *   `[ ]`   Detect when jobs are paused due to NSF by reading `stageStatus === 'paused_nsf'` from `selectUnifiedProjectProgress` (Node 12) — NOT from ephemeral in-memory state — and adjust the button to show "Add Funds to Resume" (disabled, balance too low) or "Resume {stageName}" (enabled, balance sufficient)
-    *   `[ ]`   When the user clicks "Resume", call `resumePausedNsfJobs` from the store (Node 11) instead of `generateContributions` — same button, different action based on progress-derived context
+    *   `[ ]`   Introduce the `superseded` terminal job status so that original jobs replaced by a regeneration clone are marked as replaced rather than remaining `failed`
+    *   `[ ]`   Ensure `superseded` IS treated as a terminal status by `handle_job_completion()` — it should not wake parent jobs or prerequisite chains
+    *   `[ ]`   Ensure `superseded` does NOT appear in worker-invoking trigger WHEN clauses (`on_job_status_change`, `on_new_job_created`) — the worker must never be invoked for superseded jobs
+    *   `[ ]`   Ensure `superseded` is excluded from the NSF pause function `resume_paused_nsf_jobs` — superseded jobs must not be resumed
   *   `[ ]`   `role`
-    *   `[ ]`   UI / presentation — the user-facing control for initiating, gating, and resuming dialectic generation
+    *   `[ ]`   Infrastructure — database schema and trigger layer
   *   `[ ]`   `module`
-    *   `[ ]`   Dialectic contribution generation UI — extends the existing `GenerateContributionButton` component
-    *   `[ ]`   Boundary: reads wallet balance + progress selector → renders button with appropriate text/disabled state → dispatches generate or resume action on click
+    *   `[ ]`   Dialectic generation job state machine — extends the terminal status set
+    *   `[ ]`   Boundary: defines the `superseded` status semantics within the existing trigger and completion infrastructure
   *   `[ ]`   `deps`
-    *   `[ ]`   Node 11 (store) — `resumePausedNsfJobs` action must exist on the dialectic store
-    *   `[ ]`   Node 12 (selectors) — `selectUnifiedProjectProgress` must return `stageStatus: 'paused_nsf'` for paused stages — this is the source of truth for detecting the paused state
-    *   `[ ]`   `selectUnifiedProjectProgress` from `@paynless/store` (already imported at line 3) — provides `stagesDetail[].stageStatus` which may be `'paused_nsf'`
-    *   `[ ]`   `useWalletStore` / `selectActiveChatWalletInfo` (already imported, line 9–10) — the `activeWalletInfo` object must include a `balance` field. **Discovery potential**: verify the wallet info type includes a numeric `balance` property; if not, this requires a type extension in the wallet store which would be a separate node.
-    *   `[ ]`   `useDialecticStore` (already imported) — used for `resumePausedNsfJobs` action
-    *   `[ ]`   `@paynless/types` — for `getDisplayName` (already imported) and `STAGE_BALANCE_THRESHOLDS` constant (new)
-    *   `[ ]`   No reverse dependency — this is a leaf UI component
+    *   `[ ]`   `handle_job_completion()` function (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 180) — must include `superseded` in the terminal status check at line 204: `IF NEW.status NOT IN ('completed', 'failed', 'retry_loop_failed')` → add `'superseded'`
+    *   `[ ]`   `on_job_status_change` trigger (defined in `supabase/migrations/20260109165706_state_machine_fix.sql` line 165) — WHEN clause must NOT include `superseded`
+    *   `[ ]`   `on_new_job_created` trigger (defined in `supabase/migrations/20260220213950_conditional_on_new_job_created.sql` line 15) — WHEN clause must NOT include `superseded`
+    *   `[ ]`   `resume_paused_nsf_jobs` RPC (defined in `supabase/migrations/20260302193405_nsf_pause_resume.sql`) — WHERE clause must exclude `superseded` jobs
+    *   `[ ]`   No reverse dependency introduced — this migration only extends existing infrastructure
   *   `[ ]`   `context_slice`
-    *   `[ ]`   `activeWalletInfo.balance`: `number` — current wallet token balance
-    *   `[ ]`   `selectUnifiedProjectProgress(state)`: returns `UnifiedProjectProgress` — `stagesDetail[].stageStatus` is checked for `'paused_nsf'` to detect the paused state for the active stage
-    *   `[ ]`   `resumePausedNsfJobs`: action from dialectic store (Node 11)
-    *   `[ ]`   `activeStage.slug`: `string` — used to look up threshold and match against progress data
-    *   `[ ]`   `STAGE_BALANCE_THRESHOLDS`: `Record<string, number>` — per-stage minimum balance constants
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   `STAGE_BALANCE_THRESHOLDS` constant in `@paynless/types`: `{ thesis: 200000, antithesis: 400000, synthesis: 1000000, parenthesis: 250000, paralysis: 250000 }` — values provided by product owner based on observed stage token costs. Keyed by stage slug string.
-    *   `[ ]`   Verify `activeWalletInfo` type includes a numeric `balance` field — if missing, this is a **discovery** requiring a type/selector extension in the wallet store (separate node)
-  *   `[ ]`   unit/`GenerateContributionButton.nsf.test.ts`
-    *   `[ ]`   Test: when `activeWalletInfo.balance` is below `STAGE_BALANCE_THRESHOLDS[activeStage.slug]` and active stage is NOT `paused_nsf`, button is disabled and shows "Insufficient Balance"
-    *   `[ ]`   Test: when `activeWalletInfo.balance` meets threshold and active stage is NOT `paused_nsf`, button is enabled and shows "Generate {displayName}" (existing behavior preserved)
-    *   `[ ]`   Test: when active stage `stageStatus === 'paused_nsf'` (from progress selector) AND balance is below threshold, button is disabled and shows "Add Funds to Resume"
-    *   `[ ]`   Test: when active stage `stageStatus === 'paused_nsf'` (from progress selector) AND balance meets threshold, button is enabled and shows "Resume {displayName}"
-    *   `[ ]`   Test: clicking "Resume {displayName}" calls `resumePausedNsfJobs` with `{ sessionId, stageSlug, iterationNumber }` derived from the active session/stage context — NOT `generateContributions`
-    *   `[ ]`   Test: clicking "Generate {displayName}" calls `generateContributions` — NOT `resumePausedNsfJobs` — existing behavior preserved
-    *   `[ ]`   Test: clicking "Resume" opens the `StageDAGProgressDialog` so the user can monitor resumed generation
-    *   `[ ]`   Test: button state priority order is correct — `isSessionGenerating` > `!areAnyModelsSelected` > `!isWalletReady` > `!activeStage/!activeSession` > `!isStageReady` > `hasPausedNsf && !balanceMeetsThreshold` > `hasPausedNsf && balanceMeetsThreshold` > `!balanceMeetsThreshold` > `didGenerationFail` > `contributionsExist` > default
+    *   `[ ]`   Requires access to `dialectic_generation_jobs` table status values and existing trigger/function definitions
+  *   `[ ]`   interface/`migration SQL`
+    *   `[ ]`   `superseded` added to the terminal status set in `handle_job_completion()` line 204
+    *   `[ ]`   `superseded` added to the terminal status set in `handle_job_completion()` line 209 (re-trigger guard)
+    *   `[ ]`   Sibling terminal count query in `handle_job_completion()` must include `superseded` in its terminal status list
   *   `[ ]`   `construction`
-    *   `[ ]`   No new component — all changes within the existing `GenerateContributionButton` component
-    *   `[ ]`   New store subscriptions: `selectUnifiedProjectProgress` (already imported), `resumePausedNsfJobs` action
-    *   `[ ]`   New derived state: `balanceMeetsThreshold` (boolean), `hasPausedNsfJobs` (boolean — derived from progress selector, NOT ephemeral state), `isResumeMode` (boolean)
-  *   `[ ]`   `GenerateContributionButton.tsx`
-    *   `[ ]`   Import `STAGE_BALANCE_THRESHOLDS` from `@paynless/types`
-    *   `[ ]`   Add store action: `const resumePausedNsfJobs = useDialecticStore((state) => state.resumePausedNsfJobs);`
-    *   `[ ]`   Read progress: `const unifiedProgress = useDialecticStore(selectUnifiedProjectProgress);` (selector already imported)
-    *   `[ ]`   Compute `hasPausedNsfJobs`: derive from progress selector — `const activeStageProgress = unifiedProgress?.stagesDetail?.find(s => s.stageSlug === activeStage?.slug); const hasPausedNsfJobs = activeStageProgress?.stageStatus === 'paused_nsf';` — this is durable, survives refresh/navigation because it comes from hydrated backend data
-    *   `[ ]`   Compute `balanceMeetsThreshold`: `const stageThreshold = activeStage ? STAGE_BALANCE_THRESHOLDS[activeStage.slug] ?? 0 : 0; const balanceMeetsThreshold = (activeWalletInfo.balance ?? 0) >= stageThreshold;`
-    *   `[ ]`   Compute `isResumeMode`: `const isResumeMode = hasPausedNsfJobs && balanceMeetsThreshold;`
-    *   `[ ]`   Update `isDisabled` (line 137): add `(hasPausedNsfJobs && !balanceMeetsThreshold)` for paused-but-broke, and `(!hasPausedNsfJobs && !balanceMeetsThreshold)` for the UX gate. The full disabled expression becomes: `isSessionGenerating || !areAnyModelsSelected || !activeStage || !activeSession || !isStageReady || !isWalletReady || (hasPausedNsfJobs && !balanceMeetsThreshold) || (!hasPausedNsfJobs && !balanceMeetsThreshold && !isResumeMode)`
-    *   `[ ]`   Update `getButtonText` (line 144): insert new cases BEFORE the existing `didGenerationFail` check (line 156), AFTER the `!isStageReady` check (line 154): `if (hasPausedNsfJobs && !balanceMeetsThreshold) return "Add Funds to Resume";` then `if (hasPausedNsfJobs && balanceMeetsThreshold) return \`Resume ${displayName}\`;` then `if (!balanceMeetsThreshold) return "Insufficient Balance";`
-    *   `[ ]`   Update `handleClick` (line 96): after the existing guard clause (lines 97–109), before the existing payload construction (line 119), insert: `if (isResumeMode && activeStage && activeSession) { toast.success("Resuming generation..."); setDagDialogOpen(true); await resumePausedNsfJobs({ sessionId: activeSession.id, stageSlug: activeStage.slug, iterationNumber: currentIterationNumber }); return; }`
-  *   `[ ]`   integration/`GenerateContributionButton.integration.test.ts`
-    *   `[ ]`   Test: render with progress showing `stageStatus: 'paused_nsf'` and low balance → button shows "Add Funds to Resume" and is disabled
-    *   `[ ]`   Test: render with progress showing `stageStatus: 'paused_nsf'` and sufficient balance → button shows "Resume {stageName}" and is enabled → click → verify `resumePausedNsfJobs` called with correct params
-    *   `[ ]`   Test: render with progress showing no `paused_nsf` and low balance → button shows "Insufficient Balance" and is disabled
-    *   `[ ]`   Test: render with progress showing no `paused_nsf` and sufficient balance → button shows "Generate {stageName}" and is enabled (existing behavior preserved)
+    *   `[ ]`   Single migration file with `CREATE OR REPLACE FUNCTION` for `handle_job_completion()` incorporating `superseded`
+    *   `[ ]`   No trigger recreation needed — existing WHEN clauses already exclude unlisted statuses
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: infrastructure (database)
+    *   `[ ]`   Dependencies face inward: modifies only the job state machine
+    *   `[ ]`   Provides face outward: consumed by the worker trigger system and the `regenerateDocument` handler
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `superseded` must be terminal: `handle_job_completion()` must fire for it (to unblock any prerequisite chains if needed) and must not re-trigger on already-terminal rows
+    *   `[ ]`   `superseded` must not invoke the worker: triggers must not include it in their WHEN clauses
+    *   `[ ]`   `superseded` must not be resumed by `resume_paused_nsf_jobs`
+    *   `[ ]`   Existing terminal statuses (`completed`, `failed`, `retry_loop_failed`) must continue to work identically
+
+*   `[ ]`   [BE] dialectic-service/`deriveStepStatuses` **Skip `superseded` jobs in step status derivation**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Ensure `superseded` jobs are completely invisible to progress tracking — they must not contribute to any step status flag (`hasActive`, `hasCompleted`, `hasFailed`, `hasPausedNsf`)
+    *   `[ ]`   The cloned replacement job's status is the only one that matters for the step
+  *   `[ ]`   `role`
+    *   `[ ]`   Backend logic — progress derivation
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic service — step status derivation within `getAllStageProgress`
+    *   `[ ]`   Boundary: receives jobs array → produces step status map; `superseded` jobs must be filtered out before status aggregation
+  *   `[ ]`   `deps`
+    *   `[ ]`   DB migration node (above) — `superseded` status must exist in the database
+    *   `[ ]`   Existing `ACTIVE_STATUSES`, `FAILED_STATUSES`, `PAUSED_NSF_STATUSES` sets in `deriveStepStatuses.ts`
+    *   `[ ]`   No reverse dependency introduced
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `deriveStepStatuses` function at `supabase/functions/dialectic-service/deriveStepStatuses.ts`
+    *   `[ ]`   Job `status` field — must recognize `superseded` as a skip condition
+  *   `[ ]`   interface/`dialectic.interface.ts`
+    *   `[ ]`   No interface changes required — `UnifiedStageStatus` does not need a `superseded` value because superseded jobs produce no status; they are skipped
+  *   `[ ]`   unit/`deriveStepStatuses.test.ts`
+    *   `[ ]`   Test: a step with one `superseded` job and one `completed` job → step status is `completed` (superseded job is invisible)
+    *   `[ ]`   Test: a step with one `superseded` job and one `pending` job → step status is `in_progress` (active clone is visible)
+    *   `[ ]`   Test: a step with only `superseded` jobs and no other jobs → step status is `not_started` (all evidence invisible)
+    *   `[ ]`   Test: a step with one `superseded` job, one `failed` job, and one `completed` job → step status is `failed` (the non-superseded failed job still counts)
+  *   `[ ]`   `construction`
+    *   `[ ]`   Add `const SUPERSEDED_STATUSES: Set<string> = new Set(["superseded"]);` alongside existing status sets
+    *   `[ ]`   Add skip condition at line 57 (after RENDER skip, after continuation skip): `if (SUPERSEDED_STATUSES.has(job.status)) continue;`
+  *   `[ ]`   `deriveStepStatuses.ts`
+    *   `[ ]`   Add `SUPERSEDED_STATUSES` constant
+    *   `[ ]`   Add `continue` guard for superseded jobs in the job iteration loop
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: backend logic (service)
+    *   `[ ]`   Dependencies face inward: reads job status values defined by DB migration
+    *   `[ ]`   Provides face outward: consumed by `getAllStageProgress` → frontend progress hydration
+  *   `[ ]`   `requirements`
+    *   `[ ]`   `superseded` jobs must not set any status flag (`hasActive`, `hasCompleted`, `hasFailed`, `hasPausedNsf`)
+    *   `[ ]`   All existing status derivation behavior must be preserved for non-superseded jobs
+    *   `[ ]`   A step with only superseded jobs and no successors must show `not_started`
+
+*   `[ ]`   [BE] dialectic-service/`regenerateDocument` **Clone failed/completed EXECUTE jobs as new `pending` jobs for targeted document regeneration**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Accept a request specifying session, stage, iteration, and a list of `{ jobId, modelId }` pairs identifying which EXECUTE jobs to regenerate
+    *   `[ ]`   Validate that the stage matches the session's current stage (active-stage-only gate)
+    *   `[ ]`   Validate that each referenced job belongs to the correct session/stage/iteration and is an EXECUTE job
+    *   `[ ]`   Mark each original job as `superseded`
+    *   `[ ]`   Clone each original job's row: copy `payload`, `stage_slug`, `iteration_number`, `session_id`, `user_id`, `max_retries`, `job_type`; set `status: 'pending'`, `attempt_count: 0`, `parent_job_id: null`, `prerequisite_job_id: null`, `started_at: null`, `completed_at: null`, `results: null`, `error_details: null`, `target_contribution_id: null`
+    *   `[ ]`   Insert the cloned row — the existing `on_new_job_created` trigger fires and the worker picks it up
+    *   `[ ]`   Return the array of new job IDs
+  *   `[ ]`   `role`
+    *   `[ ]`   Backend logic — edge function handler for document regeneration
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic service — new handler function within the `dialectic-service` edge function
+    *   `[ ]`   Boundary: receives validated request → marks originals superseded → inserts cloned jobs → returns new job IDs
+  *   `[ ]`   `deps`
+    *   `[ ]`   DB migration node — `superseded` status must exist
+    *   `[ ]`   `dialectic_generation_jobs` table — read original job, update to `superseded`, insert clone
+    *   `[ ]`   `dialectic_sessions` table — validate `current_stage_id` matches requested `stageSlug`
+    *   `[ ]`   `dialectic_stages` table — resolve `current_stage_id` to slug
+    *   `[ ]`   Supabase admin client — for DB operations
+    *   `[ ]`   Authenticated user — for authorization (job's `user_id` must match requesting user)
+    *   `[ ]`   No reverse dependency introduced
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `dbClient: SupabaseClient` — admin client for DB reads/writes
+    *   `[ ]`   `user: User` — authenticated user from request
+    *   `[ ]`   `payload: RegenerateDocumentPayload` — `{ sessionId, stageSlug, iterationNumber, jobs: Array<{ jobId: string; modelId: string }> }`
+  *   `[ ]`   interface/`dialectic.interface.ts`
+    *   `[ ]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; jobs: Array<{ jobId: string; modelId: string }> }`
+    *   `[ ]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
+    *   `[ ]`   `RegenerateDocumentAction`: `{ action: 'regenerateDocument'; payload: RegenerateDocumentPayload }`
+    *   `[ ]`   Add `RegenerateDocumentAction` to the `DialecticServiceRequest` union
+    *   `[ ]`   Add `regenerateDocument` to `ActionHandlers` interface
+  *   `[ ]`   interface/tests/`regenerateDocument.interface.test.ts`
+    *   `[ ]`   Test: `RegenerateDocumentPayload` requires `sessionId`, `stageSlug`, `iterationNumber`, and `jobs` array
+    *   `[ ]`   Test: `RegenerateDocumentResponse` has `jobIds` string array
+  *   `[ ]`   interface/guards/`regenerateDocument.interface.guards.ts`
+    *   `[ ]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — validates all required fields and jobs array structure
+  *   `[ ]`   unit/`regenerateDocument.test.ts`
+    *   `[ ]`   Test: valid request with one job → original marked `superseded`, clone inserted as `pending` with correct payload copy, returns new job ID
+    *   `[ ]`   Test: valid request with multiple jobs → all originals marked `superseded`, all clones inserted, returns array of new job IDs
+    *   `[ ]`   Test: stage mismatch (requested stage ≠ session's current stage) → returns 400 error, no jobs modified
+    *   `[ ]`   Test: job not found → returns 404 error
+    *   `[ ]`   Test: job belongs to different session → returns 403 error
+    *   `[ ]`   Test: job is not an EXECUTE job → returns 400 error
+    *   `[ ]`   Test: user does not own the job → returns 403 error
+    *   `[ ]`   Test: cloned job has `parent_job_id: null`, `prerequisite_job_id: null`, `attempt_count: 0`, `status: 'pending'`
+    *   `[ ]`   Test: cloned job preserves original's `payload`, `stage_slug`, `iteration_number`, `session_id`, `job_type`, `max_retries`
+  *   `[ ]`   `construction`
+    *   `[ ]`   Single exported async function `regenerateDocument(dbClient, payload, user)`
+    *   `[ ]`   Returns `{ success: boolean; data?: RegenerateDocumentResponse; error?: { message: string; status?: number } }`
+    *   `[ ]`   No DI beyond `dbClient` and `user` — this is a thin data-copy operation
+  *   `[ ]`   `regenerateDocument.ts`
+    *   `[ ]`   Validate payload fields
+    *   `[ ]`   Fetch session and verify `current_stage.slug === payload.stageSlug`
+    *   `[ ]`   For each job in `payload.jobs`:
+      *   `[ ]`   Fetch original job by ID
+      *   `[ ]`   Validate ownership (`user_id === user.id`), session match, stage match, iteration match, `job_type === 'EXECUTE'`
+      *   `[ ]`   Update original job: `SET status = 'superseded'`
+      *   `[ ]`   Insert clone row with fields copied from original, reset fields as specified in objective
+    *   `[ ]`   Return `{ success: true, data: { jobIds } }`
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: backend logic (service handler)
+    *   `[ ]`   Dependencies face inward: reads/writes `dialectic_generation_jobs`, reads `dialectic_sessions` and `dialectic_stages`
+    *   `[ ]`   Provides face outward: consumed by `dialectic-service/index.ts` router
+  *   `[ ]`   `requirements`
+    *   `[ ]`   Original job must be marked `superseded` BEFORE clone is inserted to prevent race conditions with progress tracking
+    *   `[ ]`   Clone must have `parent_job_id: null` to prevent interference with original PLAN completion tracking
+    *   `[ ]`   Clone must have `prerequisite_job_id: null` — the document's prerequisites are already met (they were met when the original ran)
+    *   `[ ]`   Active-stage-only gate: reject requests where `stageSlug` does not match `session.current_stage.slug`
+    *   `[ ]`   The clone's `payload` must be an exact copy of the original's `payload` — the worker uses payload fields to determine what to generate and where to store results
+
+*   `[ ]`   [BE] dialectic-service/`index` **Route `regenerateDocument` action to handler**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add `regenerateDocument` as a routable action in the dialectic-service edge function entry point
+    *   `[ ]`   Wire the action to the `regenerateDocument` handler with authentication required
+  *   `[ ]`   `role`
+    *   `[ ]`   Infrastructure — edge function router
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic service entry point — action dispatch
+    *   `[ ]`   Boundary: receives HTTP request → authenticates → routes to handler → returns response
+  *   `[ ]`   `deps`
+    *   `[ ]`   `regenerateDocument` handler (node above) — must exist as an importable function
+    *   `[ ]`   `RegenerateDocumentPayload` type from `dialectic.interface.ts`
+    *   `[ ]`   Existing `ActionHandlers` interface — must include `regenerateDocument` (added in the handler node's interface section)
+    *   `[ ]`   Existing `actionsRequiringAuth` array — must include `'regenerateDocument'`
+    *   `[ ]`   Existing `DialecticServiceRequest` union — must include `RegenerateDocumentAction` (added in the handler node's interface section)
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `handlers.regenerateDocument` — the handler function
+    *   `[ ]`   `adminClient` — passed to handler as `dbClient`
+    *   `[ ]`   `userForJson` — authenticated user
+    *   `[ ]`   `requestBody.payload` — typed as `RegenerateDocumentPayload`
+  *   `[ ]`   unit/`index.test.ts`
+    *   `[ ]`   Test: `regenerateDocument` action routes to handler with correct arguments
+    *   `[ ]`   Test: `regenerateDocument` action without authentication returns 401
+    *   `[ ]`   Test: handler success → returns 200 with `{ jobIds }` response
+    *   `[ ]`   Test: handler error → returns error status with error message
+  *   `[ ]`   `construction`
+    *   `[ ]`   Import `regenerateDocument` from `./regenerateDocument.ts`
+    *   `[ ]`   Add `'regenerateDocument'` to `actionsRequiringAuth` array
+    *   `[ ]`   Add `case "regenerateDocument"` to the action switch with standard auth guard pattern
+    *   `[ ]`   Wire `regenerateDocument` into `defaultHandlers` object
+  *   `[ ]`   `index.ts`
+    *   `[ ]`   Add import for `regenerateDocument` handler
+    *   `[ ]`   Add `'regenerateDocument'` to `actionsRequiringAuth` array (line 269)
+    *   `[ ]`   Add case block in switch statement (before `default:` case, after `resumePausedNsfJobs` case at line 602)
+    *   `[ ]`   Add `regenerateDocument` to `defaultHandlers` object
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: infrastructure (edge function entry point)
+    *   `[ ]`   Dependencies face inward: imports handler function, uses types from interface
+    *   `[ ]`   Provides face outward: HTTP endpoint consumed by API client
+  *   `[ ]`   `requirements`
+    *   `[ ]`   Authentication is required — unauthenticated requests return 401
+    *   `[ ]`   Handler receives `adminClient` (not `userClient`) as `dbClient` — consistent with other handlers like `resumePausedNsfJobs`
+    *   `[ ]`   Follows exact same routing pattern as `resumePausedNsfJobs` case block
+
+*   `[ ]`   [API] packages/api/`dialectic.api` **`regenerateDocument` API client method**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Add a `regenerateDocument` method to `DialecticApiClient` that calls the `dialectic-service` edge function with action `'regenerateDocument'`
+    *   `[ ]`   Follow the same pattern as `resumePausedNsfJobs` method
+  *   `[ ]`   `role`
+    *   `[ ]`   API client — typed HTTP adapter for the edge function
+  *   `[ ]`   `module`
+    *   `[ ]`   `@paynless/api` — dialectic API client class
+    *   `[ ]`   Boundary: accepts typed payload → posts to edge function → returns typed response
+  *   `[ ]`   `deps`
+    *   `[ ]`   Edge function router node (above) — `regenerateDocument` action must be routable
+    *   `[ ]`   `apiClient.post` — existing HTTP post method on the base API client
+    *   `[ ]`   No reverse dependency introduced
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `this.apiClient.post<RegenerateDocumentResponse, DialecticServiceActionPayload>('dialectic-service', { action: 'regenerateDocument', payload })`
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   `RegenerateDocumentPayload`: `{ sessionId: string; stageSlug: string; iterationNumber: number; jobs: Array<{ jobId: string; modelId: string }> }` — mirrors the backend interface
+    *   `[ ]`   `RegenerateDocumentResponse`: `{ jobIds: string[] }`
+  *   `[ ]`   interface/tests/`dialectic.types.test.ts`
+    *   `[ ]`   Test: `RegenerateDocumentPayload` shape contract
+    *   `[ ]`   Test: `RegenerateDocumentResponse` shape contract
+  *   `[ ]`   interface/guards/`type_guards.ts`
+    *   `[ ]`   `isRegenerateDocumentPayload(value: unknown): value is RegenerateDocumentPayload` — if needed by consumers
+    *   `[ ]`   `isRegenerateDocumentResponse(value: unknown): value is RegenerateDocumentResponse`
+  *   `[ ]`   unit/`dialectic.api.test.ts`
+    *   `[ ]`   Test: `regenerateDocument` calls `apiClient.post` with `{ action: 'regenerateDocument', payload }` and correct typing
+    *   `[ ]`   Test: successful response returns `{ data: { jobIds: [...] }, error: null }`
+    *   `[ ]`   Test: error response returns `{ data: null, error: { message, status } }`
+  *   `[ ]`   `construction`
+    *   `[ ]`   New `async regenerateDocument(payload: RegenerateDocumentPayload): Promise<ApiResponse<RegenerateDocumentResponse>>` method on `DialecticApiClient`
+    *   `[ ]`   Follows identical pattern to `resumePausedNsfJobs` method at line 686
+  *   `[ ]`   `dialectic.api.ts`
+    *   `[ ]`   Add import for `RegenerateDocumentPayload`, `RegenerateDocumentResponse` from types
+    *   `[ ]`   Add `regenerateDocument` method to `DialecticApiClient` class
+  *   `[ ]`   `dialectic.api.mock.ts`
+    *   `[ ]`   Add `regenerateDocument` mock method returning default success response
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: adapter (API client)
+    *   `[ ]`   Dependencies face inward: uses types from `@paynless/types`, posts to edge function
+    *   `[ ]`   Provides face outward: consumed by `@paynless/store` dialectic store action
+  *   `[ ]`   `requirements`
+    *   `[ ]`   Must follow the same pattern as `resumePausedNsfJobs` — post to `dialectic-service` with typed action payload
+    *   `[ ]`   Must return `ApiResponse<RegenerateDocumentResponse>` with standard error handling
+    *   `[ ]`   Mock must be updated for store tests
+
+*   `[ ]`   [STORE] packages/store/`dialecticStore` **`regenerateDocument` action with progress re-hydration**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Provide a `regenerateDocument` store action that calls `api.dialectic().regenerateDocument(payload)` and triggers progress re-hydration so the UI reflects the new job's lifecycle
+    *   `[ ]`   Track the new job IDs in `generatingSessions` so the generating state is correctly reflected
+    *   `[ ]`   Set `generatingForStageSlug` so the checklist shows generating spinners for the affected documents
+  *   `[ ]`   `role`
+    *   `[ ]`   State management — bridges UI action to API call and progress refresh
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic store — extends existing actions
+    *   `[ ]`   Boundary: receives regenerate action from UI → calls API → tracks jobs → re-hydrates progress
+  *   `[ ]`   `deps`
+    *   `[ ]`   API client node (above) — `api.dialectic().regenerateDocument` must exist
+    *   `[ ]`   Existing `hydrateAllStageProgress` action — called after successful API response to refresh progress data
+    *   `[ ]`   Existing `generatingSessions` state — tracks active job IDs per session
+    *   `[ ]`   Existing `generatingForStageSlug` state — identifies which stage is actively generating
+    *   `[ ]`   Existing `contributionGenerationStatus` state — set to `'generating'` during regeneration
+    *   `[ ]`   `api` — the API client instance, available via the store's existing infrastructure pattern (same as `generateContributions` at line 1906)
+    *   `[ ]`   No reverse dependency introduced — the store is consumed by UI components
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `api.dialectic().regenerateDocument`: from `@paynless/api` via the store's existing API infrastructure
+    *   `[ ]`   `RegenerateDocumentPayload`, `RegenerateDocumentResponse`: from `@paynless/types`
+    *   `[ ]`   `hydrateAllStageProgress`: existing store action
+    *   `[ ]`   Existing store state: `generatingSessions`, `contributionGenerationStatus`, `generatingForStageSlug`
+  *   `[ ]`   interface/`dialectic.types.ts`
+    *   `[ ]`   Add `regenerateDocument: (payload: RegenerateDocumentPayload) => Promise<ApiResponse<RegenerateDocumentResponse>>` to `DialecticActions` (alongside existing actions like `generateContributions`)
+  *   `[ ]`   unit/`dialecticStore.regenerateDocument.test.ts`
+    *   `[ ]`   Test: `regenerateDocument` calls `api.dialectic().regenerateDocument(payload)` with correct `{ sessionId, stageSlug, iterationNumber, jobs }`
+    *   `[ ]`   Test: on successful API response, `regenerateDocument` adds returned job IDs to `generatingSessions[sessionId]`
+    *   `[ ]`   Test: on successful API response, `regenerateDocument` sets `contributionGenerationStatus` to `'generating'` and `generatingForStageSlug` to `payload.stageSlug`
+    *   `[ ]`   Test: on successful API response, `regenerateDocument` calls `hydrateAllStageProgress` to refresh progress data
+    *   `[ ]`   Test: on API failure, `regenerateDocument` does NOT modify `generatingSessions` or `contributionGenerationStatus`
+    *   `[ ]`   Test: on API failure, `regenerateDocument` returns the error response
+  *   `[ ]`   `construction`
+    *   `[ ]`   `regenerateDocument` is a public action exposed on the store interface
+    *   `[ ]`   Follows the same pattern as `generateContributions` for job tracking and status management
+  *   `[ ]`   `dialecticStore.ts`
+    *   `[ ]`   Add `regenerateDocument(payload: RegenerateDocumentPayload)` action:
+      *   `[ ]`   Set `contributionGenerationStatus = 'generating'`, `generatingForStageSlug = payload.stageSlug`
+      *   `[ ]`   Call `api.dialectic().regenerateDocument(payload)`
+      *   `[ ]`   On success: add returned `jobIds` to `generatingSessions[payload.sessionId]`, call `get().hydrateAllStageProgress(...)`, return response
+      *   `[ ]`   On failure: reset `contributionGenerationStatus = 'idle'`, reset `generatingForStageSlug = null`, return error response
+  *   `[ ]`   `directionality`
+    *   `[ ]`   Layer: application (state management)
+    *   `[ ]`   Dependencies face inward: consumes API layer (`api.dialectic()`) and types
+    *   `[ ]`   Provides face outward: consumed by UI component (StageRunChecklist regenerate button)
+  *   `[ ]`   `requirements`
+    *   `[ ]`   The action must call through the API layer: store → `api.dialectic().regenerateDocument()` → edge function — NOT directly to Supabase
+    *   `[ ]`   After successful regeneration, `hydrateAllStageProgress` must be called to refresh progress — the progress tracker is the source of truth for UI state transitions
+    *   `[ ]`   Job IDs must be tracked in `generatingSessions` so lifecycle events from the worker are correctly processed by existing `_handleDialecticLifecycleEvent` handlers
+    *   `[ ]`   `generatingForStageSlug` must be set so the StageRunChecklist shows generating spinners for affected documents
+
+*   `[ ]`   [UI] apps/web/`StageRunChecklist` **Per-document regenerate button with model selection dialog**
+  *   `[ ]`   `objective`
+    *   `[ ]`   Replace the static status circle indicators with clickable icon-buttons that trigger document regeneration
+    *   `[ ]`   Color the icon-button based on document status: green for completed, red for failed, amber for not started — preserving the existing visual language
+    *   `[ ]`   Keep the `Loader2` spinner for `generating`/`continuing` states as non-clickable (cannot regenerate mid-generation)
+    *   `[ ]`   On click, show a model-selection confirmation dialog listing all models for that document with checkboxes
+    *   `[ ]`   Pre-check models whose status is `Failed` or `Not started`; leave `Completed` models unchecked (user must actively opt in to re-roll a successful document)
+    *   `[ ]`   Disable the regenerate button when the document's stage is not the session's current stage
+    *   `[ ]`   On confirmation, call the `regenerateDocument` store action with the selected `{ jobId, modelId }` pairs
+  *   `[ ]`   `role`
+    *   `[ ]`   UI / presentation — user-facing regeneration trigger
+  *   `[ ]`   `module`
+    *   `[ ]`   Dialectic UI — StageRunChecklist component within the stage sidebar
+    *   `[ ]`   Boundary: reads document status from store selectors → presents regeneration UI → dispatches store action
+  *   `[ ]`   `deps`
+    *   `[ ]`   Store node (above) — `regenerateDocument` action must exist on the store
+    *   `[ ]`   `RegenerateDocumentPayload` type from `@paynless/types`
+    *   `[ ]`   Existing `perModelLabels` computed in `computeStageRunChecklistData` — provides `modelId`, `displayName`, `statusLabel` per model per document
+    *   `[ ]`   Existing `StageDocumentRow` type — provides `entry` (with `documentKey`, `status`, `jobId`, `stepKey`) and `perModelLabels`
+    *   `[ ]`   Existing store selectors: `selectActiveContextSessionId`, `selectActiveStageSlug`
+    *   `[ ]`   Session's `current_stage_id` — to determine if the document's stage is the active stage (for the gate)
+    *   `[ ]`   `useDialecticStore` — for accessing store state and actions
+    *   `[ ]`   No reverse dependency introduced — leaf component
+  *   `[ ]`   `context_slice`
+    *   `[ ]`   `regenerateDocument: state.regenerateDocument` — store action
+    *   `[ ]`   `activeSessionDetail` — for `current_stage_id` and `iteration_count`
+    *   `[ ]`   `activeStageSlug` — to determine if the current stage matches the session's current stage
+    *   `[ ]`   `perModelLabels` — already computed per document row, provides model status for pre-checking
+    *   `[ ]`   `entry.jobId` — the original EXECUTE job ID per model (needed for the payload)
+    *   `[ ]`   Note: `entry.jobId` in `StageDocumentEntry` currently holds the first rendered entry's job ID, which is a RENDER job ID, not an EXECUTE job ID. The dialog needs the EXECUTE job ID. This may require enriching `perModelLabels` or `StageDocumentEntry` with per-model EXECUTE job IDs from `stageRunProgress` descriptors.
+  *   `[ ]`   interface/`StageRunChecklist types`
+    *   `[ ]`   Extend `PerModelLabel` to include `jobId: string | null` — the EXECUTE job ID for that model's document, sourced from the rendered document descriptor's `job_id` field (which tracks the EXECUTE job, not the RENDER job)
+    *   `[ ]`   `RegenerateDocumentDialogProps`: `{ open: boolean; documentKey: string; stageSlug: string; perModelLabels: PerModelLabel[]; onConfirm: (selectedJobs: Array<{ jobId: string; modelId: string }>) => void; onCancel: () => void }`
+  *   `[ ]`   unit/`StageRunChecklist.test.tsx`
+    *   `[ ]`   Test: completed document renders green clickable icon-button (not static circle)
+    *   `[ ]`   Test: failed document renders red clickable icon-button
+    *   `[ ]`   Test: not-started document renders amber clickable icon-button
+    *   `[ ]`   Test: generating document renders non-clickable spinner (existing behavior preserved)
+    *   `[ ]`   Test: clicking icon-button opens model selection dialog with correct model list
+    *   `[ ]`   Test: dialog pre-checks failed models, leaves completed models unchecked
+    *   `[ ]`   Test: confirming dialog with selected models calls `regenerateDocument` with correct payload
+    *   `[ ]`   Test: icon-button is disabled when document's stage ≠ session's current stage
+    *   `[ ]`   Test: canceling dialog does not call `regenerateDocument`
+  *   `[ ]`   `construction`
+    *   `[ ]`   `RegenerateDocumentDialog` — small inline component or extracted component for the model selection confirmation
+    *   `[ ]`   Replace `<span>` circle elements with `<button>` icon-buttons retaining the same color classes
+    *   `[ ]`   Add state for dialog open/close and selected document context
+    *   `[ ]`   Wire dialog confirm to `regenerateDocument` store action
+  *   `[ ]`   `StageRunChecklist.tsx`
+    *   `[ ]`   Add `regenerateDocument` from store to component's store subscription
+    *   `[ ]`   Add `activeSessionDetail` to determine current stage for the gate
+    *   `[ ]`   Add state: `regenerateDialogOpen`, `regenerateDialogContext` (documentKey, stageSlug, perModelLabels)
+    *   `[ ]`   Replace static `<span>` circles (lines 538-554) with `<button>` elements that open the dialog on click
+    *   `[ ]`   Preserve `Loader2` spinner for generating/continuing states as non-clickable
+    *   `[ ]`   Implement `RegenerateDocumentDialog` with checkboxes per model, pre-fill logic, confirm/cancel
+    *   `[ ]`   Enrich `perModelLabels` computation (in `computeStageRunChecklistData`) to include the EXECUTE `jobId` per model by reading from `stageRunProgress` document descriptors
+    *   `[ ]`   On confirm: construct `RegenerateDocumentPayload` and call `regenerateDocument`
   *   `[ ]`   `directionality`
     *   `[ ]`   Layer: UI / presentation
-    *   `[ ]`   Dependencies face inward: consumes store (selectors, actions) and types (constants)
+    *   `[ ]`   Dependencies face inward: consumes store (selectors, actions) and types
     *   `[ ]`   No outward-facing provides — this is a leaf component
   *   `[ ]`   `requirements`
-    *   `[ ]`   Paused state detection MUST come from `selectUnifiedProjectProgress` → `stageStatus === 'paused_nsf'` — this is durable across refresh, navigation, and tab close because it is hydrated from the backend on mount via `useStageRunProgressHydration`
-    *   `[ ]`   The Generate button must be disabled when wallet balance is below the per-stage threshold, showing "Insufficient Balance" — UX gate preventing users from starting generations they cannot afford
-    *   `[ ]`   When NSF pause is active and balance is insufficient, button shows "Add Funds to Resume" (disabled) — directing the user toward the payment resolution path
-    *   `[ ]`   When NSF pause is active and balance is sufficient, button shows "Resume {displayName}" (enabled) — the user clicks the SAME button they originally used to Generate
-    *   `[ ]`   Clicking "Resume" calls `resumePausedNsfJobs` (NOT `generateContributions`) — this restores original job statuses via the API → edge function → RPC path and the DAG resumes naturally through existing trigger infrastructure
-    *   `[ ]`   The DAG progress dialog must open on resume click so the user can monitor resumed generation
-    *   `[ ]`   All existing button states and behaviors must be preserved — new states are inserted into the priority chain without disrupting existing logic
-    *   `[ ]`   Balance thresholds: thesis=200,000 / antithesis=400,000 / synthesis=1,000,000 / parenthesis=250,000 / paralysis=250,000
-    *   `[ ]`   **Frontend NSF workflow note**: The full UX flow (catch NSF notification → redirect to payment portal → catch return → enable Resume) is a known future requirement but is NOT in scope for this node. This node implements the button states and resume action only. The notification-to-portal redirect flow will be a separate checklist item.
-  *   `[ ]`   **Commit** `feat(ui,store) apps/web + packages/store + packages/utils + packages/types NSF protection with durable progress-based pause detection, API-layer resume, frontend notification pipeline, per-stage balance gate, and single-notification UX flow`
-    *   `[ ]`   New frontend types: `ContributionGenerationPausedNsfPayload`, `STAGE_BALANCE_THRESHOLDS`, `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` in `packages/types/src/dialectic.types.ts`
-    *   `[ ]`   Updated: `DialecticNotificationTypes` union, `DialecticLifecycleEvent` union, `UnifiedProjectStatus`, `DialecticActions` in `packages/types/src/dialectic.types.ts`
-    *   `[ ]`   Updated: `isDialecticLifecycleEventType` in `packages/utils/src/type_guards.ts` — recognizes `paused_nsf` suffix
-    *   `[ ]`   Updated: `notificationStore.ts` — new `case 'contribution_generation_paused_nsf'` for payload extraction and routing
-    *   `[ ]`   Updated: `dialecticStore.ts` — `_handleContributionGenerationPausedNsf` handler with progress re-hydration, `resumePausedNsfJobs` action via API layer
-    *   `[ ]`   Updated: `dialecticStore.selectors.ts` — `paused_nsf` handling in `selectUnifiedProjectProgress`
-    *   `[ ]`   Modified: `StageDAGProgressDialog.tsx` — `paused_nsf` color in `STATUS_FILL`
-    *   `[ ]`   Modified: `GenerateContributionButton.tsx` — balance threshold gate, progress-based paused NSF detection, resume-via-same-button UX
-    *   `[ ]`   New tests: type guard tests, notification store routing tests, dialectic store NSF handler/action tests, selector paused_nsf mapping tests, DAG dialog color test, button state transition tests
+    *   `[ ]`   Visual language must be preserved: green = completed, red = failed, amber = not started, blue spinner = generating
+    *   `[ ]`   The regenerate button must be visually distinguishable as clickable (not just a colored dot) — an icon-button with the status color
+    *   `[ ]`   The model selection dialog must pre-check only failed/not-started models — completed models require active user opt-in
+    *   `[ ]`   Active-stage-only gate: the button is disabled (or hidden) for documents on stages that are not the session's current stage
+    *   `[ ]`   The dialog must show model display names (not IDs) — these are already available in `perModelLabels.displayName`
+    *   `[ ]`   If only one model is selected for the session, skip the dialog and regenerate directly (single-model fast path)
+    *   `[ ]`   The user must be able to cancel without side effects
+  *   `[ ]`   **Commit** `feat(be,api,store,ui) Regenerate individual documents — superseded job status, EXECUTE job cloning, API client, store action, and per-document regenerate button with model selection`
+    *   `[ ]`   New migration: `superseded` terminal job status in `handle_job_completion()`
+    *   `[ ]`   Updated: `deriveStepStatuses.ts` — skip `superseded` jobs in status derivation
+    *   `[ ]`   New handler: `regenerateDocument.ts` in `dialectic-service` — clone EXECUTE jobs, mark originals superseded
+    *   `[ ]`   Updated: `dialectic-service/index.ts` — route `regenerateDocument` action
+    *   `[ ]`   Updated: `dialectic.interface.ts` — `RegenerateDocumentPayload`, `RegenerateDocumentResponse`, `RegenerateDocumentAction`, `ActionHandlers`
+    *   `[ ]`   New API method: `regenerateDocument()` in `packages/api/src/dialectic.api.ts`
+    *   `[ ]`   Updated: `dialectic.api.mock.ts` — mock for `regenerateDocument`
+    *   `[ ]`   New frontend types: `RegenerateDocumentPayload`, `RegenerateDocumentResponse` in `packages/types/src/dialectic.types.ts`
+    *   `[ ]`   Updated: `DialecticActions` in `packages/types/src/dialectic.types.ts` — `regenerateDocument` action signature
+    *   `[ ]`   New store action: `regenerateDocument` in `packages/store/src/dialecticStore.ts`
+    *   `[ ]`   Updated: `StageRunChecklist.tsx` — per-document regenerate icon-buttons, model selection dialog, active-stage gate
+    *   `[ ]`   New tests: migration validation, `deriveStepStatuses` superseded tests, `regenerateDocument` handler unit tests, API client tests, store action tests, StageRunChecklist UI tests
 
-    
 # ToDo
 
     - Regenerate individual specific documents on demand without regenerating inputs or other sibling documents 
@@ -786,3 +1179,7 @@ A user cannot begin a set of work when they have NSF. If a user reaches NSF whil
    - DynamicProgressBar uses formal names instead of friendly names
    - SessionContributionsDisplayCard uses formal names instead of friendly names 
    - SessionInfoCard uses formal names instead of friendly names 
+
+   - Move "Generate" button into StageRunCard left hand side where the icons are 
+
+    - The full UX flow (catch NSF notification → redirect to payment portal → catch return → enable Resume) is a known future requirement but is NOT in scope for this node. This node implements the button states and resume action only. The notification-to-portal redirect flow will be a separate checklist item.

--- a/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
+++ b/docs/implementations/Current/Checklists/Current/NSF Pause and Resume.md
@@ -373,48 +373,48 @@ A user cannot begin a set of work when they have NSF. If a user reaches NSF whil
     *   `[✅]`   The routing case, handler signature, and `defaultHandlers` entry must follow the existing patterns exactly
 
 ### Node 8
-*   `[ ]`   [API] packages/api/src/`dialectic.api` **Add `resumePausedNsfJobs` method to `DialecticApiClient` interface and implementation**
-  *   `[ ]`   `objective`
-    *   `[ ]`   Add a `resumePausedNsfJobs` method to the `DialecticApiClient` interface in `packages/types/src/dialectic.types.ts` and the `DialecticApiClientImpl` class in `packages/api/src/dialectic.api.ts` so that the frontend store can call the backend resume handler through the established API layer
-    *   `[ ]`   Add `ResumePausedNsfJobsPayload` and `ResumePausedNsfJobsResponse` frontend types
-  *   `[ ]`   `role`
-    *   `[ ]`   Port — API layer bridge between the frontend store and the backend edge function
-  *   `[ ]`   `module`
-    *   `[ ]`   Dialectic API client — extends the existing standardized interface for frontend-to-backend communication
-    *   `[ ]`   Boundary: receives typed payload from store → sends `POST { action: 'resumePausedNsfJobs', payload }` to `dialectic-service` → returns typed response
-  *   `[ ]`   `deps`
-    *   `[ ]`   Node 7 (resume handler) — the `dialectic-service` edge function must have the `resumePausedNsfJobs` routing case before this API method can successfully call it
-    *   `[ ]`   `this.apiClient.post` — existing infrastructure for sending typed POST requests to edge functions
-    *   `[ ]`   `DialecticServiceActionPayload` — existing generic type used by `apiClient.post` for the request body shape
-    *   `[ ]`   No reverse dependency introduced — this is consumed by the dialectic store (Node 11)
-  *   `[ ]`   `context_slice`
-    *   `[ ]`   `apiClient.post<TResponse, TPayload>(edgeFunctionName, payload)` — the standard method for calling edge functions, used by `getAllStageProgress` (line 659), `generateContributions` (line 521), and all other API methods
-    *   `[ ]`   `DialecticApiClient` interface (dialectic.types.ts line 1043) — the interface that the store depends on
-  *   `[ ]`   interface/`dialectic.types.ts`
-    *   `[ ]`   `ResumePausedNsfJobsPayload` — `{ sessionId: string; stageSlug: string; iterationNumber: number }` — matches the backend `ResumePausedNsfJobsPayload` in `dialectic.interface.ts`
-    *   `[ ]`   `ResumePausedNsfJobsResponse` — `{ resumedCount: number }` — matches the backend response
-    *   `[ ]`   Add `resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>;` to the `DialecticApiClient` interface (line 1043)
-  *   `[ ]`   unit/`dialectic.api.test.ts`
-    *   `[ ]`   Test: `resumePausedNsfJobs` calls `apiClient.post` with `action: 'resumePausedNsfJobs'` and the correct payload
-    *   `[ ]`   Test: on success, returns `{ data: { resumedCount: N }, status: 200 }`
-    *   `[ ]`   Test: on error, returns `{ error: { message: '...' }, status: 500 }`
-  *   `[ ]`   `construction`
-    *   `[ ]`   No new class — method added to existing `DialecticApiClientImpl`
-  *   `[ ]`   `dialectic.api.ts`
-    *   `[ ]`   Add import of `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` from `@paynless/types` (add to existing import block)
-    *   `[ ]`   Add method following the `getAllStageProgress` pattern (line 656):
-      *   `[ ]`   `async resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>`
-      *   `[ ]`   Body: `const response = await this.apiClient.post<ResumePausedNsfJobsResponse, DialecticServiceActionPayload>('dialectic-service', { action: 'resumePausedNsfJobs', payload });`
-      *   `[ ]`   Error logging and return following the `getAllStageProgress` pattern
-  *   `[ ]`   `directionality`
-    *   `[ ]`   Layer: port (API client)
-    *   `[ ]`   Dependencies face inward: depends on `apiClient` (infra) for HTTP communication
-    *   `[ ]`   Provides face outward: consumed by the dialectic store (Node 11) via `api.dialectic().resumePausedNsfJobs(payload)`
-  *   `[ ]`   `requirements`
-    *   `[ ]`   The API method must follow the same pattern as `getAllStageProgress` and `generateContributions` — `POST` to `dialectic-service` with `action` and `payload`
-    *   `[ ]`   The frontend payload and response types must mirror the backend types
-    *   `[ ]`   The method must be declared on the `DialecticApiClient` interface so the store depends on the interface, not the implementation
-    *   `[ ]`   Error handling must follow the existing pattern — log errors, return `ApiResponse` with error details
+*   `[✅]`   [API] packages/api/src/`dialectic.api` **Add `resumePausedNsfJobs` method to `DialecticApiClient` interface and implementation**
+  *   `[✅]`   `objective`
+    *   `[✅]`   Add a `resumePausedNsfJobs` method to the `DialecticApiClient` interface in `packages/types/src/dialectic.types.ts` and the `DialecticApiClientImpl` class in `packages/api/src/dialectic.api.ts` so that the frontend store can call the backend resume handler through the established API layer
+    *   `[✅]`   Add `ResumePausedNsfJobsPayload` and `ResumePausedNsfJobsResponse` frontend types
+  *   `[✅]`   `role`
+    *   `[✅]`   Port — API layer bridge between the frontend store and the backend edge function
+  *   `[✅]`   `module`
+    *   `[✅]`   Dialectic API client — extends the existing standardized interface for frontend-to-backend communication
+    *   `[✅]`   Boundary: receives typed payload from store → sends `POST { action: 'resumePausedNsfJobs', payload }` to `dialectic-service` → returns typed response
+  *   `[✅]`   `deps`
+    *   `[✅]`   Node 7 (resume handler) — the `dialectic-service` edge function must have the `resumePausedNsfJobs` routing case before this API method can successfully call it
+    *   `[✅]`   `this.apiClient.post` — existing infrastructure for sending typed POST requests to edge functions
+    *   `[✅]`   `DialecticServiceActionPayload` — existing generic type used by `apiClient.post` for the request body shape
+    *   `[✅]`   No reverse dependency introduced — this is consumed by the dialectic store (Node 11)
+  *   `[✅]`   `context_slice`
+    *   `[✅]`   `apiClient.post<TResponse, TPayload>(edgeFunctionName, payload)` — the standard method for calling edge functions, used by `getAllStageProgress` (line 659), `generateContributions` (line 521), and all other API methods
+    *   `[✅]`   `DialecticApiClient` interface (dialectic.types.ts line 1043) — the interface that the store depends on
+  *   `[✅]`   interface/`dialectic.types.ts`
+    *   `[✅]`   `ResumePausedNsfJobsPayload` — `{ sessionId: string; stageSlug: string; iterationNumber: number }` — matches the backend `ResumePausedNsfJobsPayload` in `dialectic.interface.ts`
+    *   `[✅]`   `ResumePausedNsfJobsResponse` — `{ resumedCount: number }` — matches the backend response
+    *   `[✅]`   Add `resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>;` to the `DialecticApiClient` interface (line 1043)
+  *   `[✅]`   unit/`dialectic.api.test.ts`
+    *   `[✅]`   Test: `resumePausedNsfJobs` calls `apiClient.post` with `action: 'resumePausedNsfJobs'` and the correct payload
+    *   `[✅]`   Test: on success, returns `{ data: { resumedCount: N }, status: 200 }`
+    *   `[✅]`   Test: on error, returns `{ error: { message: '...' }, status: 500 }`
+  *   `[✅]`   `construction`
+    *   `[✅]`   No new class — method added to existing `DialecticApiClientImpl`
+  *   `[✅]`   `dialectic.api.ts`
+    *   `[✅]`   Add import of `ResumePausedNsfJobsPayload`, `ResumePausedNsfJobsResponse` from `@paynless/types` (add to existing import block)
+    *   `[✅]`   Add method following the `getAllStageProgress` pattern (line 656):
+      *   `[✅]`   `async resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>`
+      *   `[✅]`   Body: `const response = await this.apiClient.post<ResumePausedNsfJobsResponse, DialecticServiceActionPayload>('dialectic-service', { action: 'resumePausedNsfJobs', payload });`
+      *   `[✅]`   Error logging and return following the `getAllStageProgress` pattern
+  *   `[✅]`   `directionality`
+    *   `[✅]`   Layer: port (API client)
+    *   `[✅]`   Dependencies face inward: depends on `apiClient` (infra) for HTTP communication
+    *   `[✅]`   Provides face outward: consumed by the dialectic store (Node 11) via `api.dialectic().resumePausedNsfJobs(payload)`
+  *   `[✅]`   `requirements`
+    *   `[✅]`   The API method must follow the same pattern as `getAllStageProgress` and `generateContributions` — `POST` to `dialectic-service` with `action` and `payload`
+    *   `[✅]`   The frontend payload and response types must mirror the backend types
+    *   `[✅]`   The method must be declared on the `DialecticApiClient` interface so the store depends on the interface, not the implementation
+    *   `[✅]`   Error handling must follow the existing pattern — log errors, return `ApiResponse` with error details
   *   `[ ]`   **Commit** `feat(be,api) dialectic-service resume handler, routing, and API client method for NSF job resume`
     *   `[ ]`   New handler: `resumePausedNsfJobs.ts` in `dialectic-service/`
     *   `[ ]`   Modified: `dialectic.interface.ts` — new payload, response, and action types

--- a/docs/implementations/Current/Checklists/Current/Prelaunch Fixes.md
+++ b/docs/implementations/Current/Checklists/Current/Prelaunch Fixes.md
@@ -1249,6 +1249,201 @@ The user sees per-stage progress as `completedSteps / totalSteps` and per-DAG pr
         *   `[✅]`   Node 3: `dialecticStore.selectors.ts` + `dialectic.types.ts` — selector uses backend progress counts, reports `hydrationReady`
         *   `[✅]`   Node 4: `useStageRunProgressHydration.ts` — ref guards replaced with store status, execution ordering guaranteed, retry supported
 
+*   `[✅]`   `[STORE]` packages/store/notificationStore **Handle execute lifecycle events and relax planner_started validation**
+    *   `[✅]`   `objective`
+        *   `[✅]`   Add `case` branches for `execute_started`, `execute_chunk_completed`, `execute_completed` so these events reach `_handleDialecticLifecycleEvent`
+        *   `[✅]`   Relax `planner_started` validation to make `document_key` and `modelId` optional, matching backend payload (PLAN jobs intentionally omit these)
+        *   `[✅]`   Preserve all existing case branches and their validation logic
+    *   `[✅]`   `role`
+        *   `[✅]`   Application — notification ingestion and routing to dialectic store
+    *   `[✅]`   `module`
+        *   `[✅]`   Notification store — internal event dispatch
+        *   `[✅]`   Bounded to the `handleIncomingNotification` switch statement
+    *   `[✅]`   `deps`
+        *   `[✅]`   `isDialecticLifecycleEventType` from `@paynless/utils` — domain utility — inward dependency
+        *   `[✅]`   `ExecuteStartedPayload`, `ExecuteChunkCompletedPayload`, `ExecuteCompletedPayload`, `PlannerStartedPayload` from `@paynless/types` — domain types — inward dependency
+        *   `[✅]`   `_handleDialecticLifecycleEvent` from `useDialecticStore` — application — lateral dependency (existing, unchanged)
+        *   `[✅]`   Confirm no reverse dependency is introduced
+    *   `[✅]`   `context_slice`
+        *   `[✅]`   Injection via Zustand store — no changes to store shape
+        *   `[✅]`   Confirm no concrete imports from higher or lateral layers
+    *   `[✅]`   interface/`dialectic.types.ts`
+        *   `[✅]`   `PlannerStartedPayload` — override `document_key` and `modelId` as optional (do not change base `DocumentLifecyclePayload` — other consumers need them required)
+        *   `[✅]`   `ExecuteStartedPayload`, `ExecuteChunkCompletedPayload`, `ExecuteCompletedPayload` — verify already defined, no changes needed
+    *   `[✅]`   interface/tests/`type_guards.dialectic.test.ts`
+        *   `[✅]`   Contract: `isDialecticLifecycleEventType('execute_started')` returns `true`
+        *   `[✅]`   Contract: `isDialecticLifecycleEventType('execute_chunk_completed')` returns `true`
+        *   `[✅]`   Contract: `isDialecticLifecycleEventType('execute_completed')` returns `true`
+        *   `[✅]`   Confirm existing contracts for `planner_started`, `document_*`, `render_completed`, `job_failed`, `contribution_*`, `dialectic_contribution_*` unchanged
+    *   `[✅]`   interface/guards/`type_guards.ts`
+        *   `[✅]`   Add `execute_started`, `execute_chunk_completed`, `execute_completed` to the string comparison block in `isDialecticLifecycleEventType`
+    *   `[✅]`   unit/`notificationStore.test.ts`
+        *   `[✅]`   Test: `execute_started` notification with valid data dispatches to `_handleDialecticLifecycleEvent`
+        *   `[✅]`   Test: `execute_chunk_completed` notification with valid data dispatches to `_handleDialecticLifecycleEvent`
+        *   `[✅]`   Test: `execute_completed` notification with valid data (including optional `latestRenderedResourceId`) dispatches to `_handleDialecticLifecycleEvent`
+        *   `[✅]`   Test: `planner_started` notification **without** `document_key` and `modelId` dispatches successfully
+        *   `[✅]`   Test: `planner_started` notification **with** `document_key` and `modelId` still dispatches successfully
+        *   `[✅]`   Confirm all existing notification tests unchanged
+    *   `[✅]`   `construction`
+        *   `[✅]`   No new functions — additions are `case` branches within existing `handleIncomingNotification`
+        *   `[✅]`   Validation pattern: match existing case style (check required fields with `typeof`, assign optional fields conditionally)
+    *   `[✅]`   `notificationStore.ts`
+        *   `[✅]`   Add `case 'execute_started'` — validate `sessionId`, `stageSlug`, `iterationNumber`, `job_id`, `modelId` required; `document_key`, `step_key` optional
+        *   `[✅]`   Add `case 'execute_chunk_completed'` — same as `execute_started` plus optional `isFinalChunk`, `continuationNumber`
+        *   `[✅]`   Add `case 'execute_completed'` — same as `execute_started` plus optional `latestRenderedResourceId`
+        *   `[✅]`   Modify `case 'planner_started'` — make `document_key` and `modelId` optional (conditional `typeof` assignment like `step_key` already does)
+    *   `[✅]`   provides/`notificationStore.provides.ts`
+        *   `[✅]`   Not applicable — `useNotificationStore` is the existing Zustand export, unchanged
+    *   `[✅]`   `notificationStore.mock.ts`
+        *   `[✅]`   Not required — no new exported surface; existing mock (if any) unchanged
+    *   `[✅]`   integration/`notificationStore.integration.test.ts`
+        *   `[✅]`   Not required — changes are internal routing logic, covered by unit tests
+    *   `[✅]`   `directionality`
+        *   `[✅]`   Layer: application
+        *   `[✅]`   All dependencies inward-facing (types, utils)
+        *   `[✅]`   Provides outward to: UI components via Zustand subscription
+    *   `[✅]`   `requirements`
+        *   `[✅]`   `execute_started`, `execute_chunk_completed`, `execute_completed` events reach `_handleDialecticLifecycleEvent`
+        *   `[✅]`   `planner_started` events from backend (without `document_key`/`modelId`) no longer produce the "data payload did not match" warning
+        *   `[✅]`   All existing event types continue to work unchanged
+        *   `[✅]`   DAG popup receives progress updates for both plan and execute phases
+    *   `[✅]`   **Commit** `fix(store) packages/utils + packages/store add execute lifecycle event handling and relax planner_started validation to match backend payloads`
+        *   `[✅]`   `dialectic.types.ts` — updated `PlannerStartedPayload` to allow optional `document_key`/`modelId`
+        *   `[✅]`   `type_guards.ts` — added execute event types to `isDialecticLifecycleEventType`
+        *   `[✅]`   `type_guards.dialectic.test.ts` — added contracts for execute event types
+        *   `[✅]`   `notificationStore.ts` — added execute case branches, relaxed planner_started validation
+        *   `[✅]`   `notificationStore.test.ts` — added tests for execute events and planner_started without document_key/modelId
+
+*   `[ ]` supabase/functions/dialectic-worker/`executeModelCallAndSave` **[BE] Gate RENDER job enqueue behind continuation completion**
+    *   `[ ]` `objective`
+        *   `[ ]` Prevent RENDER jobs from being enqueued for intermediate continuation chunks that contain incomplete JSON fragments
+        *   `[ ]` RENDER jobs must only be enqueued when `needsContinuation` is false (i.e., the current chunk is the final chunk in the continuation chain, or the response completed without needing continuation)
+        *   `[ ]` Preserve existing behavior for non-continuation responses (single-chunk responses that complete with `finish_reason: 'stop'` must still enqueue RENDER jobs immediately)
+    *   `[ ]` `role`
+        *   `[ ]` Infrastructure — orchestrator function that coordinates AI model calls, response storage, continuation dispatch, and downstream job enqueue
+    *   `[ ]` `module`
+        *   `[ ]` Dialectic worker pipeline: the RENDER job enqueue section (lines ~1504–1751) currently runs unconditionally after every chunk save
+        *   `[ ]` The fix wraps the RENDER job enqueue block in a `!needsContinuation` guard so it only fires on the terminal chunk
+    *   `[ ]` `deps`
+        *   `[ ]` `needsContinuation` (local boolean, already computed at line 1789) — must be moved or duplicated earlier in the function, before the RENDER enqueue block at line 1504
+        *   `[ ]` `shouldContinue` (local boolean, line 1102) — already available at the RENDER enqueue site
+        *   `[ ]` `job.payload.continueUntilComplete` (payload field) — already available
+        *   `[ ]` No new external dependencies introduced
+        *   `[ ]` Confirm no reverse dependency is introduced
+    *   `[ ]` `context_slice`
+        *   `[ ]` Requires `shouldContinue` and `job.payload.continueUntilComplete` to compute `needsContinuation` earlier in the function
+        *   `[ ]` No new injection shape needed — uses existing local variables
+        *   `[ ]` Confirm no concrete imports from higher or lateral layers
+    *   `[ ]` unit/`executeModelCallAndSave.render.test.ts`
+        *   `[ ]` Test: when `shouldContinue` is true and `continueUntilComplete` is true (`needsContinuation` = true), no RENDER job is inserted into `dialectic_generation_jobs`
+        *   `[ ]` Test: when `shouldContinue` is false (final chunk, `finish_reason: 'stop'`), RENDER job IS enqueued as before
+        *   `[ ]` Test: when `continueUntilComplete` is false (no continuation opted in), RENDER job IS enqueued as before even if `shouldContinue` would be true
+        *   `[ ]` Test: single-chunk non-continuation response still enqueues RENDER job (regression guard)
+    *   `[ ]` `construction`
+        *   `[ ]` Move computation of `needsContinuation` (currently at line 1789: `job.payload.continueUntilComplete && shouldContinue`) to immediately after the sanitize/parse decision block (after line 1178), so it is available before the RENDER enqueue section
+        *   `[ ]` Keep the existing `needsContinuation` reference at line 1789 working (use the same variable)
+        *   `[ ]` No new objects or factories required
+    *   `[ ]` `executeModelCallAndSave.ts`
+        *   `[ ]` Move `const needsContinuation = job.payload.continueUntilComplete && shouldContinue;` from line 1789 to after line 1178 (after the sanitize/parse/content-level-continuation-flag block completes)
+        *   `[ ]` Wrap the RENDER job enqueue block (lines ~1504–1751, starting at `const { shouldRender, reason, details } = ...`) inside `if (!needsContinuation) { ... }`
+        *   `[ ]` Remove the duplicate `needsContinuation` declaration at the old location (line 1789) and reference the earlier variable
+        *   `[ ]` Preserve all existing RENDER enqueue logic, error handling, and logging unchanged inside the guard
+    *   `[ ]` `requirements`
+        *   `[ ]` Intermediate continuation chunks (chunks 1..N-1) must NOT trigger a RENDER job
+        *   `[ ]` The final chunk (or a single non-continuation chunk) MUST trigger a RENDER job for markdown outputs, exactly as before
+        *   `[ ]` `assembleAndSaveFinalDocument` path (line 1861, gated by `isFinalChunk && !shouldRender`) must remain unaffected
+        *   `[ ]` Continuation dispatch (`continueJob` call at line 1806) must remain unaffected
+        *   `[ ]` All existing tests in `executeModelCallAndSave.render.test.ts` and `executeModelCallAndSave.continue.test.ts` must continue to pass
+
+*   `[ ]` supabase/functions/_shared/services/`renderDocument` **[BE] Concatenate continuation chunks before JSON.parse in renderDocument**
+    *   `[ ]` `objective`
+        *   `[ ]` Change `renderDocument` to concatenate all ordered chunk text content first, then parse the assembled string as JSON once, instead of parsing each chunk individually
+        *   `[ ]` This is a defensive-depth fix: even if a RENDER job somehow runs against incomplete chunks, the parse strategy must handle fragment-based continuations where individual chunks are not valid JSON
+    *   `[ ]` `role`
+        *   `[ ]` Infrastructure — document rendering service that assembles raw model contributions into rendered markdown documents using templates
+    *   `[ ]` `module`
+        *   `[ ]` The chunk iteration loop in `renderDocument` (lines ~308–374 in `document_renderer.ts`) currently downloads each chunk, checks if it starts with `{`, and calls `JSON.parse(text)` on each chunk individually
+        *   `[ ]` The fix changes this to: download all chunks, concatenate their text in order, then parse the concatenated result once
+    *   `[ ]` `deps`
+        *   `[ ]` `downloadText` (internal helper, already used at line 314) — no change
+        *   `[ ]` `JSON.parse` — called once on concatenated string instead of N times on individual chunks
+        *   `[ ]` `isRecord` (type guard, already imported) — no change
+        *   `[ ]` No new external dependencies introduced
+        *   `[ ]` Confirm no reverse dependency is introduced
+    *   `[ ]` `context_slice`
+        *   `[ ]` Requires the ordered chunk list (`uniqueChunks`) and `downloadText` function — both already in scope
+        *   `[ ]` No new injection shape needed
+        *   `[ ]` Confirm no concrete imports from higher or lateral layers
+    *   `[ ]` unit/`document_renderer.test.ts`
+        *   `[ ]` Test: two chunks whose individual text are JSON fragments (e.g., `{"content": "hello ` and `world"}`) are concatenated and parsed successfully into a single merged object
+        *   `[ ]` Test: single chunk with complete JSON still works (regression guard)
+        *   `[ ]` Test: multiple chunks that are each complete JSON objects still work via concatenation (the concatenated result `{...}{...}` would fail parse — decide whether to fall back to per-chunk parse or require assembled JSON; document the decision)
+        *   `[ ]` Test: non-JSON chunks (plain text not starting with `{` or `[`) are still handled by the existing plain-text path
+    *   `[ ]` `construction`
+        *   `[ ]` No new objects or factories required
+        *   `[ ]` The concatenation buffer is a local `string` variable initialized to `""`
+    *   `[ ]` `document_renderer.ts`
+        *   `[ ]` Replace the per-chunk download-and-parse loop (lines ~308–374) with a two-phase approach:
+            *   `[ ]` Phase 1: iterate over `uniqueChunks`, download each chunk's text via `downloadText`, and accumulate into an ordered array of `{ chunkId, text }` tuples
+            *   `[ ]` Phase 2: if ALL texts start with `{` or `[` (JSON-like), concatenate them in order and `JSON.parse` the concatenated result once; extract structured data from the parsed object as before
+            *   `[ ]` Phase 2 fallback: if concatenated parse fails, attempt per-chunk parse as the current code does (graceful degradation for cases where chunks are independently valid JSON)
+            *   `[ ]` Non-JSON chunks (plain text) continue through the existing `_extra_content` path unchanged
+        *   `[ ]` Preserve all existing structured data extraction logic (`content` envelope unwrap, `continuation_needed`/`stop_reason` stripping, key merging)
+        *   `[ ]` Preserve all existing logging
+    *   `[ ]` `requirements`
+        *   `[ ]` Continuation chunks that are individual JSON fragments must be parseable when concatenated in chain order
+        *   `[ ]` Single-chunk documents must render identically to current behavior
+        *   `[ ]` Non-JSON content (plain markdown text) must continue through the plain-text rendering path
+        *   `[ ]` All existing tests in `document_renderer.test.ts` and `document_renderer.examples.test.ts` must continue to pass
+        *   `[ ]` Error messages must remain actionable and include chunk IDs and storage paths
+
+*   `[ ]` supabase/functions/_shared/services/`assembleAndSaveFinalDocument` **[BE] Concatenate continuation chunks before JSON.parse in assembleAndSaveFinalDocument**
+    *   `[ ]` `objective`
+        *   `[ ]` Change `assembleAndSaveFinalDocument` to concatenate all ordered chunk text content first, then parse the assembled string as JSON once, instead of parsing each chunk individually
+        *   `[ ]` This is a defensive-depth fix for the JSON assembly path (non-rendered JSON-only artifacts): individual continuation chunks are fragments of a single JSON object and are not independently parseable
+    *   `[ ]` `role`
+        *   `[ ]` Infrastructure — file management service method that assembles continuation chain chunks into a single final JSON document for storage
+    *   `[ ]` `module`
+        *   `[ ]` The chunk download-and-parse loop in `assembleAndSaveFinalDocument` (lines ~620–651 in `file_manager.ts`) currently downloads each chunk, calls `JSON.parse(textContent)` on each chunk individually, validates each is a record, then deep-merges them
+        *   `[ ]` The fix changes this to: download all chunks, concatenate their text in order, parse the concatenated result once, then proceed with the existing merge/upload logic
+    *   `[ ]` `deps`
+        *   `[ ]` `this.supabase.storage.from().download()` — already used, no change
+        *   `[ ]` `JSON.parse` — called once on concatenated string instead of N times
+        *   `[ ]` `isRecord` (type guard, already imported) — called once on the final parsed result
+        *   `[ ]` No new external dependencies introduced
+        *   `[ ]` Confirm no reverse dependency is introduced
+    *   `[ ]` `context_slice`
+        *   `[ ]` Requires the ordered chunk list (`orderedChunks`) and Supabase storage client — both already in scope
+        *   `[ ]` No new injection shape needed
+        *   `[ ]` Confirm no concrete imports from higher or lateral layers
+    *   `[ ]` unit/`file_manager.assemble.test.ts`
+        *   `[ ]` Test: two chunks whose individual text are JSON fragments (e.g., `{"key": "val` and `ue", "key2": "v2"}`) are concatenated and parsed successfully
+        *   `[ ]` Test: single-chunk assembly still works (regression guard — concatenation of one string is the same string)
+        *   `[ ]` Test: error message when concatenated JSON still fails to parse includes all chunk IDs and the parse error detail
+        *   `[ ]` Test: the parsed result must be validated as a record via `isRecord` (existing behavior preserved)
+    *   `[ ]` `construction`
+        *   `[ ]` No new objects or factories required
+        *   `[ ]` The concatenation buffer is a local `string` variable
+    *   `[ ]` `file_manager.ts` / `assembleAndSaveFinalDocument`
+        *   `[ ]` Replace the per-chunk download-parse-validate loop (lines ~620–651) with a two-phase approach:
+            *   `[ ]` Phase 1: iterate over `orderedChunks`, download each chunk's content via storage, decode to text, and accumulate text strings in order
+            *   `[ ]` Phase 2: concatenate all text strings in order, `JSON.parse` the concatenated result once
+            *   `[ ]` Validate the parsed result is a record via `isRecord`
+        *   `[ ]` Remove the per-chunk `parsedChunks` array and the per-chunk deep-merge loop (lines ~660–695) — since the concatenated result is already a single complete JSON object, no merging is needed; the parsed object IS the final document
+        *   `[ ]` Preserve all existing error handling: if concatenation parse fails, throw with chunk IDs and storage paths for diagnostics
+        *   `[ ]` Preserve the existing upload-to-assembled-path logic and `is_latest_edit` flag management unchanged
+    *   `[ ]` `requirements`
+        *   `[ ]` Continuation chunks that are individual JSON fragments must be parseable when concatenated in chain order
+        *   `[ ]` Single-chunk assembly must produce identical output to current behavior
+        *   `[ ]` Parse errors must include diagnostic information (chunk IDs, storage paths, parse error message)
+        *   `[ ]` All existing tests in `file_manager.assemble.test.ts` must continue to pass
+        *   `[ ]` The `shouldRender` guard (lines 708–724) that prevents this method from being called on rendered documents must remain unchanged
+    *   `[ ]` **Commit** `fix(be) supabase/functions gate RENDER enqueue behind continuation completion and concatenate continuation chunks before JSON.parse in renderDocument and assembleAndSaveFinalDocument`
+        *   `[ ]` `executeModelCallAndSave.ts`: moved `needsContinuation` computation earlier; wrapped RENDER enqueue block in `!needsContinuation` guard
+        *   `[ ]` `document_renderer.ts`: replaced per-chunk JSON.parse with concatenate-then-parse strategy for continuation chunk support
+        *   `[ ]` `file_manager.ts` / `assembleAndSaveFinalDocument`: replaced per-chunk JSON.parse with concatenate-then-parse strategy for continuation chunk support
+        *   `[ ]` Updated tests in `executeModelCallAndSave.render.test.ts`, `document_renderer.test.ts`, and `file_manager.assemble.test.ts`
+
 # ToDo
 
     - Regenerate individual specific documents on demand without regenerating inputs or other sibling documents 
@@ -1325,8 +1520,6 @@ The user sees per-stage progress as `completedSteps / totalSteps` and per-DAG pr
    --- Conservative / base / aggressive
    --- IS, BS, CF 
    -- A "generate next set of work" for the implementation stage 
-
-   x Change "Generate {stage}" button to use semantic names 
 
    - DynamicProgressBar uses formal names instead of friendly names
    - SessionContributionsDisplayCard uses formal names instead of friendly names 

--- a/docs/implementations/Current/Checklists/Current/Prelaunch Fixes.md
+++ b/docs/implementations/Current/Checklists/Current/Prelaunch Fixes.md
@@ -1314,135 +1314,156 @@ The user sees per-stage progress as `completedSteps / totalSteps` and per-DAG pr
         *   `[✅]`   `notificationStore.ts` — added execute case branches, relaxed planner_started validation
         *   `[✅]`   `notificationStore.test.ts` — added tests for execute events and planner_started without document_key/modelId
 
-*   `[ ]` supabase/functions/dialectic-worker/`executeModelCallAndSave` **[BE] Gate RENDER job enqueue behind continuation completion**
-    *   `[ ]` `objective`
-        *   `[ ]` Prevent RENDER jobs from being enqueued for intermediate continuation chunks that contain incomplete JSON fragments
-        *   `[ ]` RENDER jobs must only be enqueued when `needsContinuation` is false (i.e., the current chunk is the final chunk in the continuation chain, or the response completed without needing continuation)
-        *   `[ ]` Preserve existing behavior for non-continuation responses (single-chunk responses that complete with `finish_reason: 'stop'` must still enqueue RENDER jobs immediately)
-    *   `[ ]` `role`
-        *   `[ ]` Infrastructure — orchestrator function that coordinates AI model calls, response storage, continuation dispatch, and downstream job enqueue
-    *   `[ ]` `module`
-        *   `[ ]` Dialectic worker pipeline: the RENDER job enqueue section (lines ~1504–1751) currently runs unconditionally after every chunk save
-        *   `[ ]` The fix wraps the RENDER job enqueue block in a `!needsContinuation` guard so it only fires on the terminal chunk
-    *   `[ ]` `deps`
-        *   `[ ]` `needsContinuation` (local boolean, already computed at line 1789) — must be moved or duplicated earlier in the function, before the RENDER enqueue block at line 1504
-        *   `[ ]` `shouldContinue` (local boolean, line 1102) — already available at the RENDER enqueue site
-        *   `[ ]` `job.payload.continueUntilComplete` (payload field) — already available
-        *   `[ ]` No new external dependencies introduced
-        *   `[ ]` Confirm no reverse dependency is introduced
-    *   `[ ]` `context_slice`
-        *   `[ ]` Requires `shouldContinue` and `job.payload.continueUntilComplete` to compute `needsContinuation` earlier in the function
-        *   `[ ]` No new injection shape needed — uses existing local variables
-        *   `[ ]` Confirm no concrete imports from higher or lateral layers
-    *   `[ ]` unit/`executeModelCallAndSave.render.test.ts`
-        *   `[ ]` Test: when `shouldContinue` is true and `continueUntilComplete` is true (`needsContinuation` = true), no RENDER job is inserted into `dialectic_generation_jobs`
-        *   `[ ]` Test: when `shouldContinue` is false (final chunk, `finish_reason: 'stop'`), RENDER job IS enqueued as before
-        *   `[ ]` Test: when `continueUntilComplete` is false (no continuation opted in), RENDER job IS enqueued as before even if `shouldContinue` would be true
-        *   `[ ]` Test: single-chunk non-continuation response still enqueues RENDER job (regression guard)
-    *   `[ ]` `construction`
-        *   `[ ]` Move computation of `needsContinuation` (currently at line 1789: `job.payload.continueUntilComplete && shouldContinue`) to immediately after the sanitize/parse decision block (after line 1178), so it is available before the RENDER enqueue section
-        *   `[ ]` Keep the existing `needsContinuation` reference at line 1789 working (use the same variable)
-        *   `[ ]` No new objects or factories required
-    *   `[ ]` `executeModelCallAndSave.ts`
-        *   `[ ]` Move `const needsContinuation = job.payload.continueUntilComplete && shouldContinue;` from line 1789 to after line 1178 (after the sanitize/parse/content-level-continuation-flag block completes)
-        *   `[ ]` Wrap the RENDER job enqueue block (lines ~1504–1751, starting at `const { shouldRender, reason, details } = ...`) inside `if (!needsContinuation) { ... }`
-        *   `[ ]` Remove the duplicate `needsContinuation` declaration at the old location (line 1789) and reference the earlier variable
-        *   `[ ]` Preserve all existing RENDER enqueue logic, error handling, and logging unchanged inside the guard
-    *   `[ ]` `requirements`
-        *   `[ ]` Intermediate continuation chunks (chunks 1..N-1) must NOT trigger a RENDER job
-        *   `[ ]` The final chunk (or a single non-continuation chunk) MUST trigger a RENDER job for markdown outputs, exactly as before
-        *   `[ ]` `assembleAndSaveFinalDocument` path (line 1861, gated by `isFinalChunk && !shouldRender`) must remain unaffected
-        *   `[ ]` Continuation dispatch (`continueJob` call at line 1806) must remain unaffected
-        *   `[ ]` All existing tests in `executeModelCallAndSave.render.test.ts` and `executeModelCallAndSave.continue.test.ts` must continue to pass
+*   `[✅]` supabase/functions/dialectic-worker/`executeModelCallAndSave` **[BE] Gate RENDER job enqueue behind continuation completion**
+    *   `[✅]` `objective`
+        *   `[✅]` Prevent RENDER jobs from being enqueued for intermediate continuation chunks that contain incomplete JSON fragments
+        *   `[✅]` RENDER jobs must only be enqueued when `needsContinuation` is false (i.e., the current chunk is the final chunk in the continuation chain, or the response completed without needing continuation)
+        *   `[✅]` Preserve existing behavior for non-continuation responses (single-chunk responses that complete with `finish_reason: 'stop'` must still enqueue RENDER jobs immediately)
+    *   `[✅]` `role`
+        *   `[✅]` Infrastructure — orchestrator function that coordinates AI model calls, response storage, continuation dispatch, and downstream job enqueue
+    *   `[✅]` `module`
+        *   `[✅]` Dialectic worker pipeline: the RENDER job enqueue section (lines ~1504–1751) currently runs unconditionally after every chunk save
+        *   `[✅]` The fix wraps the RENDER job enqueue block in a `!needsContinuation` guard so it only fires on the terminal chunk
+    *   `[✅]` `deps`
+        *   `[✅]` `needsContinuation` (local boolean, already computed at line 1789) — must be moved or duplicated earlier in the function, before the RENDER enqueue block at line 1504
+        *   `[✅]` `shouldContinue` (local boolean, line 1102) — already available at the RENDER enqueue site
+        *   `[✅]` `job.payload.continueUntilComplete` (payload field) — already available
+        *   `[✅]` No new external dependencies introduced
+        *   `[✅]` Confirm no reverse dependency is introduced
+    *   `[✅]` `context_slice`
+        *   `[✅]` Requires `shouldContinue` and `job.payload.continueUntilComplete` to compute `needsContinuation` earlier in the function
+        *   `[✅]` No new injection shape needed — uses existing local variables
+        *   `[✅]` Confirm no concrete imports from higher or lateral layers
+    *   `[✅]` unit/`executeModelCallAndSave.render.test.ts`
+        *   `[✅]` Test: when `shouldContinue` is true and `continueUntilComplete` is true (`needsContinuation` = true), no RENDER job is inserted into `dialectic_generation_jobs`
+        *   `[✅]` Test: when `shouldContinue` is false (final chunk, `finish_reason: 'stop'`), RENDER job IS enqueued as before
+        *   `[✅]` Test: when `continueUntilComplete` is false (no continuation opted in), RENDER job IS enqueued as before even if `shouldContinue` would be true
+        *   `[✅]` Test: single-chunk non-continuation response still enqueues RENDER job (regression guard)
+    *   `[✅]` `construction`
+        *   `[✅]` Move computation of `needsContinuation` (currently at line 1789: `job.payload.continueUntilComplete && shouldContinue`) to immediately after the sanitize/parse decision block (after line 1178), so it is available before the RENDER enqueue section
+        *   `[✅]` Keep the existing `needsContinuation` reference at line 1789 working (use the same variable)
+        *   `[✅]` No new objects or factories required
+    *   `[✅]` `executeModelCallAndSave.ts`
+        *   `[✅]` Move `const needsContinuation = job.payload.continueUntilComplete && shouldContinue;` from line 1789 to after line 1178 (after the sanitize/parse/content-level-continuation-flag block completes)
+        *   `[✅]` Wrap the RENDER job enqueue block (lines ~1504–1751, starting at `const { shouldRender, reason, details } = ...`) inside `if (!needsContinuation) { ... }`
+        *   `[✅]` Remove the duplicate `needsContinuation` declaration at the old location (line 1789) and reference the earlier variable
+        *   `[✅]` Preserve all existing RENDER enqueue logic, error handling, and logging unchanged inside the guard
+    *   `[✅]` `requirements`
+        *   `[✅]` Intermediate continuation chunks (chunks 1..N-1) must NOT trigger a RENDER job
+        *   `[✅]` The final chunk (or a single non-continuation chunk) MUST trigger a RENDER job for markdown outputs, exactly as before
+        *   `[✅]` `assembleAndSaveFinalDocument` path (line 1861, gated by `isFinalChunk && !shouldRender`) must remain unaffected
+        *   `[✅]` Continuation dispatch (`continueJob` call at line 1806) must remain unaffected
+        *   `[✅]` All existing tests in `executeModelCallAndSave.render.test.ts` and `executeModelCallAndSave.continue.test.ts` must continue to pass
 
-*   `[ ]` supabase/functions/_shared/services/`renderDocument` **[BE] Concatenate continuation chunks before JSON.parse in renderDocument**
-    *   `[ ]` `objective`
-        *   `[ ]` Change `renderDocument` to concatenate all ordered chunk text content first, then parse the assembled string as JSON once, instead of parsing each chunk individually
-        *   `[ ]` This is a defensive-depth fix: even if a RENDER job somehow runs against incomplete chunks, the parse strategy must handle fragment-based continuations where individual chunks are not valid JSON
-    *   `[ ]` `role`
-        *   `[ ]` Infrastructure — document rendering service that assembles raw model contributions into rendered markdown documents using templates
-    *   `[ ]` `module`
-        *   `[ ]` The chunk iteration loop in `renderDocument` (lines ~308–374 in `document_renderer.ts`) currently downloads each chunk, checks if it starts with `{`, and calls `JSON.parse(text)` on each chunk individually
-        *   `[ ]` The fix changes this to: download all chunks, concatenate their text in order, then parse the concatenated result once
-    *   `[ ]` `deps`
-        *   `[ ]` `downloadText` (internal helper, already used at line 314) — no change
-        *   `[ ]` `JSON.parse` — called once on concatenated string instead of N times on individual chunks
-        *   `[ ]` `isRecord` (type guard, already imported) — no change
-        *   `[ ]` No new external dependencies introduced
-        *   `[ ]` Confirm no reverse dependency is introduced
-    *   `[ ]` `context_slice`
-        *   `[ ]` Requires the ordered chunk list (`uniqueChunks`) and `downloadText` function — both already in scope
-        *   `[ ]` No new injection shape needed
-        *   `[ ]` Confirm no concrete imports from higher or lateral layers
-    *   `[ ]` unit/`document_renderer.test.ts`
-        *   `[ ]` Test: two chunks whose individual text are JSON fragments (e.g., `{"content": "hello ` and `world"}`) are concatenated and parsed successfully into a single merged object
-        *   `[ ]` Test: single chunk with complete JSON still works (regression guard)
-        *   `[ ]` Test: multiple chunks that are each complete JSON objects still work via concatenation (the concatenated result `{...}{...}` would fail parse — decide whether to fall back to per-chunk parse or require assembled JSON; document the decision)
-        *   `[ ]` Test: non-JSON chunks (plain text not starting with `{` or `[`) are still handled by the existing plain-text path
-    *   `[ ]` `construction`
-        *   `[ ]` No new objects or factories required
-        *   `[ ]` The concatenation buffer is a local `string` variable initialized to `""`
-    *   `[ ]` `document_renderer.ts`
-        *   `[ ]` Replace the per-chunk download-and-parse loop (lines ~308–374) with a two-phase approach:
-            *   `[ ]` Phase 1: iterate over `uniqueChunks`, download each chunk's text via `downloadText`, and accumulate into an ordered array of `{ chunkId, text }` tuples
-            *   `[ ]` Phase 2: if ALL texts start with `{` or `[` (JSON-like), concatenate them in order and `JSON.parse` the concatenated result once; extract structured data from the parsed object as before
-            *   `[ ]` Phase 2 fallback: if concatenated parse fails, attempt per-chunk parse as the current code does (graceful degradation for cases where chunks are independently valid JSON)
-            *   `[ ]` Non-JSON chunks (plain text) continue through the existing `_extra_content` path unchanged
-        *   `[ ]` Preserve all existing structured data extraction logic (`content` envelope unwrap, `continuation_needed`/`stop_reason` stripping, key merging)
-        *   `[ ]` Preserve all existing logging
-    *   `[ ]` `requirements`
-        *   `[ ]` Continuation chunks that are individual JSON fragments must be parseable when concatenated in chain order
-        *   `[ ]` Single-chunk documents must render identically to current behavior
-        *   `[ ]` Non-JSON content (plain markdown text) must continue through the plain-text rendering path
-        *   `[ ]` All existing tests in `document_renderer.test.ts` and `document_renderer.examples.test.ts` must continue to pass
-        *   `[ ]` Error messages must remain actionable and include chunk IDs and storage paths
+*   `[✅]` supabase/functions/_shared/services/`renderDocument` **[BE] Concatenate continuation chunks before sanitize/parse in renderDocument**
+    *   `[✅]` `objective`
+        *   `[✅]` Change `renderDocument` to concatenate all ordered chunk text content first, then run the concatenated result through `sanitizeJsonContent` → `isJsonSanitizationResult` → `JSON.parse` — the same sanitize/parse pipeline used in `executeModelCallAndSave` — instead of calling `JSON.parse` on each chunk individually
+        *   `[✅]` This is a defensive-depth fix: even if a RENDER job somehow runs against incomplete chunks, the parse strategy must handle fragment-based continuations where individual chunks are not valid JSON
+        *   `[✅]` All finished content — single-chunk or multi-chunk — must be judged by one sanitization/validation standard
+    *   `[✅]` `role`
+        *   `[✅]` Infrastructure — document rendering service that assembles raw model contributions into rendered markdown documents using templates
+    *   `[✅]` `module`
+        *   `[✅]` The chunk iteration loop in `renderDocument` (lines ~308–374 in `document_renderer.ts`) currently downloads each chunk, checks if it starts with `{`, and calls `JSON.parse(text)` on each chunk individually
+        *   `[✅]` The fix changes this to: download all chunks, attempt concatenated sanitize/parse first (normal path for continuation fragments), then if that fails attempt per-chunk sanitize/parse (normal path for independently-complete chunks), then throw if neither method produces a valid result
+    *   `[✅]` `deps`
+        *   `[✅]` `downloadText` (internal helper, already used at line 314) — no change
+        *   `[✅]` `sanitizeJsonContent` from `../utils/jsonSanitizer.ts` — **new import** required
+        *   `[✅]` `isJsonSanitizationResult` from `../utils/type_guards.ts` — **new import** required
+        *   `[✅]` `JsonSanitizationResult` from `../types/jsonSanitizer.interface.ts` — **new import** required for typing the sanitization result
+        *   `[✅]` `isRecord` (type guard, already imported) — no change
+        *   `[✅]` No new external dependencies introduced
+        *   `[✅]` Confirm no reverse dependency is introduced
+    *   `[✅]` `context_slice`
+        *   `[✅]` Requires the ordered chunk list (`uniqueChunks`) and `downloadText` function — both already in scope
+        *   `[✅]` `sanitizeJsonContent` is a pure function in `_shared/utils/` — same layer, inward-facing dependency
+        *   `[✅]` No new injection shape needed
+        *   `[✅]` Confirm no concrete imports from higher or lateral layers
+    *   `[✅]` unit/`document_renderer.test.ts`
+        *   `[✅]` Test: two chunks whose individual text are JSON fragments (e.g., `{"content": "hello ` and `world"}`) are concatenated, sanitized, and parsed successfully into a single object
+        *   `[✅]` Test: single chunk with complete JSON still works (regression guard)
+        *   `[✅]` Test: concatenated result with backtick wrappers (e.g., chunk 1 starts with `` ```json ``) is sanitized correctly before parse
+        *   `[✅]` Test: multiple chunks that are each independently complete JSON objects — concatenated parse fails, per-chunk sanitize/parse succeeds and results are merged
+        *   `[✅]` Test: non-JSON chunks (plain text not starting with `{` or `[`) are still handled by the existing plain-text path
+        *   `[✅]` Test: when both concatenated and per-chunk sanitize/parse fail, error is thrown with chunk IDs, storage paths, and parse error details
+    *   `[✅]` `construction`
+        *   `[✅]` No new objects or factories required
+        *   `[✅]` The concatenation buffer is a local `string` variable initialized to `""`
+    *   `[✅]` `document_renderer.ts`
+        *   `[✅]` Add imports: `sanitizeJsonContent` from `../utils/jsonSanitizer.ts`, `isJsonSanitizationResult` from `../utils/type_guards.ts`, `JsonSanitizationResult` from `../types/jsonSanitizer.interface.ts`
+        *   `[✅]` Replace the per-chunk download-and-parse loop (lines ~308–374) with a three-phase approach:
+            *   `[✅]` Phase 1 (download): iterate over `uniqueChunks`, download each chunk's text via `downloadText`, and accumulate into an ordered array of `{ chunkId: string, text: string, rawJsonPath: string }` tuples
+            *   `[✅]` Phase 2 (concatenated sanitize/parse — normal path for continuation fragments): if ALL trimmed texts start with `{` or `[` (JSON-like), concatenate them in order and run the concatenated result through `sanitizeJsonContent(concatenated)` → validate with `isJsonSanitizationResult` → `JSON.parse(sanitizationResult.sanitized)` → extract structured data from the parsed object as before
+            *   `[✅]` Phase 3 (per-chunk sanitize/parse — normal path for independently-complete chunks): if Phase 2 did not produce a valid parsed object (concatenated parse threw, or not all chunks were JSON-like), process each chunk individually through `sanitizeJsonContent(chunk.text)` → `isJsonSanitizationResult` → `JSON.parse(sanitizationResult.sanitized)`, merge per-chunk results using the existing structured data merge logic (`content` envelope unwrap, key merging)
+            *   `[✅]` If neither Phase 2 nor Phase 3 produces a valid parsed object, throw with chunk IDs, storage paths, sanitization details, and parse error
+            *   `[✅]` Non-JSON chunks (plain text) continue through the existing `_extra_content` path unchanged
+        *   `[✅]` Preserve all existing structured data extraction logic (`content` envelope unwrap, `continuation_needed`/`stop_reason` stripping, key merging)
+        *   `[✅]` Preserve all existing logging; add logging for sanitization events (wasSanitized, wasStructurallyFixed, hasDuplicateKeys) consistent with `executeModelCallAndSave`'s logging pattern
+    *   `[✅]` `requirements`
+        *   `[✅]` Continuation chunks that are individual JSON fragments must be parseable when concatenated and sanitized in chain order
+        *   `[✅]` Independently-complete chunks must be parseable via per-chunk sanitize/parse and merged
+        *   `[✅]` The sanitize/parse pipeline for both methods must be the same as `executeModelCallAndSave`: `sanitizeJsonContent` → `isJsonSanitizationResult` → `JSON.parse`
+        *   `[✅]` Single-chunk documents must render identically to current behavior
+        *   `[✅]` Non-JSON content (plain markdown text) must continue through the plain-text rendering path
+        *   `[✅]` If no method produces a valid parsed object, the error must propagate with actionable diagnostics including chunk IDs and storage paths
+        *   `[✅]` All existing tests in `document_renderer.test.ts` and `document_renderer.examples.test.ts` must continue to pass
 
-*   `[ ]` supabase/functions/_shared/services/`assembleAndSaveFinalDocument` **[BE] Concatenate continuation chunks before JSON.parse in assembleAndSaveFinalDocument**
-    *   `[ ]` `objective`
-        *   `[ ]` Change `assembleAndSaveFinalDocument` to concatenate all ordered chunk text content first, then parse the assembled string as JSON once, instead of parsing each chunk individually
-        *   `[ ]` This is a defensive-depth fix for the JSON assembly path (non-rendered JSON-only artifacts): individual continuation chunks are fragments of a single JSON object and are not independently parseable
-    *   `[ ]` `role`
-        *   `[ ]` Infrastructure — file management service method that assembles continuation chain chunks into a single final JSON document for storage
-    *   `[ ]` `module`
-        *   `[ ]` The chunk download-and-parse loop in `assembleAndSaveFinalDocument` (lines ~620–651 in `file_manager.ts`) currently downloads each chunk, calls `JSON.parse(textContent)` on each chunk individually, validates each is a record, then deep-merges them
-        *   `[ ]` The fix changes this to: download all chunks, concatenate their text in order, parse the concatenated result once, then proceed with the existing merge/upload logic
-    *   `[ ]` `deps`
-        *   `[ ]` `this.supabase.storage.from().download()` — already used, no change
-        *   `[ ]` `JSON.parse` — called once on concatenated string instead of N times
-        *   `[ ]` `isRecord` (type guard, already imported) — called once on the final parsed result
-        *   `[ ]` No new external dependencies introduced
-        *   `[ ]` Confirm no reverse dependency is introduced
-    *   `[ ]` `context_slice`
-        *   `[ ]` Requires the ordered chunk list (`orderedChunks`) and Supabase storage client — both already in scope
-        *   `[ ]` No new injection shape needed
-        *   `[ ]` Confirm no concrete imports from higher or lateral layers
-    *   `[ ]` unit/`file_manager.assemble.test.ts`
-        *   `[ ]` Test: two chunks whose individual text are JSON fragments (e.g., `{"key": "val` and `ue", "key2": "v2"}`) are concatenated and parsed successfully
-        *   `[ ]` Test: single-chunk assembly still works (regression guard — concatenation of one string is the same string)
-        *   `[ ]` Test: error message when concatenated JSON still fails to parse includes all chunk IDs and the parse error detail
-        *   `[ ]` Test: the parsed result must be validated as a record via `isRecord` (existing behavior preserved)
-    *   `[ ]` `construction`
-        *   `[ ]` No new objects or factories required
-        *   `[ ]` The concatenation buffer is a local `string` variable
-    *   `[ ]` `file_manager.ts` / `assembleAndSaveFinalDocument`
-        *   `[ ]` Replace the per-chunk download-parse-validate loop (lines ~620–651) with a two-phase approach:
-            *   `[ ]` Phase 1: iterate over `orderedChunks`, download each chunk's content via storage, decode to text, and accumulate text strings in order
-            *   `[ ]` Phase 2: concatenate all text strings in order, `JSON.parse` the concatenated result once
-            *   `[ ]` Validate the parsed result is a record via `isRecord`
-        *   `[ ]` Remove the per-chunk `parsedChunks` array and the per-chunk deep-merge loop (lines ~660–695) — since the concatenated result is already a single complete JSON object, no merging is needed; the parsed object IS the final document
-        *   `[ ]` Preserve all existing error handling: if concatenation parse fails, throw with chunk IDs and storage paths for diagnostics
-        *   `[ ]` Preserve the existing upload-to-assembled-path logic and `is_latest_edit` flag management unchanged
-    *   `[ ]` `requirements`
-        *   `[ ]` Continuation chunks that are individual JSON fragments must be parseable when concatenated in chain order
-        *   `[ ]` Single-chunk assembly must produce identical output to current behavior
-        *   `[ ]` Parse errors must include diagnostic information (chunk IDs, storage paths, parse error message)
-        *   `[ ]` All existing tests in `file_manager.assemble.test.ts` must continue to pass
-        *   `[ ]` The `shouldRender` guard (lines 708–724) that prevents this method from being called on rendered documents must remain unchanged
-    *   `[ ]` **Commit** `fix(be) supabase/functions gate RENDER enqueue behind continuation completion and concatenate continuation chunks before JSON.parse in renderDocument and assembleAndSaveFinalDocument`
-        *   `[ ]` `executeModelCallAndSave.ts`: moved `needsContinuation` computation earlier; wrapped RENDER enqueue block in `!needsContinuation` guard
-        *   `[ ]` `document_renderer.ts`: replaced per-chunk JSON.parse with concatenate-then-parse strategy for continuation chunk support
-        *   `[ ]` `file_manager.ts` / `assembleAndSaveFinalDocument`: replaced per-chunk JSON.parse with concatenate-then-parse strategy for continuation chunk support
-        *   `[ ]` Updated tests in `executeModelCallAndSave.render.test.ts`, `document_renderer.test.ts`, and `file_manager.assemble.test.ts`
+*   `[✅]` supabase/functions/_shared/services/`assembleAndSaveFinalDocument` **[BE] Concatenate continuation chunks before sanitize/parse in assembleAndSaveFinalDocument**
+    *   `[✅]` `objective`
+        *   `[✅]` Change `assembleAndSaveFinalDocument` to concatenate all ordered chunk text content first, then run the concatenated result through `sanitizeJsonContent` → `isJsonSanitizationResult` → `JSON.parse` — the same sanitize/parse pipeline used in `executeModelCallAndSave` — instead of calling `JSON.parse` on each chunk individually
+        *   `[✅]` This is a defensive-depth fix for the JSON assembly path (non-rendered JSON-only artifacts): individual continuation chunks are fragments of a single JSON object and are not independently parseable
+        *   `[✅]` All finished content — single-chunk or multi-chunk — must be judged by one sanitization/validation standard
+    *   `[✅]` `role`
+        *   `[✅]` Infrastructure — file management service method that assembles continuation chain chunks into a single final JSON document for storage
+    *   `[✅]` `module`
+        *   `[✅]` The chunk download-and-parse loop in `assembleAndSaveFinalDocument` (lines ~620–651 in `file_manager.ts`) currently downloads each chunk, calls `JSON.parse(textContent)` on each chunk individually, validates each is a record, then deep-merges them
+        *   `[✅]` The fix changes this to: download all chunks, attempt concatenated sanitize/parse first (normal path for continuation fragments), then if that fails attempt per-chunk sanitize/parse with merge (normal path for independently-complete chunks), then throw if neither method produces a valid result
+    *   `[✅]` `deps`
+        *   `[✅]` `this.supabase.storage.from().download()` — already used, no change
+        *   `[✅]` `sanitizeJsonContent` from `../utils/jsonSanitizer.ts` — **new import** required
+        *   `[✅]` `isJsonSanitizationResult` from `../utils/type_guards.ts` — **new import** required
+        *   `[✅]` `JsonSanitizationResult` from `../types/jsonSanitizer.interface.ts` — **new import** required for typing the sanitization result
+        *   `[✅]` `isRecord` (type guard, already imported) — called on the final parsed result regardless of which method succeeded
+        *   `[✅]` No new external dependencies introduced
+        *   `[✅]` Confirm no reverse dependency is introduced
+    *   `[✅]` `context_slice`
+        *   `[✅]` Requires the ordered chunk list (`orderedChunks`) and Supabase storage client — both already in scope
+        *   `[✅]` `sanitizeJsonContent` is a pure function in `_shared/utils/` — same layer, inward-facing dependency
+        *   `[✅]` No new injection shape needed
+        *   `[✅]` Confirm no concrete imports from higher or lateral layers
+    *   `[✅]` unit/`file_manager.assemble.test.ts`
+        *   `[✅]` Test: two chunks whose individual text are JSON fragments (e.g., `{"key": "val` and `ue", "key2": "v2"}`) are concatenated, sanitized, and parsed successfully
+        *   `[✅]` Test: single-chunk assembly still works (regression guard — concatenation of one string is the same string)
+        *   `[✅]` Test: concatenated result with backtick wrappers is sanitized correctly before parse
+        *   `[✅]` Test: multiple independently-complete chunks — concatenated parse fails, per-chunk sanitize/parse succeeds and results are deep-merged
+        *   `[✅]` Test: error message when both concatenated and per-chunk sanitize/parse fail includes all chunk IDs, storage paths, and parse error details
+        *   `[✅]` Test: the parsed result must be validated as a record via `isRecord` (existing behavior preserved)
+        *   `[✅]` Test: when sanitization result fails `isJsonSanitizationResult`, error is thrown with diagnostic info
+    *   `[✅]` `construction`
+        *   `[✅]` No new objects or factories required
+        *   `[✅]` The concatenation buffer is a local `string` variable
+    *   `[✅]` `file_manager.ts` / `assembleAndSaveFinalDocument`
+        *   `[✅]` Add imports: `sanitizeJsonContent` from `../utils/jsonSanitizer.ts`, `isJsonSanitizationResult` from `../utils/type_guards.ts`, `JsonSanitizationResult` from `../types/jsonSanitizer.interface.ts`
+        *   `[✅]` Replace the per-chunk download-parse-validate loop (lines ~620–651) with a three-phase approach:
+            *   `[✅]` Phase 1 (download): iterate over `orderedChunks`, download each chunk's content via storage, decode to text, and accumulate text strings in order (with chunk ID and storage path for diagnostics)
+            *   `[✅]` Phase 2 (concatenated sanitize/parse — normal path for continuation fragments): concatenate all text strings in order, run through `sanitizeJsonContent(concatenated)` → validate with `isJsonSanitizationResult` → `JSON.parse(sanitizationResult.sanitized)`, validate result is a record via `isRecord`
+            *   `[✅]` Phase 3 (per-chunk sanitize/parse — normal path for independently-complete chunks): if Phase 2 did not produce a valid parsed record, process each chunk individually through `sanitizeJsonContent(chunkText)` → `isJsonSanitizationResult` → `JSON.parse(sanitizationResult.sanitized)` → validate each is a record via `isRecord`, then deep-merge using the existing merge logic
+            *   `[✅]` If neither Phase 2 nor Phase 3 produces a valid parsed record, throw with chunk IDs, storage paths, sanitization details, and parse error
+        *   `[✅]` Add logging for sanitization events (wasSanitized, wasStructurallyFixed, hasDuplicateKeys) consistent with `executeModelCallAndSave`'s logging pattern
+        *   `[✅]` Preserve all existing error handling beyond sanitize/parse: if storage download fails, throw as before
+        *   `[✅]` Preserve the existing upload-to-assembled-path logic and `is_latest_edit` flag management unchanged
+    *   `[✅]` `requirements`
+        *   `[✅]` Continuation chunks that are individual JSON fragments must be parseable when concatenated and sanitized in chain order
+        *   `[✅]` Independently-complete chunks must be parseable via per-chunk sanitize/parse and deep-merged
+        *   `[✅]` The sanitize/parse pipeline for both methods must be the same as `executeModelCallAndSave`: `sanitizeJsonContent` → `isJsonSanitizationResult` → `JSON.parse`
+        *   `[✅]` Single-chunk assembly must produce identical output to current behavior
+        *   `[✅]` If no method produces a valid parsed record, the error must propagate with actionable diagnostics including chunk IDs, storage paths, and parse error details
+        *   `[✅]` All existing tests in `file_manager.assemble.test.ts` must continue to pass
+        *   `[✅]` The `shouldRender` guard (lines 708–724) that prevents this method from being called on rendered documents must remain unchanged
+    *   `[✅]` **Commit** `fix(be) supabase/functions gate RENDER enqueue behind continuation completion and concatenate continuation chunks before sanitize/parse in renderDocument and assembleAndSaveFinalDocument`
+        *   `[✅]` `executeModelCallAndSave.ts`: moved `needsContinuation` computation earlier; wrapped RENDER enqueue block in `!needsContinuation` guard
+        *   `[✅]` `document_renderer.ts`: replaced per-chunk JSON.parse with concatenated sanitize/parse then per-chunk sanitize/parse strategy for continuation chunk support
+        *   `[✅]` `file_manager.ts` / `assembleAndSaveFinalDocument`: replaced per-chunk JSON.parse with concatenated sanitize/parse then per-chunk sanitize/parse strategy for continuation chunk support
+        *   `[✅]` Updated tests in `executeModelCallAndSave.render.test.ts`, `document_renderer.test.ts`, and `file_manager.assemble.test.ts`
 
 # ToDo
 

--- a/packages/api/src/dialectic.api.documents.test.ts
+++ b/packages/api/src/dialectic.api.documents.test.ts
@@ -5,6 +5,8 @@ import type {
   StageRunDocumentDescriptor,
   GetAllStageProgressPayload,
   GetAllStageProgressResponse,
+  ResumePausedNsfJobsPayload,
+  ResumePausedNsfJobsResponse,
   ApiError,
   ApiResponse,
 } from '@paynless/types';
@@ -340,6 +342,86 @@ describe('DialecticApiClient - Document Listing', () => {
         code: 'NETWORK_ERROR',
         message: 'Network request failed',
       });
+    });
+  });
+
+  describe('resumePausedNsfJobs', () => {
+    it('should call the post method with the correct action and payload and return resumedCount on success', async () => {
+      const payload: ResumePausedNsfJobsPayload = {
+        sessionId: 'test-session-id',
+        stageSlug: 'antithesis',
+        iterationNumber: 1,
+      };
+      const mockResponseData: ResumePausedNsfJobsResponse = { resumedCount: 3 };
+      const mockApiResponse: ApiResponse<ResumePausedNsfJobsResponse> = {
+        data: mockResponseData,
+        error: undefined,
+        status: 200,
+      };
+
+      vi.mocked(mockApiClient.post).mockResolvedValue(mockApiResponse);
+
+      const result = await dialecticApiClient.resumePausedNsfJobs(payload);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        'dialectic-service',
+        {
+          action: 'resumePausedNsfJobs',
+          payload,
+        }
+      );
+      expect(result.data).toEqual(mockResponseData);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(200);
+    });
+
+    it('should return an error when the API call fails', async () => {
+      const payload: ResumePausedNsfJobsPayload = {
+        sessionId: 'test-session-id',
+        stageSlug: 'antithesis',
+        iterationNumber: 1,
+      };
+      const mockError: ApiError = { message: 'Resume failed', code: '500' };
+      const mockApiResponse: ApiResponse<ResumePausedNsfJobsResponse> = {
+        data: undefined,
+        error: mockError,
+        status: 500,
+      };
+
+      vi.mocked(mockApiClient.post).mockResolvedValue(mockApiResponse);
+
+      const result = await dialecticApiClient.resumePausedNsfJobs(payload);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        'dialectic-service',
+        {
+          action: 'resumePausedNsfJobs',
+          payload,
+        }
+      );
+      expect(result.data).toBeUndefined();
+      expect(result.error).toEqual(mockError);
+      expect(result.status).toBe(500);
+    });
+
+    it('should propagate when post rejects (network error)', async () => {
+      const payload: ResumePausedNsfJobsPayload = {
+        sessionId: 'test-session-id',
+        stageSlug: 'antithesis',
+        iterationNumber: 1,
+      };
+      const networkError = new Error('Network request failed');
+      vi.mocked(mockApiClient.post).mockRejectedValue(networkError);
+
+      await expect(dialecticApiClient.resumePausedNsfJobs(payload)).rejects.toThrow('Network request failed');
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        'dialectic-service',
+        {
+          action: 'resumePausedNsfJobs',
+          payload,
+        }
+      );
     });
   });
 });

--- a/packages/api/src/dialectic.api.documents.test.ts
+++ b/packages/api/src/dialectic.api.documents.test.ts
@@ -7,6 +7,8 @@ import type {
   GetAllStageProgressResponse,
   ResumePausedNsfJobsPayload,
   ResumePausedNsfJobsResponse,
+  RegenerateDocumentPayload,
+  RegenerateDocumentResponse,
   ApiError,
   ApiResponse,
 } from '@paynless/types';
@@ -419,6 +421,89 @@ describe('DialecticApiClient - Document Listing', () => {
         'dialectic-service',
         {
           action: 'resumePausedNsfJobs',
+          payload,
+        }
+      );
+    });
+  });
+
+  describe('regenerateDocument', () => {
+    it('should call the post method with the correct action and payload and return jobIds on success', async () => {
+      const payload: RegenerateDocumentPayload = {
+        sessionId: 'test-session-id',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        documents: [{ documentKey: 'doc-1', modelId: 'model-a' }, { documentKey: 'doc-2', modelId: 'model-b' }],
+      };
+      const mockResponseData: RegenerateDocumentResponse = { jobIds: ['new-job-1', 'new-job-2'] };
+      const mockApiResponse: ApiResponse<RegenerateDocumentResponse> = {
+        data: mockResponseData,
+        error: undefined,
+        status: 200,
+      };
+
+      vi.mocked(mockApiClient.post).mockResolvedValue(mockApiResponse);
+
+      const result = await dialecticApiClient.regenerateDocument(payload);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        'dialectic-service',
+        {
+          action: 'regenerateDocument',
+          payload,
+        }
+      );
+      expect(result.data).toEqual(mockResponseData);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(200);
+    });
+
+    it('should return an error when the API call fails', async () => {
+      const payload: RegenerateDocumentPayload = {
+        sessionId: 'test-session-id',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        documents: [{ documentKey: 'doc-1', modelId: 'model-a' }],
+      };
+      const mockError: ApiError = { message: 'Regenerate failed', code: '500' };
+      const mockApiResponse: ApiResponse<RegenerateDocumentResponse> = {
+        data: undefined,
+        error: mockError,
+        status: 500,
+      };
+
+      vi.mocked(mockApiClient.post).mockResolvedValue(mockApiResponse);
+
+      const result = await dialecticApiClient.regenerateDocument(payload);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        'dialectic-service',
+        {
+          action: 'regenerateDocument',
+          payload,
+        }
+      );
+      expect(result.data).toBeUndefined();
+      expect(result.error).toEqual(mockError);
+      expect(result.status).toBe(500);
+    });
+
+    it('should propagate when post rejects (network error)', async () => {
+      const payload: RegenerateDocumentPayload = {
+        sessionId: 'test-session-id',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        documents: [{ documentKey: 'doc-1', modelId: 'model-a' }],
+      };
+      const networkError = new Error('Network request failed');
+      vi.mocked(mockApiClient.post).mockRejectedValue(networkError);
+
+      await expect(dialecticApiClient.regenerateDocument(payload)).rejects.toThrow('Network request failed');
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        'dialectic-service',
+        {
+          action: 'regenerateDocument',
           payload,
         }
       );

--- a/packages/api/src/dialectic.api.ts
+++ b/packages/api/src/dialectic.api.ts
@@ -38,6 +38,8 @@ import type {
     GetAllStageProgressResponse,
     ResumePausedNsfJobsPayload,
     ResumePausedNsfJobsResponse,
+    RegenerateDocumentPayload,
+    RegenerateDocumentResponse,
 } from '@paynless/types';
 import { logger } from '@paynless/utils';
 
@@ -693,6 +695,20 @@ export class DialecticApiClient {
             logger.error('Error resuming paused NSF jobs:', { error: response.error, ...payload });
         } else {
             logger.info('Successfully resumed paused NSF jobs', { ...payload });
+        }
+        return response;
+    }
+
+    async regenerateDocument(payload: RegenerateDocumentPayload): Promise<ApiResponse<RegenerateDocumentResponse>> {
+        logger.info('Regenerating document', { sessionId: payload.sessionId, stageSlug: payload.stageSlug, iterationNumber: payload.iterationNumber, documentCount: payload.documents.length });
+        const response = await this.apiClient.post<RegenerateDocumentResponse, DialecticServiceActionPayload>(
+            'dialectic-service',
+            { action: 'regenerateDocument', payload }
+        );
+        if (response.error) {
+            logger.error('Error regenerating document:', { error: response.error, sessionId: payload.sessionId, stageSlug: payload.stageSlug });
+        } else {
+            logger.info('Successfully regenerated document', { sessionId: payload.sessionId, stageSlug: payload.stageSlug, jobIds: response.data?.jobIds });
         }
         return response;
     }

--- a/packages/api/src/dialectic.api.ts
+++ b/packages/api/src/dialectic.api.ts
@@ -36,6 +36,8 @@ import type {
     ListStageDocumentsResponse,
     GetAllStageProgressPayload,
     GetAllStageProgressResponse,
+    ResumePausedNsfJobsPayload,
+    ResumePausedNsfJobsResponse,
 } from '@paynless/types';
 import { logger } from '@paynless/utils';
 
@@ -679,6 +681,20 @@ export class DialecticApiClient {
                 status: 0,
             };
         }
+    }
+
+    async resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>> {
+        logger.info('Resuming paused NSF jobs', { ...payload });
+        const response = await this.apiClient.post<ResumePausedNsfJobsResponse, DialecticServiceActionPayload>(
+            'dialectic-service',
+            { action: 'resumePausedNsfJobs', payload }
+        );
+        if (response.error) {
+            logger.error('Error resuming paused NSF jobs:', { error: response.error, ...payload });
+        } else {
+            logger.info('Successfully resumed paused NSF jobs', { ...payload });
+        }
+        return response;
     }
 
     /**

--- a/packages/api/src/mocks/dialectic.api.mock.ts
+++ b/packages/api/src/mocks/dialectic.api.mock.ts
@@ -35,6 +35,8 @@ import type {
     GetAllStageProgressResponse,
     ResumePausedNsfJobsPayload,
     ResumePausedNsfJobsResponse,
+    RegenerateDocumentPayload,
+    RegenerateDocumentResponse,
 } from '@paynless/types'; 
 
 // --- Dialectic Client Mock Setup ---
@@ -67,6 +69,7 @@ export type MockDialecticApiClient = {
     listStageDocuments: ReturnType<typeof vi.fn<[payload: ListStageDocumentsPayload], Promise<ApiResponse<ListStageDocumentsResponse>>>>;
     getAllStageProgress: ReturnType<typeof vi.fn<[payload: GetAllStageProgressPayload], Promise<ApiResponse<GetAllStageProgressResponse>>>>;
     resumePausedNsfJobs: ReturnType<typeof vi.fn<[payload: ResumePausedNsfJobsPayload], Promise<ApiResponse<ResumePausedNsfJobsResponse>>>>;
+    regenerateDocument: ReturnType<typeof vi.fn<[payload: RegenerateDocumentPayload], Promise<ApiResponse<RegenerateDocumentResponse>>>>;
 };
 
 // Factory function to create a new mock instance
@@ -100,6 +103,7 @@ export function createMockDialecticClient(): MockDialecticApiClient {
         listStageDocuments: vi.fn<[ListStageDocumentsPayload], Promise<ApiResponse<ListStageDocumentsResponse>>>(),
         getAllStageProgress: vi.fn<[GetAllStageProgressPayload], Promise<ApiResponse<GetAllStageProgressResponse>>>(),
         resumePausedNsfJobs: vi.fn<[ResumePausedNsfJobsPayload], Promise<ApiResponse<ResumePausedNsfJobsResponse>>>(),
+        regenerateDocument: vi.fn<[RegenerateDocumentPayload], Promise<ApiResponse<RegenerateDocumentResponse>>>(),
     };
 }
 

--- a/packages/api/src/mocks/dialectic.api.mock.ts
+++ b/packages/api/src/mocks/dialectic.api.mock.ts
@@ -33,6 +33,8 @@ import type {
     ListStageDocumentsResponse,
     GetAllStageProgressPayload,
     GetAllStageProgressResponse,
+    ResumePausedNsfJobsPayload,
+    ResumePausedNsfJobsResponse,
 } from '@paynless/types'; 
 
 // --- Dialectic Client Mock Setup ---
@@ -64,6 +66,7 @@ export type MockDialecticApiClient = {
     submitStageDocumentFeedback: ReturnType<typeof vi.fn<[payload: SubmitStageDocumentFeedbackPayload], Promise<ApiResponse<{ success: boolean }>>>>;
     listStageDocuments: ReturnType<typeof vi.fn<[payload: ListStageDocumentsPayload], Promise<ApiResponse<ListStageDocumentsResponse>>>>;
     getAllStageProgress: ReturnType<typeof vi.fn<[payload: GetAllStageProgressPayload], Promise<ApiResponse<GetAllStageProgressResponse>>>>;
+    resumePausedNsfJobs: ReturnType<typeof vi.fn<[payload: ResumePausedNsfJobsPayload], Promise<ApiResponse<ResumePausedNsfJobsResponse>>>>;
 };
 
 // Factory function to create a new mock instance
@@ -96,6 +99,7 @@ export function createMockDialecticClient(): MockDialecticApiClient {
         submitStageDocumentFeedback: vi.fn<[SubmitStageDocumentFeedbackPayload], Promise<ApiResponse<{ success: boolean }>>>(),
         listStageDocuments: vi.fn<[ListStageDocumentsPayload], Promise<ApiResponse<ListStageDocumentsResponse>>>(),
         getAllStageProgress: vi.fn<[GetAllStageProgressPayload], Promise<ApiResponse<GetAllStageProgressResponse>>>(),
+        resumePausedNsfJobs: vi.fn<[ResumePausedNsfJobsPayload], Promise<ApiResponse<ResumePausedNsfJobsResponse>>>(),
     };
 }
 

--- a/packages/store/src/dialecticStore.nsf.test.ts
+++ b/packages/store/src/dialecticStore.nsf.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDialecticStore, initialDialecticStateValues } from './dialecticStore';
+import type {
+  ContributionGenerationPausedNsfPayload,
+  DialecticLifecycleEvent,
+  DialecticProject,
+  GetAllStageProgressPayload,
+  ResumePausedNsfJobsPayload,
+  User,
+} from '@paynless/types';
+import { resetApiMock, getMockDialecticClient } from '@paynless/api/mocks';
+import { useAuthStore } from './authStore';
+
+vi.mock('@paynless/api', async () => {
+  const { api, resetApiMock, getMockDialecticClient } = await import('@paynless/api/mocks');
+  return {
+    api,
+    initializeApiClient: vi.fn(),
+    resetApiMock,
+    getMockDialecticClient,
+  };
+});
+
+describe('dialecticStore NSF pause and resume', () => {
+  const sessionId = 'session-nsf-1';
+  const projectId = 'project-nsf-1';
+  const stageSlug = 'antithesis';
+  const iterationNumber = 1;
+  const userId = 'user-nsf-1';
+
+  const pausedNsfPayload: ContributionGenerationPausedNsfPayload = {
+    type: 'contribution_generation_paused_nsf',
+    sessionId,
+    projectId,
+    stageSlug,
+    iterationNumber,
+  };
+
+  beforeEach(() => {
+    resetApiMock();
+    useDialecticStore.getState()._resetForTesting?.();
+    vi.clearAllMocks();
+    const mockUser: User = { id: userId };
+    useAuthStore.setState({ user: mockUser });
+    const progressComplete: { completedSteps: number; totalSteps: number; failedSteps: number } = {
+      completedSteps: 1,
+      totalSteps: 1,
+      failedSteps: 0,
+    };
+    const progressNone: { completedSteps: number; totalSteps: number; failedSteps: number } = {
+      completedSteps: 0,
+      totalSteps: 1,
+      failedSteps: 0,
+    };
+    getMockDialecticClient().getAllStageProgress.mockResolvedValue({
+      data: {
+        dagProgress: { completedStages: 0, totalStages: 3 },
+        stages: [
+          { stageSlug: 'thesis', status: 'completed', modelCount: 1, steps: [], progress: progressComplete, documents: [] },
+          { stageSlug: 'antithesis', status: 'paused_nsf', modelCount: 1, steps: [], progress: progressNone, documents: [] },
+          { stageSlug: 'synthesis', status: 'not_started', modelCount: 1, steps: [], progress: progressNone, documents: [] },
+        ],
+      },
+      status: 200,
+    });
+  });
+
+  describe('_handleContributionGenerationPausedNsf', () => {
+    it('clears the affected session from generatingSessions and resets contributionGenerationStatus and generatingForStageSlug', () => {
+      useDialecticStore.setState({
+        contributionGenerationStatus: 'generating',
+        generatingForStageSlug: stageSlug,
+        generatingSessions: { [sessionId]: ['job-1', 'job-2'] },
+      });
+
+      useDialecticStore.getState()._handleContributionGenerationPausedNsf(pausedNsfPayload);
+
+      const state = useDialecticStore.getState();
+      expect(state.contributionGenerationStatus).toBe('idle');
+      expect(state.generatingForStageSlug).toBeNull();
+      expect(state.generatingSessions[sessionId]).toBeUndefined();
+    });
+
+    it('calls hydrateAllStageProgress with sessionId, iterationNumber, userId, projectId from the payload so the progress tracker refreshes to show paused_nsf', () => {
+      useDialecticStore.getState()._handleContributionGenerationPausedNsf(pausedNsfPayload);
+
+      expect(getMockDialecticClient().getAllStageProgress).toHaveBeenCalledTimes(1);
+      const callPayload: GetAllStageProgressPayload = getMockDialecticClient().getAllStageProgress.mock.calls[0][0];
+      expect(callPayload.sessionId).toBe(sessionId);
+      expect(callPayload.iterationNumber).toBe(iterationNumber);
+      expect(callPayload.projectId).toBe(projectId);
+      expect(callPayload.userId).toBe(userId);
+    });
+  });
+
+  describe('_handleDialecticLifecycleEvent', () => {
+    it('routes type contribution_generation_paused_nsf to _handleContributionGenerationPausedNsf', () => {
+      useDialecticStore.setState({
+        contributionGenerationStatus: 'generating',
+        generatingSessions: { [sessionId]: ['job-1'] },
+      });
+
+      const event: DialecticLifecycleEvent = pausedNsfPayload;
+      useDialecticStore.getState()._handleDialecticLifecycleEvent?.(event);
+
+      const state = useDialecticStore.getState();
+      expect(state.contributionGenerationStatus).toBe('idle');
+      expect(state.generatingSessions[sessionId]).toBeUndefined();
+      expect(getMockDialecticClient().getAllStageProgress).toHaveBeenCalled();
+    });
+  });
+
+  describe('resumePausedNsfJobs', () => {
+    const resumePayload: ResumePausedNsfJobsPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+    };
+
+    it('calls api.dialectic().resumePausedNsfJobs(payload) with correct sessionId, stageSlug, iterationNumber', async () => {
+      getMockDialecticClient().resumePausedNsfJobs.mockResolvedValue({
+        data: { resumedCount: 3 },
+        status: 200,
+      });
+
+      await useDialecticStore.getState().resumePausedNsfJobs(resumePayload);
+
+      expect(getMockDialecticClient().resumePausedNsfJobs).toHaveBeenCalledTimes(1);
+      expect(getMockDialecticClient().resumePausedNsfJobs).toHaveBeenCalledWith(resumePayload);
+      expect(getMockDialecticClient().resumePausedNsfJobs.mock.calls[0][0]).toEqual({
+        sessionId,
+        stageSlug,
+        iterationNumber,
+      });
+    });
+
+    it('on successful API response, calls hydrateAllStageProgress to refresh progress data', async () => {
+      const minimalProject: DialecticProject = {
+        id: projectId,
+        user_id: userId,
+        project_name: 'NSF Test Project',
+        selected_domain_id: 'domain-1',
+        dialectic_domains: { name: 'Tech' },
+        selected_domain_overlay_id: null,
+        repo_url: null,
+        status: 'active',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        dialectic_sessions: [],
+        process_template_id: null,
+        dialectic_process_templates: null,
+        isLoadingProcessTemplate: false,
+        processTemplateError: null,
+        contributionGenerationStatus: 'idle',
+        generateContributionsError: null,
+        isSubmittingStageResponses: false,
+        submitStageResponsesError: null,
+        isSavingContributionEdit: false,
+        saveContributionEditError: null,
+      };
+      useDialecticStore.setState({ currentProjectDetail: minimalProject });
+
+      getMockDialecticClient().resumePausedNsfJobs.mockResolvedValue({
+        data: { resumedCount: 2 },
+        status: 200,
+      });
+
+      await useDialecticStore.getState().resumePausedNsfJobs(resumePayload);
+
+      expect(getMockDialecticClient().getAllStageProgress).toHaveBeenCalled();
+      const hydrateCall: GetAllStageProgressPayload = getMockDialecticClient().getAllStageProgress.mock.calls[0][0];
+      expect(hydrateCall.sessionId).toBe(sessionId);
+      expect(hydrateCall.iterationNumber).toBe(iterationNumber);
+      expect(hydrateCall.projectId).toBeDefined();
+    });
+
+    it('on API failure, does not call hydrateAllStageProgress', async () => {
+      getMockDialecticClient().resumePausedNsfJobs.mockResolvedValue({
+        error: { message: 'RPC failed', code: 'RESUME_FAILED' },
+        status: 500,
+      });
+
+      await useDialecticStore.getState().resumePausedNsfJobs(resumePayload);
+
+      expect(getMockDialecticClient().getAllStageProgress).not.toHaveBeenCalled();
+    });
+
+    it('on API failure, returns the error response and does not leave the store in a broken state', async () => {
+      const apiError = { message: 'Resume failed', code: 'RESUME_FAILED' };
+      getMockDialecticClient().resumePausedNsfJobs.mockResolvedValue({
+        error: apiError,
+        status: 500,
+      });
+
+      const result = await useDialecticStore.getState().resumePausedNsfJobs(resumePayload);
+
+      expect(result.error).toEqual(apiError);
+      expect(result.status).toBe(500);
+      const state = useDialecticStore.getState();
+      expect(state.contributionGenerationStatus).toBe(initialDialecticStateValues.contributionGenerationStatus);
+      expect(state.resumePausedNsfJobs).toBeDefined();
+    });
+  });
+});

--- a/packages/store/src/dialecticStore.regenerateDocument.test.ts
+++ b/packages/store/src/dialecticStore.regenerateDocument.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDialecticStore, initialDialecticStateValues } from './dialecticStore';
+import type {
+  DialecticProject,
+  GetAllStageProgressPayload,
+  RegenerateDocumentPayload,
+  User,
+} from '@paynless/types';
+import { resetApiMock, getMockDialecticClient } from '@paynless/api/mocks';
+import { useAuthStore } from './authStore';
+
+vi.mock('@paynless/api', async () => {
+  const { api, resetApiMock, getMockDialecticClient } = await import('@paynless/api/mocks');
+  return {
+    api,
+    initializeApiClient: vi.fn(),
+    resetApiMock,
+    getMockDialecticClient,
+  };
+});
+
+describe('dialecticStore regenerateDocument', () => {
+  const sessionId = 'session-regen-1';
+  const projectId = 'project-regen-1';
+  const stageSlug = 'thesis';
+  const iterationNumber = 1;
+  const userId = 'user-regen-1';
+
+  const regeneratePayload: RegenerateDocumentPayload = {
+    sessionId,
+    stageSlug,
+    iterationNumber,
+    documents: [
+      { documentKey: 'business_case', modelId: 'model-1' },
+      { documentKey: 'feature_spec', modelId: 'model-2' },
+    ],
+  };
+
+  const minimalProject: DialecticProject = {
+    id: projectId,
+    user_id: userId,
+    project_name: 'Regen Test Project',
+    selected_domain_id: 'domain-1',
+    dialectic_domains: { name: 'Tech' },
+    selected_domain_overlay_id: null,
+    repo_url: null,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    dialectic_sessions: [],
+    process_template_id: null,
+    dialectic_process_templates: null,
+    isLoadingProcessTemplate: false,
+    processTemplateError: null,
+    contributionGenerationStatus: 'idle',
+    generateContributionsError: null,
+    isSubmittingStageResponses: false,
+    submitStageResponsesError: null,
+    isSavingContributionEdit: false,
+    saveContributionEditError: null,
+  };
+
+  beforeEach(() => {
+    resetApiMock();
+    useDialecticStore.getState()._resetForTesting?.();
+    vi.clearAllMocks();
+    const mockUser: User = { id: userId };
+    useAuthStore.setState({ user: mockUser });
+    useDialecticStore.setState({ currentProjectDetail: minimalProject });
+    getMockDialecticClient().getAllStageProgress.mockResolvedValue({
+      data: {
+        dagProgress: { completedStages: 0, totalStages: 3 },
+        stages: [
+          { stageSlug: 'thesis', status: 'in_progress', modelCount: 2, steps: [], progress: { completedSteps: 0, totalSteps: 2, failedSteps: 0 }, documents: [] },
+          { stageSlug: 'antithesis', status: 'not_started', modelCount: 1, steps: [], progress: { completedSteps: 0, totalSteps: 1, failedSteps: 0 }, documents: [] },
+          { stageSlug: 'synthesis', status: 'not_started', modelCount: 1, steps: [], progress: { completedSteps: 0, totalSteps: 1, failedSteps: 0 }, documents: [] },
+        ],
+      },
+      status: 200,
+    });
+  });
+
+  it('calls api.dialectic().regenerateDocument(payload) with correct sessionId, stageSlug, iterationNumber, documents', async () => {
+    getMockDialecticClient().regenerateDocument.mockResolvedValue({
+      data: { jobIds: ['new-job-1', 'new-job-2'] },
+      status: 200,
+    });
+
+    await useDialecticStore.getState().regenerateDocument(regeneratePayload);
+
+    expect(getMockDialecticClient().regenerateDocument).toHaveBeenCalledTimes(1);
+    expect(getMockDialecticClient().regenerateDocument).toHaveBeenCalledWith(regeneratePayload);
+    const callPayload: RegenerateDocumentPayload = getMockDialecticClient().regenerateDocument.mock.calls[0][0];
+    expect(callPayload.sessionId).toBe(sessionId);
+    expect(callPayload.stageSlug).toBe(stageSlug);
+    expect(callPayload.iterationNumber).toBe(iterationNumber);
+    expect(callPayload.documents).toEqual(regeneratePayload.documents);
+  });
+
+  it('on successful API response, adds returned job IDs to generatingSessions[sessionId]', async () => {
+    const jobIds: string[] = ['new-job-1', 'new-job-2'];
+    getMockDialecticClient().regenerateDocument.mockResolvedValue({
+      data: { jobIds },
+      status: 200,
+    });
+
+    await useDialecticStore.getState().regenerateDocument(regeneratePayload);
+
+    const state = useDialecticStore.getState();
+    expect(state.generatingSessions[sessionId]).toEqual(jobIds);
+  });
+
+  it('on successful API response, sets contributionGenerationStatus to generating and generatingForStageSlug to payload.stageSlug', async () => {
+    getMockDialecticClient().regenerateDocument.mockResolvedValue({
+      data: { jobIds: ['new-job-1'] },
+      status: 200,
+    });
+
+    const promise = useDialecticStore.getState().regenerateDocument(regeneratePayload);
+    expect(useDialecticStore.getState().contributionGenerationStatus).toBe('generating');
+    expect(useDialecticStore.getState().generatingForStageSlug).toBe(stageSlug);
+
+    await promise;
+    expect(useDialecticStore.getState().contributionGenerationStatus).toBe('generating');
+    expect(useDialecticStore.getState().generatingForStageSlug).toBe(stageSlug);
+  });
+
+  it('on successful API response, calls hydrateAllStageProgress to refresh progress data', async () => {
+    getMockDialecticClient().regenerateDocument.mockResolvedValue({
+      data: { jobIds: ['new-job-1'] },
+      status: 200,
+    });
+
+    await useDialecticStore.getState().regenerateDocument(regeneratePayload);
+
+    expect(getMockDialecticClient().getAllStageProgress).toHaveBeenCalled();
+    const hydrateCall: GetAllStageProgressPayload = getMockDialecticClient().getAllStageProgress.mock.calls[0][0];
+    expect(hydrateCall.sessionId).toBe(sessionId);
+    expect(hydrateCall.iterationNumber).toBe(iterationNumber);
+    expect(hydrateCall.projectId).toBe(projectId);
+    expect(hydrateCall.userId).toBe(userId);
+  });
+
+  it('on API failure, does not add job IDs to generatingSessions and resets contributionGenerationStatus', async () => {
+    getMockDialecticClient().regenerateDocument.mockResolvedValue({
+      error: { message: 'Regenerate failed', code: 'REGENERATE_FAILED' },
+      status: 500,
+    });
+
+    await useDialecticStore.getState().regenerateDocument(regeneratePayload);
+
+    const state = useDialecticStore.getState();
+    expect(state.generatingSessions[sessionId]).toBeUndefined();
+    expect(state.contributionGenerationStatus).toBe(initialDialecticStateValues.contributionGenerationStatus);
+    expect(state.generatingForStageSlug).toBeNull();
+  });
+
+  it('on API failure, returns the error response', async () => {
+    const apiError = { message: 'Stage mismatch', code: 'VALIDATION_ERROR' };
+    getMockDialecticClient().regenerateDocument.mockResolvedValue({
+      error: apiError,
+      status: 400,
+    });
+
+    const result = await useDialecticStore.getState().regenerateDocument(regeneratePayload);
+
+    expect(result.error).toEqual(apiError);
+    expect(result.status).toBe(400);
+  });
+});

--- a/packages/store/src/dialecticStore.selectors.progress.test.ts
+++ b/packages/store/src/dialecticStore.selectors.progress.test.ts
@@ -1729,6 +1729,222 @@ describe('selectUnifiedProjectProgress', () => {
       const result: UnifiedProjectProgress = selectUnifiedProjectProgress(state, sessionId);
       expect(result.totalStages).toBe(0);
     });
+
+    it('maps raw step status paused_nsf to UnifiedProjectStatus paused_nsf', () => {
+      const session: DialecticSession = {
+        id: sessionId,
+        project_id: 'proj-1',
+        session_description: null,
+        user_input_reference_url: null,
+        iteration_count: iterationNumber,
+        selected_models: [{ id: 'model-1', displayName: 'Model 1' }],
+        status: null,
+        associated_chat_id: null,
+        current_stage_id: 'stage-abc',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      const recipe: DialecticStageRecipe = {
+        stageSlug: 'mock-stage-1',
+        instanceId: 'inst-1',
+        steps: [{
+          id: 's1',
+          step_key: 'step_a',
+          step_slug: 'step-a',
+          step_name: 'Step A',
+          execution_order: 1,
+          parallel_group: 1,
+          branch_key: 'b1',
+          job_type: 'EXECUTE',
+          prompt_type: 'Turn',
+          output_type: 'assembled_document_json',
+          granularity_strategy: 'per_source_document',
+          inputs_required: [],
+          inputs_relevance: [],
+          outputs_required: [{ document_key: 'doc_a', artifact_class: 'rendered_document', file_type: 'markdown' }],
+        }],
+        edges: [],
+      };
+      const progressKey = progressKeyForStage('mock-stage-1');
+      const projectWithSession: DialecticProject = {
+        ...projectBaseForUnified,
+        dialectic_sessions: [session],
+      };
+      const state: DialecticStateValues = {
+        ...initialDialecticStateValues,
+        currentProjectDetail: projectWithSession,
+        currentProcessTemplate: templateForUnified,
+        selectedModels: [{ id: 'model-1', displayName: 'Model 1' }],
+        recipesByStageSlug: { 'mock-stage-1': recipe, 'mock-stage-2': recipe2Minimal },
+        stageRunProgress: {
+          [progressKey]: {
+            stepStatuses: { step_a: 'paused_nsf' },
+            documents: {},
+            jobProgress: {},
+            progress: { completedSteps: 0, totalSteps: 1, failedSteps: 0 },
+          },
+          [progressKeyForStage('mock-stage-2')]: emptyStageProgress,
+        },
+      };
+      const result: UnifiedProjectProgress = selectUnifiedProjectProgress(state, sessionId);
+      const firstStage = result.stageDetails[0];
+      expect(firstStage.stepsDetail[0].status).toBe('paused_nsf');
+    });
+
+    it('sets stage status paused_nsf when any step is paused_nsf and none are failed', () => {
+      const session: DialecticSession = {
+        id: sessionId,
+        project_id: 'proj-1',
+        session_description: null,
+        user_input_reference_url: null,
+        iteration_count: iterationNumber,
+        selected_models: [{ id: 'model-1', displayName: 'Model 1' }],
+        status: null,
+        associated_chat_id: null,
+        current_stage_id: 'stage-abc',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      const recipe: DialecticStageRecipe = {
+        stageSlug: 'mock-stage-1',
+        instanceId: 'inst-1',
+        steps: [
+          { id: 's1', step_key: 'step_a', step_slug: 'step-a', step_name: 'Step A', execution_order: 1, parallel_group: 1, branch_key: 'b1', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_a', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+          { id: 's2', step_key: 'step_b', step_slug: 'step-b', step_name: 'Step B', execution_order: 2, parallel_group: 2, branch_key: 'b2', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_b', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+        ],
+        edges: [],
+      };
+      const progressKey = progressKeyForStage('mock-stage-1');
+      const projectWithSession: DialecticProject = {
+        ...projectBaseForUnified,
+        dialectic_sessions: [session],
+      };
+      const state: DialecticStateValues = {
+        ...initialDialecticStateValues,
+        currentProjectDetail: projectWithSession,
+        currentProcessTemplate: templateForUnified,
+        selectedModels: [{ id: 'model-1', displayName: 'Model 1' }],
+        recipesByStageSlug: { 'mock-stage-1': recipe, 'mock-stage-2': recipe2Minimal },
+        stageRunProgress: {
+          [progressKey]: {
+            stepStatuses: { step_a: 'paused_nsf', step_b: 'paused_nsf' },
+            documents: {},
+            jobProgress: {},
+            progress: { completedSteps: 0, totalSteps: 2, failedSteps: 0 },
+          },
+          [progressKeyForStage('mock-stage-2')]: emptyStageProgress,
+        },
+      };
+      const result: UnifiedProjectProgress = selectUnifiedProjectProgress(state, sessionId);
+      const firstStage = result.stageDetails[0];
+      expect(firstStage.stageStatus).toBe('paused_nsf');
+      expect(firstStage.stepsDetail[0].status).toBe('paused_nsf');
+      expect(firstStage.stepsDetail[1].status).toBe('paused_nsf');
+    });
+
+    it('sets stage status failed when one step is paused_nsf and another is failed (failure takes priority)', () => {
+      const session: DialecticSession = {
+        id: sessionId,
+        project_id: 'proj-1',
+        session_description: null,
+        user_input_reference_url: null,
+        iteration_count: iterationNumber,
+        selected_models: [{ id: 'model-1', displayName: 'Model 1' }],
+        status: null,
+        associated_chat_id: null,
+        current_stage_id: 'stage-abc',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      const recipe: DialecticStageRecipe = {
+        stageSlug: 'mock-stage-1',
+        instanceId: 'inst-1',
+        steps: [
+          { id: 's1', step_key: 'step_a', step_slug: 'step-a', step_name: 'Step A', execution_order: 1, parallel_group: 1, branch_key: 'b1', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_a', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+          { id: 's2', step_key: 'step_b', step_slug: 'step-b', step_name: 'Step B', execution_order: 2, parallel_group: 2, branch_key: 'b2', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_b', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+        ],
+        edges: [],
+      };
+      const progressKey = progressKeyForStage('mock-stage-1');
+      const projectWithSession: DialecticProject = {
+        ...projectBaseForUnified,
+        dialectic_sessions: [session],
+      };
+      const state: DialecticStateValues = {
+        ...initialDialecticStateValues,
+        currentProjectDetail: projectWithSession,
+        currentProcessTemplate: templateForUnified,
+        selectedModels: [{ id: 'model-1', displayName: 'Model 1' }],
+        recipesByStageSlug: { 'mock-stage-1': recipe, 'mock-stage-2': recipe2Minimal },
+        stageRunProgress: {
+          [progressKey]: {
+            stepStatuses: { step_a: 'paused_nsf', step_b: 'failed' },
+            documents: {},
+            jobProgress: {},
+            progress: { completedSteps: 0, totalSteps: 2, failedSteps: 1 },
+          },
+          [progressKeyForStage('mock-stage-2')]: emptyStageProgress,
+        },
+      };
+      const result: UnifiedProjectProgress = selectUnifiedProjectProgress(state, sessionId);
+      const firstStage = result.stageDetails[0];
+      expect(firstStage.stageStatus).toBe('failed');
+      expect(firstStage.stepsDetail[0].status).toBe('paused_nsf');
+      expect(firstStage.stepsDetail[1].status).toBe('failed');
+    });
+
+    it('preserves existing in_progress, completed, failed, not_started step and stage mappings', () => {
+      const session: DialecticSession = {
+        id: sessionId,
+        project_id: 'proj-1',
+        session_description: null,
+        user_input_reference_url: null,
+        iteration_count: iterationNumber,
+        selected_models: [{ id: 'model-1', displayName: 'Model 1' }],
+        status: null,
+        associated_chat_id: null,
+        current_stage_id: 'stage-abc',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      const recipe: DialecticStageRecipe = {
+        stageSlug: 'mock-stage-1',
+        instanceId: 'inst-1',
+        steps: [
+          { id: 's1', step_key: 'step_a', step_slug: 'step-a', step_name: 'Step A', execution_order: 1, parallel_group: 1, branch_key: 'b1', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_a', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+          { id: 's2', step_key: 'step_b', step_slug: 'step-b', step_name: 'Step B', execution_order: 2, parallel_group: 2, branch_key: 'b2', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_b', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+          { id: 's3', step_key: 'step_c', step_slug: 'step-c', step_name: 'Step C', execution_order: 3, parallel_group: 3, branch_key: 'b3', job_type: 'EXECUTE', prompt_type: 'Turn', output_type: 'assembled_document_json', granularity_strategy: 'per_source_document', inputs_required: [], inputs_relevance: [], outputs_required: [{ document_key: 'doc_c', artifact_class: 'rendered_document', file_type: 'markdown' }] },
+        ],
+        edges: [],
+      };
+      const progressKey = progressKeyForStage('mock-stage-1');
+      const projectWithSession: DialecticProject = {
+        ...projectBaseForUnified,
+        dialectic_sessions: [session],
+      };
+      const state: DialecticStateValues = {
+        ...initialDialecticStateValues,
+        currentProjectDetail: projectWithSession,
+        currentProcessTemplate: templateForUnified,
+        selectedModels: [{ id: 'model-1', displayName: 'Model 1' }],
+        recipesByStageSlug: { 'mock-stage-1': recipe, 'mock-stage-2': recipe2Minimal },
+        stageRunProgress: {
+          [progressKey]: {
+            stepStatuses: { step_a: 'completed', step_b: 'in_progress', step_c: 'not_started' },
+            documents: {},
+            jobProgress: {},
+            progress: { completedSteps: 1, totalSteps: 3, failedSteps: 0 },
+          },
+          [progressKeyForStage('mock-stage-2')]: emptyStageProgress,
+        },
+      };
+      const result: UnifiedProjectProgress = selectUnifiedProjectProgress(state, sessionId);
+      const firstStage = result.stageDetails[0];
+      expect(firstStage.stepsDetail[0].status).toBe('completed');
+      expect(firstStage.stepsDetail[1].status).toBe('in_progress');
+      expect(firstStage.stepsDetail[2].status).toBe('not_started');
+      expect(firstStage.stageStatus).toBe('in_progress');
+    });
   });
 
 describe('selectStageHasUnsavedChanges', () => {

--- a/packages/store/src/dialecticStore.selectors.test.ts
+++ b/packages/store/src/dialecticStore.selectors.test.ts
@@ -609,6 +609,7 @@ describe('Dialectic Store Selectors', () => {
                         outputs_required: [{ document_key: 'doc_a', artifact_class: 'rendered_document', file_type: 'markdown' }],
                     },
                 ],
+                edges: [],
             };
             const jobProgressEntry: JobProgressEntry = {
                 totalJobs: 3,
@@ -884,6 +885,7 @@ describe('Dialectic Store Selectors', () => {
             ],
           },
         ],
+        edges: [],
       };
 
       const progressState: DialecticStateValues = {
@@ -993,6 +995,7 @@ describe('Dialectic Store Selectors', () => {
             ],
           },
         ],
+        edges: [],
       };
 
       const progressState: DialecticStateValues = {
@@ -1103,7 +1106,8 @@ describe('Dialectic Store Selectors', () => {
             ],
           },
         ],
-      };
+        edges: [],
+        };
 
       const progressState: DialecticStateValues = {
         ...initialDialecticStateValues,
@@ -1236,6 +1240,7 @@ describe('Dialectic Store Selectors', () => {
             ],
           },
         ],
+        edges: [],
       };
 
       const progressState: DialecticStateValues = {
@@ -1558,6 +1563,7 @@ describe('selectIsStageReadyForSessionIteration', () => {
     const requiredSeedPromptRecipe: DialecticStageRecipe = {
         stageSlug,
         instanceId: 'instance-1',
+        edges: [],
         steps: [
             {
                 id: 'step-seed',
@@ -2189,6 +2195,7 @@ describe('selectIsStageReadyForSessionIteration', () => {
         const recipeRequiringDocument: DialecticStageRecipe = {
             stageSlug: targetStageSlug,
             instanceId: 'instance-2',
+            edges: [],
             steps: [
                 {
                     id: 'step-require-doc',

--- a/packages/store/src/dialecticStore.selectors.ts
+++ b/packages/store/src/dialecticStore.selectors.ts
@@ -871,10 +871,12 @@ export const selectUnifiedProjectProgress = (
                 raw === 'failed' ? 'failed'
                     : raw === 'completed' ? 'completed'
                     : raw === 'in_progress' || raw === 'waiting_for_children' ? 'in_progress'
+                    : raw === 'paused_nsf' ? 'paused_nsf'
                     : 'not_started';
 
             if (stepStatus === 'failed') stageStatus = 'failed';
             else if (stepStatus === 'in_progress' && stageStatus !== 'failed') stageStatus = 'in_progress';
+            else if (stepStatus === 'paused_nsf' && stageStatus !== 'failed') stageStatus = 'paused_nsf';
 
             const stepName = recipeStep.step_name;
 

--- a/packages/store/src/dialecticStore.ts
+++ b/packages/store/src/dialecticStore.ts
@@ -31,6 +31,7 @@ import {
   type ContributionGenerationFailedPayload,
   type ContributionGenerationCompletePayload,
   type ContributionGenerationContinuedPayload,
+  type ContributionGenerationPausedNsfPayload,
   type PlannerStartedPayload,
   type PlannerCompletedPayload,
   type DocumentStartedPayload,
@@ -48,6 +49,7 @@ import {
   type SubmitStageDocumentFeedbackPayload,
   type ListStageDocumentsPayload,
   type GetAllStageProgressPayload,
+  type ResumePausedNsfJobsPayload,
   StartSessionSuccessResponse,
 } from '@paynless/types';
 import { api } from '@paynless/api';
@@ -1526,7 +1528,9 @@ export const useDialecticStore = create<DialecticStore>()(
                     modelId: payload.modelId,
                 });
             } else {
+				if (payload.step_key !== undefined && payload.step_key !== '') {
                 setStepStatusLogic(get, set, `${payload.sessionId}:${payload.stageSlug}:${payload.iterationNumber}`, payload.step_key, 'in_progress');
+				}
             }
             break;
         case 'document_chunk_completed':
@@ -1564,7 +1568,9 @@ export const useDialecticStore = create<DialecticStore>()(
                     modelId: payload.modelId,
                 });
             } else {
-                setStepStatusLogic(get, set, `${payload.sessionId}:${payload.stageSlug}:${payload.iterationNumber}`, payload.step_key, 'completed');
+				if (payload.step_key !== undefined && payload.step_key !== '') {
+					setStepStatusLogic(get, set, `${payload.sessionId}:${payload.stageSlug}:${payload.iterationNumber}`, payload.step_key, 'completed');
+				}
             }
             break;
         case 'render_started':
@@ -1578,6 +1584,9 @@ export const useDialecticStore = create<DialecticStore>()(
             break;
         case 'job_failed':
             handlers._handleJobFailed(payload);
+            break;
+        case 'contribution_generation_paused_nsf':
+            handlers._handleContributionGenerationPausedNsf(payload);
             break;
         default:
             logger.warn('[DialecticStore] Received unhandled dialectic lifecycle event', { payload });
@@ -1604,6 +1613,28 @@ export const useDialecticStore = create<DialecticStore>()(
 		handleRenderCompletedLogic(get, set, event),
 
 	_handleJobFailed: (event: JobFailedPayload) => handleJobFailedLogic(get, set, event),
+
+  _handleContributionGenerationPausedNsf: (payload: ContributionGenerationPausedNsfPayload) => {
+    set(state => {
+      delete state.generatingSessions[payload.sessionId];
+      state.contributionGenerationStatus = 'idle';
+      state.generatingForStageSlug = null;
+    });
+    const userId: string | undefined = useAuthStore.getState().user?.id;
+    if (userId && userId.length > 0) {
+      get().hydrateAllStageProgress({
+        sessionId: payload.sessionId,
+        iterationNumber: payload.iterationNumber,
+        userId,
+        projectId: payload.projectId,
+      });
+    } else {
+      logger.warn('[DialecticStore] _handleContributionGenerationPausedNsf: no userId available, skipping hydrateAllStageProgress', {
+        sessionId: payload.sessionId,
+        projectId: payload.projectId,
+      });
+    }
+  },
 
   _handleContributionGenerationStarted: (event: ContributionGenerationStartedPayload) => {
     set({
@@ -1977,6 +2008,25 @@ export const useDialecticStore = create<DialecticStore>()(
       });
       return { error: networkError, status: 500 };
     }
+  },
+
+  resumePausedNsfJobs: async (payload: ResumePausedNsfJobsPayload) => {
+    const response = await api.dialectic().resumePausedNsfJobs(payload);
+    if (response.error) {
+      logger.error('[DialecticStore] resumePausedNsfJobs failed', { payload, errorDetails: response.error });
+      return response;
+    }
+    const userId: string | undefined = useAuthStore.getState().user?.id;
+    const projectId: string | undefined = get().currentProjectDetail?.id;
+    if (userId && userId.length > 0 && projectId) {
+      get().hydrateAllStageProgress({
+        sessionId: payload.sessionId,
+        iterationNumber: payload.iterationNumber,
+        userId,
+        projectId,
+      });
+    }
+    return response;
   },
 
 	setSubmittingStageResponses: (isSubmitting: boolean) =>

--- a/packages/store/src/dialecticStore.ts
+++ b/packages/store/src/dialecticStore.ts
@@ -50,6 +50,8 @@ import {
   type ListStageDocumentsPayload,
   type GetAllStageProgressPayload,
   type ResumePausedNsfJobsPayload,
+  type RegenerateDocumentPayload,
+  type RegenerateDocumentResponse,
   StartSessionSuccessResponse,
 } from '@paynless/types';
 import { api } from '@paynless/api';
@@ -2027,6 +2029,57 @@ export const useDialecticStore = create<DialecticStore>()(
       });
     }
     return response;
+  },
+
+  regenerateDocument: async (payload: RegenerateDocumentPayload): Promise<ApiResponse<RegenerateDocumentResponse>> => {
+    set(state => {
+      state.contributionGenerationStatus = 'generating';
+      state.generatingForStageSlug = payload.stageSlug;
+    });
+    try {
+      const response = await api.dialectic().regenerateDocument(payload);
+      if (response.error || !response.data?.jobIds) {
+        const error: ApiError = response.error ?? { message: 'API call succeeded but returned no jobIds', code: 'UNEXPECTED_RESPONSE' };
+        logger.error('[DialecticStore] regenerateDocument failed', { payload, errorDetails: error });
+        set(state => {
+          state.contributionGenerationStatus = 'idle';
+          state.generatingForStageSlug = null;
+        });
+        return { error, status: response.status ?? 500 };
+      }
+      const sessionId: string = payload.sessionId;
+      const jobIds: string[] = response.data.jobIds;
+      set(state => {
+        const existing: string[] | undefined = state.generatingSessions[sessionId];
+        if (existing !== undefined) {
+          state.generatingSessions[sessionId] = [...existing, ...jobIds];
+        } else {
+          state.generatingSessions[sessionId] = jobIds;
+        }
+      });
+      const userId: string | undefined = useAuthStore.getState().user?.id;
+      const projectId: string | undefined = get().currentProjectDetail?.id;
+      if (userId && userId.length > 0 && projectId) {
+        get().hydrateAllStageProgress({
+          sessionId: payload.sessionId,
+          iterationNumber: payload.iterationNumber,
+          userId,
+          projectId,
+        });
+      }
+      return { data: response.data, status: response.status };
+    } catch (error: unknown) {
+      const networkError: ApiError = {
+        message: error instanceof Error ? error.message : 'An unknown network error occurred',
+        code: 'NETWORK_ERROR',
+      };
+      logger.error('[DialecticStore] regenerateDocument network error', { payload, errorDetails: networkError });
+      set(state => {
+        state.contributionGenerationStatus = 'idle';
+        state.generatingForStageSlug = null;
+      });
+      return { error: networkError, status: 500 };
+    }
   },
 
 	setSubmittingStageResponses: (isSubmitting: boolean) =>

--- a/packages/store/src/notificationStore.test.ts
+++ b/packages/store/src/notificationStore.test.ts
@@ -754,6 +754,87 @@ describe('notificationStore', () => {
                 expect(addNotificationSpy).not.toHaveBeenCalled();
                 addNotificationSpy.mockRestore();
             });
+
+            it('should route contribution_generation_paused_nsf events to the dialectic store with correct payload', () => {
+                const addNotificationSpy = vi.spyOn(useNotificationStore.getState(), 'addNotification');
+                const pausedNsfNotification: Notification = {
+                    ...baseDocumentEvent,
+                    id: 'uuid-paused-nsf',
+                    type: 'contribution_generation_paused_nsf',
+                    data: {
+                        type: 'contribution_generation_paused_nsf',
+                        sessionId: 'x',
+                        projectId: 'y',
+                        stageSlug: 'thesis',
+                        iterationNumber: 1,
+                    },
+                };
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(pausedNsfNotification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).toHaveBeenCalledWith({
+                    type: 'contribution_generation_paused_nsf',
+                    sessionId: 'x',
+                    projectId: 'y',
+                    stageSlug: 'thesis',
+                    iterationNumber: 1,
+                });
+                expect(addNotificationSpy).not.toHaveBeenCalled();
+                addNotificationSpy.mockRestore();
+            });
+
+            it('should not forward contribution_generation_paused_nsf when data is missing sessionId, stageSlug, or iterationNumber', () => {
+                mockHandleDialecticLifecycleEvent.mockClear();
+                const notification: Notification = {
+                    ...baseDocumentEvent,
+                    id: 'uuid-paused-nsf-invalid',
+                    type: 'contribution_generation_paused_nsf',
+                    data: {
+                        type: 'contribution_generation_paused_nsf',
+                        projectId: 'y',
+                        stageSlug: 'thesis',
+                        // missing sessionId and iterationNumber
+                    },
+                };
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(notification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).not.toHaveBeenCalled();
+                expect(mockLogger.warn).toHaveBeenCalledWith(
+                    "[NotificationStore] Internal event 'contribution_generation_paused_nsf' received, but its data payload did not match the expected format.",
+                    { data: notification.data }
+                );
+            });
+
+            it('should not forward contribution_generation_paused_nsf when data is missing projectId', () => {
+                mockHandleDialecticLifecycleEvent.mockClear();
+                const notification: Notification = {
+                    ...baseDocumentEvent,
+                    id: 'uuid-paused-nsf-no-project',
+                    type: 'contribution_generation_paused_nsf',
+                    data: {
+                        type: 'contribution_generation_paused_nsf',
+                        sessionId: 'x',
+                        stageSlug: 'thesis',
+                        iterationNumber: 1,
+                        // missing projectId
+                    },
+                };
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(notification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).not.toHaveBeenCalled();
+                expect(mockLogger.warn).toHaveBeenCalledWith(
+                    "[NotificationStore] Internal event 'contribution_generation_paused_nsf' received, but its data payload did not match the expected format.",
+                    { data: notification.data }
+                );
+            });
         });
 
         describe('markNotificationRead', () => {

--- a/packages/store/src/notificationStore.test.ts
+++ b/packages/store/src/notificationStore.test.ts
@@ -218,6 +218,67 @@ const documentCompletedNotification: Notification = {
     },
 };
 
+const executeStartedNotification: Notification = {
+    ...baseDocumentEvent,
+    id: 'uuid-execute-started',
+    type: 'execute_started',
+    data: {
+        sessionId: 'sid-123',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        job_id: 'job-exec',
+        modelId: 'model-exec',
+        step_key: 'execute-step-1',
+        document_key: 'business_case',
+    },
+};
+
+const executeChunkCompletedNotification: Notification = {
+    ...baseDocumentEvent,
+    id: 'uuid-execute-chunk-completed',
+    type: 'execute_chunk_completed',
+    data: {
+        sessionId: 'sid-123',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        job_id: 'job-exec',
+        modelId: 'model-exec',
+        step_key: 'execute-step-1',
+        document_key: 'business_case',
+        isFinalChunk: false,
+        continuationNumber: 2,
+    },
+};
+
+const executeCompletedNotification: Notification = {
+    ...baseDocumentEvent,
+    id: 'uuid-execute-completed',
+    type: 'execute_completed',
+    data: {
+        sessionId: 'sid-123',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        job_id: 'job-exec',
+        modelId: 'model-exec',
+        step_key: 'execute-step-1',
+        document_key: 'business_case',
+        latestRenderedResourceId: 'resource-789',
+    },
+};
+
+const plannerStartedWithoutDocKeyModelIdNotification: Notification = {
+    ...baseDocumentEvent,
+    id: 'uuid-planner-started-plan-only',
+    type: 'planner_started',
+    data: {
+        sessionId: 'sid-123',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        job_id: 'job-planner',
+        step_key: 'planner-step-1',
+    },
+};
+
 // --- Test Suite ---
 describe('notificationStore', () => {
     // Reset store state and mocks before each test
@@ -509,7 +570,95 @@ describe('notificationStore', () => {
                 addNotificationSpy.mockRestore();
             });
 
-            
+            it('should route execute_started events to the dialectic store without creating a visible notification', () => {
+                const addNotificationSpy = vi.spyOn(useNotificationStore.getState(), 'addNotification');
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(executeStartedNotification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).toHaveBeenCalledWith({
+                    type: 'execute_started',
+                    sessionId: 'sid-123',
+                    stageSlug: 'thesis',
+                    iterationNumber: 1,
+                    job_id: 'job-exec',
+                    modelId: 'model-exec',
+                    step_key: 'execute-step-1',
+                    document_key: 'business_case',
+                });
+
+                expect(addNotificationSpy).not.toHaveBeenCalled();
+                addNotificationSpy.mockRestore();
+            });
+
+            it('should route execute_chunk_completed events to the dialectic store without creating a visible notification', () => {
+                const addNotificationSpy = vi.spyOn(useNotificationStore.getState(), 'addNotification');
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(executeChunkCompletedNotification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).toHaveBeenCalledWith({
+                    type: 'execute_chunk_completed',
+                    sessionId: 'sid-123',
+                    stageSlug: 'thesis',
+                    iterationNumber: 1,
+                    job_id: 'job-exec',
+                    modelId: 'model-exec',
+                    step_key: 'execute-step-1',
+                    document_key: 'business_case',
+                    isFinalChunk: false,
+                    continuationNumber: 2,
+                });
+
+                expect(addNotificationSpy).not.toHaveBeenCalled();
+                addNotificationSpy.mockRestore();
+            });
+
+            it('should route execute_completed events to the dialectic store with optional latestRenderedResourceId', () => {
+                const addNotificationSpy = vi.spyOn(useNotificationStore.getState(), 'addNotification');
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(executeCompletedNotification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).toHaveBeenCalledWith({
+                    type: 'execute_completed',
+                    sessionId: 'sid-123',
+                    stageSlug: 'thesis',
+                    iterationNumber: 1,
+                    job_id: 'job-exec',
+                    modelId: 'model-exec',
+                    step_key: 'execute-step-1',
+                    document_key: 'business_case',
+                    latestRenderedResourceId: 'resource-789',
+                });
+
+                expect(addNotificationSpy).not.toHaveBeenCalled();
+                addNotificationSpy.mockRestore();
+            });
+
+            it('should route planner_started events without document_key and modelId to the dialectic store', () => {
+                const addNotificationSpy = vi.spyOn(useNotificationStore.getState(), 'addNotification');
+
+                act(() => {
+                    useNotificationStore.getState().handleIncomingNotification(plannerStartedWithoutDocKeyModelIdNotification);
+                });
+
+                expect(mockHandleDialecticLifecycleEvent).toHaveBeenCalledWith({
+                    type: 'planner_started',
+                    sessionId: 'sid-123',
+                    stageSlug: 'thesis',
+                    iterationNumber: 1,
+                    job_id: 'job-planner',
+                    step_key: 'planner-step-1',
+                });
+
+                expect(addNotificationSpy).not.toHaveBeenCalled();
+                addNotificationSpy.mockRestore();
+            });
+
             it('should not process wallet notifications as internal events', () => {
                 const addNotificationSpy = vi.spyOn(useNotificationStore.getState(), 'addNotification');
                 const walletNotification: Notification = {

--- a/packages/store/src/notificationStore.ts
+++ b/packages/store/src/notificationStore.ts
@@ -328,9 +328,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => {
                                 typeof data['sessionId'] === 'string' &&
                                 typeof data['stageSlug'] === 'string' &&
                                 typeof data['iterationNumber'] === 'number' &&
-                                typeof data['job_id'] === 'string' &&
-                                typeof data['document_key'] === 'string' &&
-                                typeof data['modelId'] === 'string'
+                                typeof data['job_id'] === 'string'
                             ) {
                                 eventPayload = {
                                     type,
@@ -338,8 +336,8 @@ export const useNotificationStore = create<NotificationState>((set, get) => {
                                     stageSlug: data['stageSlug'],
                                     iterationNumber: data['iterationNumber'],
                                     job_id: data['job_id'],
-                                    document_key: data['document_key'],
-                                    modelId: data['modelId'],
+                                    document_key: typeof data['document_key'] === 'string' ? data['document_key'] : undefined,
+                                    modelId: typeof data['modelId'] === 'string' ? data['modelId'] : undefined,
                                     step_key: typeof data['step_key'] === 'string' ? data['step_key'] : undefined,
                                     latestRenderedResourceId: typeof data['latestRenderedResourceId'] === 'string' ? data['latestRenderedResourceId'] : (data['latestRenderedResourceId'] === null ? null : undefined),
                                 };
@@ -456,6 +454,69 @@ export const useNotificationStore = create<NotificationState>((set, get) => {
                                     modelId: data['modelId'],
                                     step_key: typeof data['step_key'] === 'string' ? data['step_key'] : undefined,
                                     error: data['error'],
+                                    latestRenderedResourceId: typeof data['latestRenderedResourceId'] === 'string' ? data['latestRenderedResourceId'] : (data['latestRenderedResourceId'] === null ? null : undefined),
+                                };
+                            }
+                            break;
+                        case 'execute_started':
+                            if (
+                                typeof data['sessionId'] === 'string' &&
+                                typeof data['stageSlug'] === 'string' &&
+                                typeof data['iterationNumber'] === 'number' &&
+                                typeof data['job_id'] === 'string' &&
+                                typeof data['modelId'] === 'string'
+                            ) {
+                                eventPayload = {
+                                    type,
+                                    sessionId: data['sessionId'],
+                                    stageSlug: data['stageSlug'],
+                                    iterationNumber: data['iterationNumber'],
+                                    job_id: data['job_id'],
+                                    modelId: data['modelId'],
+                                    document_key: typeof data['document_key'] === 'string' ? data['document_key'] : undefined,
+                                    step_key: typeof data['step_key'] === 'string' ? data['step_key'] : undefined,
+                                };
+                            }
+                            break;
+                        case 'execute_chunk_completed':
+                            if (
+                                typeof data['sessionId'] === 'string' &&
+                                typeof data['stageSlug'] === 'string' &&
+                                typeof data['iterationNumber'] === 'number' &&
+                                typeof data['job_id'] === 'string' &&
+                                typeof data['modelId'] === 'string'
+                            ) {
+                                eventPayload = {
+                                    type,
+                                    sessionId: data['sessionId'],
+                                    stageSlug: data['stageSlug'],
+                                    iterationNumber: data['iterationNumber'],
+                                    job_id: data['job_id'],
+                                    modelId: data['modelId'],
+                                    document_key: typeof data['document_key'] === 'string' ? data['document_key'] : undefined,
+                                    step_key: typeof data['step_key'] === 'string' ? data['step_key'] : undefined,
+                                    isFinalChunk: typeof data['isFinalChunk'] === 'boolean' ? data['isFinalChunk'] : undefined,
+                                    continuationNumber: typeof data['continuationNumber'] === 'number' ? data['continuationNumber'] : undefined,
+                                };
+                            }
+                            break;
+                        case 'execute_completed':
+                            if (
+                                typeof data['sessionId'] === 'string' &&
+                                typeof data['stageSlug'] === 'string' &&
+                                typeof data['iterationNumber'] === 'number' &&
+                                typeof data['job_id'] === 'string' &&
+                                typeof data['modelId'] === 'string'
+                            ) {
+                                eventPayload = {
+                                    type,
+                                    sessionId: data['sessionId'],
+                                    stageSlug: data['stageSlug'],
+                                    iterationNumber: data['iterationNumber'],
+                                    job_id: data['job_id'],
+                                    modelId: data['modelId'],
+                                    document_key: typeof data['document_key'] === 'string' ? data['document_key'] : undefined,
+                                    step_key: typeof data['step_key'] === 'string' ? data['step_key'] : undefined,
                                     latestRenderedResourceId: typeof data['latestRenderedResourceId'] === 'string' ? data['latestRenderedResourceId'] : (data['latestRenderedResourceId'] === null ? null : undefined),
                                 };
                             }

--- a/packages/store/src/notificationStore.ts
+++ b/packages/store/src/notificationStore.ts
@@ -323,6 +323,11 @@ export const useNotificationStore = create<NotificationState>((set, get) => {
                                 eventPayload = { type, sessionId: data['sessionId'], projectId: data['projectId'] };
                             }
                             break;
+                        case 'contribution_generation_paused_nsf':
+                            if (typeof data['sessionId'] === 'string' && typeof data['projectId'] === 'string' && typeof data['stageSlug'] === 'string' && typeof data['iterationNumber'] === 'number') {
+                                eventPayload = { type, sessionId: data['sessionId'], projectId: data['projectId'], stageSlug: data['stageSlug'], iterationNumber: data['iterationNumber'] };
+                            }
+                            break;
                         case 'planner_started':
                             if (
                                 typeof data['sessionId'] === 'string' &&

--- a/packages/types/src/dialectic.types.ts
+++ b/packages/types/src/dialectic.types.ts
@@ -1074,6 +1074,7 @@ export interface DialecticApiClient {
   getStageDocumentFeedback(payload: GetStageDocumentFeedbackPayload): Promise<ApiResponse<StageDocumentFeedback[]>>;
   submitStageDocumentFeedback(payload: SubmitStageDocumentFeedbackPayload): Promise<ApiResponse<{ success: boolean }>>;
   listStageDocuments(payload: ListStageDocumentsPayload): Promise<ApiResponse<ListStageDocumentsResponse>>;
+  resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>;
 }
 
 
@@ -1147,6 +1148,16 @@ export interface StageProgressEntry {
 export interface GetAllStageProgressResponse {
   dagProgress: DagProgressDto;
   stages: StageProgressEntry[];
+}
+
+export interface ResumePausedNsfJobsPayload {
+  sessionId: string;
+  stageSlug: string;
+  iterationNumber: number;
+}
+
+export interface ResumePausedNsfJobsResponse {
+  resumedCount: number;
 }
 
 export interface ContributionContentSignedUrlResponse {
@@ -1282,6 +1293,9 @@ export type DialecticServiceActionPayload = {
 } | {
   action: 'getAllStageProgress';
   payload: GetAllStageProgressPayload;
+} | {
+  action: 'resumePausedNsfJobs';
+  payload: ResumePausedNsfJobsPayload;
 }
 
 export interface DialecticServiceResponsePayload {

--- a/packages/types/src/dialectic.types.ts
+++ b/packages/types/src/dialectic.types.ts
@@ -35,6 +35,15 @@ export function getDisplayName(slug: string): string {
   return DialecticStages[slug];
 }
 
+/** Per-stage minimum wallet balance (token count) required before generating. Values from product owner. */
+export const STAGE_BALANCE_THRESHOLDS: Record<string, number> = {
+  thesis: 200_000,
+  antithesis: 400_000,
+  synthesis: 1_000_000,
+  parenthesis: 250_000,
+  paralysis: 250_000,
+};
+
 export type DialecticStageTransition = Database['public']['Tables']['dialectic_stage_transitions']['Row'];
 
 export type DialecticProcessTemplate = Database['public']['Tables']['dialectic_process_templates']['Row'] & {
@@ -565,14 +574,14 @@ export interface JobProgressEntry {
 export type StepJobProgress = Record<string, JobProgressEntry>;
 
 export interface StageRunProgressSnapshot {
-  stepStatuses: Record<string, 'not_started' | 'in_progress' | 'waiting_for_children' | 'completed' | 'failed'>;
+  stepStatuses: Record<string, 'not_started' | 'in_progress' | 'waiting_for_children' | 'completed' | 'failed' | 'paused_nsf'>;
   /** Keyed by StageRunDocumentKey (documentKey:modelId). One document key can have N descriptors. */
   documents: Record<StageRunDocumentKey, StageRunDocumentDescriptor>;
   jobProgress: StepJobProgress;
   progress: { completedSteps: number; totalSteps: number; failedSteps: number };
 }
 
-export type UnifiedProjectStatus = 'not_started' | 'in_progress' | 'completed' | 'failed';
+export type UnifiedProjectStatus = 'not_started' | 'in_progress' | 'completed' | 'failed' | 'paused_nsf';
 
 export interface StepProgressDetail {
   stepKey: string;
@@ -713,6 +722,8 @@ export interface DialecticActions {
 
   // Action for generating contributions
   generateContributions: (payload: GenerateContributionsPayload) => Promise<ApiResponse<GenerateContributionsResponse>>;
+
+  resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload) => Promise<ApiResponse<ResumePausedNsfJobsResponse>>;
   
   // Actions for submitting stage responses and preparing next seed (plan 1.2.Y / 1.5.6.4)
   setSubmittingStageResponses: (isSubmitting: boolean) => void;
@@ -768,6 +779,7 @@ export interface DialecticActions {
   _handleRenderStarted: (event: RenderStartedPayload) => void;
   _handleRenderCompleted: (event: RenderCompletedPayload) => void;
   _handleJobFailed: (event: JobFailedPayload) => void;
+  _handleContributionGenerationPausedNsf: (event: ContributionGenerationPausedNsfPayload) => void;
   
   
   reset: () => void;
@@ -832,6 +844,7 @@ export type DialecticNotificationTypes =
   | 'contribution_generation_failed'
   | 'contribution_generation_complete'
   | 'contribution_generation_continued'
+  | 'contribution_generation_paused_nsf'
   | 'planner_started'
   | 'planner_completed'
   | 'document_started'
@@ -908,6 +921,14 @@ export interface ContributionGenerationCompletePayload {
   type: 'contribution_generation_complete';
   sessionId: string;
   projectId: string;
+}
+
+export interface ContributionGenerationPausedNsfPayload {
+  type: 'contribution_generation_paused_nsf';
+  sessionId: string;
+  projectId: string;
+  stageSlug: string;
+  iterationNumber: number;
 }
 
 export interface DocumentLifecyclePayload {
@@ -1009,6 +1030,7 @@ ContributionGenerationStartedPayload
 | ContributionGenerationFailedPayload 
 | ContributionGenerationContinuedPayload
 | ContributionGenerationCompletePayload
+| ContributionGenerationPausedNsfPayload
 | PlannerStartedPayload
 | PlannerCompletedPayload
 | DocumentStartedPayload

--- a/packages/types/src/dialectic.types.ts
+++ b/packages/types/src/dialectic.types.ts
@@ -930,8 +930,11 @@ export interface JobNotificationBase {
   step_key: string;
 }
 
-export interface PlannerStartedPayload extends DocumentLifecyclePayload {
+/** PLAN jobs may omit document_key and modelId; override base so they are optional. */
+export interface PlannerStartedPayload extends Omit<DocumentLifecyclePayload, 'document_key' | 'modelId'> {
   type: 'planner_started';
+  document_key?: string;
+  modelId?: string;
 }
 
 export interface PlannerCompletedPayload extends JobNotificationBase {
@@ -952,10 +955,11 @@ export interface DocumentCompletedPayload extends DocumentLifecyclePayload {
   type: 'document_completed';
 }
 
-/** EXECUTE job payload: modelId required, document_key optional. */
-export interface ExecutePayload extends JobNotificationBase {
+/** EXECUTE job payload: modelId required, document_key and step_key optional. */
+export interface ExecutePayload extends Omit<JobNotificationBase, 'step_key'> {
   modelId: string;
   document_key?: string;
+  step_key?: string;
 }
 
 export interface ExecuteStartedPayload extends ExecutePayload {

--- a/packages/types/src/dialectic.types.ts
+++ b/packages/types/src/dialectic.types.ts
@@ -724,7 +724,8 @@ export interface DialecticActions {
   generateContributions: (payload: GenerateContributionsPayload) => Promise<ApiResponse<GenerateContributionsResponse>>;
 
   resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload) => Promise<ApiResponse<ResumePausedNsfJobsResponse>>;
-  
+  regenerateDocument: (payload: RegenerateDocumentPayload) => Promise<ApiResponse<RegenerateDocumentResponse>>;
+
   // Actions for submitting stage responses and preparing next seed (plan 1.2.Y / 1.5.6.4)
   setSubmittingStageResponses: (isSubmitting: boolean) => void;
   setSubmitStageResponsesError: (error: ApiError | null) => void;
@@ -1097,6 +1098,7 @@ export interface DialecticApiClient {
   submitStageDocumentFeedback(payload: SubmitStageDocumentFeedbackPayload): Promise<ApiResponse<{ success: boolean }>>;
   listStageDocuments(payload: ListStageDocumentsPayload): Promise<ApiResponse<ListStageDocumentsResponse>>;
   resumePausedNsfJobs(payload: ResumePausedNsfJobsPayload): Promise<ApiResponse<ResumePausedNsfJobsResponse>>;
+  regenerateDocument(payload: RegenerateDocumentPayload): Promise<ApiResponse<RegenerateDocumentResponse>>;
 }
 
 
@@ -1180,6 +1182,17 @@ export interface ResumePausedNsfJobsPayload {
 
 export interface ResumePausedNsfJobsResponse {
   resumedCount: number;
+}
+
+export interface RegenerateDocumentPayload {
+  sessionId: string;
+  stageSlug: string;
+  iterationNumber: number;
+  documents: Array<{ documentKey: string; modelId: string }>;
+}
+
+export interface RegenerateDocumentResponse {
+  jobIds: string[];
 }
 
 export interface ContributionContentSignedUrlResponse {
@@ -1318,6 +1331,9 @@ export type DialecticServiceActionPayload = {
 } | {
   action: 'resumePausedNsfJobs';
   payload: ResumePausedNsfJobsPayload;
+} | {
+  action: 'regenerateDocument';
+  payload: RegenerateDocumentPayload;
 }
 
 export interface DialecticServiceResponsePayload {

--- a/packages/utils/src/type_guards.test.ts
+++ b/packages/utils/src/type_guards.test.ts
@@ -150,6 +150,7 @@ describe('isChatContextPreferences', () => {
 describe('isDialecticLifecycleEventType', () => {
     it('should return true for valid dialectic event types', () => {
         expect(isDialecticLifecycleEventType('contribution_generation_started')).toBe(true);
+        expect(isDialecticLifecycleEventType('contribution_generation_paused_nsf')).toBe(true);
         expect(isDialecticLifecycleEventType('dialectic_contribution_received')).toBe(true);
         expect(isDialecticLifecycleEventType('planner_started')).toBe(true);
         expect(isDialecticLifecycleEventType('document_started')).toBe(true);

--- a/packages/utils/src/type_guards.test.ts
+++ b/packages/utils/src/type_guards.test.ts
@@ -157,6 +157,9 @@ describe('isDialecticLifecycleEventType', () => {
         expect(isDialecticLifecycleEventType('document_completed')).toBe(true);
         expect(isDialecticLifecycleEventType('render_completed')).toBe(true);
         expect(isDialecticLifecycleEventType('job_failed')).toBe(true);
+        expect(isDialecticLifecycleEventType('execute_started')).toBe(true);
+        expect(isDialecticLifecycleEventType('execute_chunk_completed')).toBe(true);
+        expect(isDialecticLifecycleEventType('execute_completed')).toBe(true);
     });
 
     it('should return false for invalid event types', () => {

--- a/packages/utils/src/type_guards.ts
+++ b/packages/utils/src/type_guards.ts
@@ -196,6 +196,9 @@ export function isDialecticLifecycleEventType(x: unknown): x is DialecticNotific
     || x === 'document_started'
     || x === 'document_chunk_completed'
     || x === 'document_completed'
+    || x === 'execute_started'
+    || x === 'execute_chunk_completed'
+    || x === 'execute_completed'
     || x === 'render_completed'
     || x === 'job_failed'
   ) {

--- a/packages/utils/src/type_guards.ts
+++ b/packages/utils/src/type_guards.ts
@@ -212,7 +212,8 @@ export function isDialecticLifecycleEventType(x: unknown): x is DialecticNotific
       || suffix === 'retrying'
       || suffix === 'failed'
       || suffix === 'complete'
-      || suffix === 'continued';
+      || suffix === 'continued'
+      || suffix === 'paused_nsf';
   }
 
   const dcPrefix = 'dialectic_contribution_';

--- a/supabase/functions/_shared/services/document_renderer.interface.ts
+++ b/supabase/functions/_shared/services/document_renderer.interface.ts
@@ -40,6 +40,13 @@ export type RenderDocumentResult = {
   renderedBytes: Uint8Array;
 };
 
+/** One downloaded chunk's text for the concatenate-then-sanitize/parse pipeline in renderDocument. */
+export type DownloadedChunkText = {
+  chunkId: string;
+  text: string;
+  rawJsonPath: string;
+};
+
 export interface DocumentRendererDeps {
   downloadFromStorage: DownloadFromStorageFn;
   fileManager: IFileManager;

--- a/supabase/functions/_shared/services/document_renderer.test.ts
+++ b/supabase/functions/_shared/services/document_renderer.test.ts
@@ -5368,3 +5368,437 @@ Deno.test("DocumentRenderer - array content handling", async (t) => {
   });
 });
 
+Deno.test("DocumentRenderer - concatenate then sanitize/parse pipeline", async (t) => {
+  const setup = (config: MockSupabaseDataConfig = {}) => {
+    const { client, clearAllStubs } = createMockSupabaseClient(undefined, config);
+    return { dbClient: client as unknown as SupabaseClient<Database>, clearAllStubs };
+  };
+
+  const defaultTemplateSelect = {
+    data: [
+      {
+        id: "template-1",
+        created_at: "2025-01-01T00:00:00Z",
+        description: null,
+        domain_id: "domain-1",
+        file_name: "thesis_business_case.md",
+        is_active: true,
+        name: "thesis_business_case",
+        storage_bucket: "prompt-templates",
+        storage_path: "templates/thesis",
+        updated_at: "2025-01-01T00:00:00Z",
+      },
+    ],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: "OK",
+  };
+
+  const baseContributionRow: Database["public"]["Tables"]["dialectic_contributions"]["Row"] = {
+    id: "root-concat-1",
+    session_id: "session_concat",
+    stage: "THESIS",
+    iteration_number: 1,
+    model_id: "model-uuid-test",
+    model_name: "Test Model",
+    storage_bucket: "content",
+    storage_path: "proj_x/session_s/iteration_1/thesis/documents",
+    file_name: "gpt-4o-mini_0_business_case_raw.json",
+    raw_response_storage_path: "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json",
+    mime_type: "text/markdown",
+    document_relationships: { thesis: "root-concat-1" },
+    created_at: new Date(2025, 0, 1, 12, 0, 0).toISOString(),
+    target_contribution_id: null,
+    edit_version: 1,
+    is_latest_edit: true,
+    updated_at: new Date(2025, 0, 1, 12, 0, 0).toISOString(),
+    contribution_type: null,
+    citations: null,
+    error: null,
+    is_header: false,
+    original_model_contribution_id: null,
+    processing_time_ms: null,
+    prompt_template_id_used: null,
+    seed_prompt_url: null,
+    size_bytes: null,
+    source_prompt_resource_id: null,
+    tokens_used_input: null,
+    tokens_used_output: null,
+    user_id: "user_123",
+  };
+
+  await t.step("two chunks as JSON fragments are concatenated, sanitized, and parsed into a single merged object", async () => {
+    const fragment1 = `{"content": {"executive_summary": "hello `;
+    const fragment2 = `world"}}`;
+    const path1 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json";
+    const path2 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_1_business_case_raw.json";
+
+    const contributions: Array<Database["public"]["Tables"]["dialectic_contributions"]["Row"]> = [
+      { ...baseContributionRow, id: "root-frag", document_relationships: { thesis: "root-frag" }, file_name: "gpt-4o-mini_0_business_case_raw.json", raw_response_storage_path: path1 },
+      {
+        ...baseContributionRow,
+        id: "cont-frag",
+        file_name: "gpt-4o-mini_1_business_case_raw.json",
+        raw_response_storage_path: path2,
+        target_contribution_id: "root-frag",
+        edit_version: 2,
+        created_at: new Date(2025, 0, 1, 12, 1, 0).toISOString(),
+        updated_at: new Date(2025, 0, 1, 12, 1, 0).toISOString(),
+        document_relationships: { thesis: "root-frag" },
+      },
+    ];
+
+    const mockDownloadFromStorage = async (
+      _supabase: SupabaseClient<Database>,
+      _bucket: string,
+      path: string,
+    ): Promise<{ data: ArrayBuffer; error: null }> => {
+      if (path === path1) return { data: (await new Blob([fragment1]).arrayBuffer()), error: null };
+      if (path === path2) return { data: (await new Blob([fragment2]).arrayBuffer()), error: null };
+      return { data: (await new Blob([REAL_THESIS_BUSINESS_CASE_TEMPLATE]).arrayBuffer()), error: null };
+    };
+
+    const { dbClient, clearAllStubs } = setup({
+      genericMockResults: {
+        dialectic_contributions: { select: { data: contributions, error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_projects: { select: { data: [{ id: "project_123", selected_domain_id: "domain-1" }], error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_document_templates: { select: defaultTemplateSelect },
+      },
+    });
+
+    const params: RenderDocumentParams = {
+      projectId: "project_123",
+      sessionId: "session_concat",
+      iterationNumber: 1,
+      stageSlug: "thesis",
+      documentIdentity: "root-frag",
+      documentKey: FileType.business_case,
+      sourceContributionId: "root-frag",
+      template_filename: "thesis_business_case.md",
+    };
+
+    const result: RenderDocumentResult = await renderDocument(dbClient, {
+      downloadFromStorage: mockDownloadFromStorage,
+      fileManager: (() => {
+        const fm = new MockFileManagerService();
+        fm.setUploadAndRegisterFileResponse(createMockFileRecord(), null);
+        return fm;
+      })(),
+      notificationService: mockNotificationService,
+      notifyUserId: "user_123",
+      logger: logger,
+    }, params);
+
+    const rendered = new TextDecoder().decode(result.renderedBytes);
+    assert(rendered.includes("hello world"), "concatenated fragment content must appear in rendered output");
+    clearAllStubs?.();
+  });
+
+  await t.step("single chunk with complete JSON still works (regression guard)", async () => {
+    const path1 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json";
+    const structuredData = { executive_summary: "Single chunk summary.", market_opportunity: "Single chunk market." };
+    const jsonContent = JSON.stringify({ content: structuredData });
+
+    const contributions: Array<Database["public"]["Tables"]["dialectic_contributions"]["Row"]> = [
+      { ...baseContributionRow, raw_response_storage_path: path1 },
+    ];
+
+    const mockDownloadFromStorage = async (
+      _supabase: SupabaseClient<Database>,
+      _bucket: string,
+      path: string,
+    ): Promise<{ data: ArrayBuffer; error: null }> => {
+      if (path === path1) return { data: (await new Blob([jsonContent]).arrayBuffer()), error: null };
+      return { data: (await new Blob([REAL_THESIS_BUSINESS_CASE_TEMPLATE]).arrayBuffer()), error: null };
+    };
+
+    const { dbClient, clearAllStubs } = setup({
+      genericMockResults: {
+        dialectic_contributions: { select: { data: contributions, error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_projects: { select: { data: [{ id: "project_123", selected_domain_id: "domain-1" }], error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_document_templates: { select: defaultTemplateSelect },
+      },
+    });
+
+    const params: RenderDocumentParams = {
+      projectId: "project_123",
+      sessionId: "session_concat",
+      iterationNumber: 1,
+      stageSlug: "thesis",
+      documentIdentity: baseContributionRow.id,
+      documentKey: FileType.business_case,
+      sourceContributionId: baseContributionRow.id,
+      template_filename: "thesis_business_case.md",
+    };
+
+    const result: RenderDocumentResult = await renderDocument(dbClient, {
+      downloadFromStorage: mockDownloadFromStorage,
+      fileManager: (() => {
+        const fm = new MockFileManagerService();
+        fm.setUploadAndRegisterFileResponse(createMockFileRecord(), null);
+        return fm;
+      })(),
+      notificationService: mockNotificationService,
+      notifyUserId: "user_123",
+      logger: logger,
+    }, params);
+
+    const rendered = new TextDecoder().decode(result.renderedBytes);
+    assert(rendered.includes("Single chunk summary."), "single-chunk extracted content must appear");
+    assert(rendered.includes("Single chunk market."), "single-chunk market content must appear");
+    clearAllStubs?.();
+  });
+
+  await t.step("concatenated result with backtick wrappers is sanitized correctly before parse", async () => {
+    const path1 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json";
+    const wrappedContent = "```json\n" + JSON.stringify({ content: { executive_summary: "From backticks.", market_opportunity: "Market from backticks." } }) + "\n```";
+
+    const contributions: Array<Database["public"]["Tables"]["dialectic_contributions"]["Row"]> = [
+      { ...baseContributionRow, raw_response_storage_path: path1 },
+    ];
+
+    const mockDownloadFromStorage = async (
+      _supabase: SupabaseClient<Database>,
+      _bucket: string,
+      path: string,
+    ): Promise<{ data: ArrayBuffer; error: null }> => {
+      if (path === path1) return { data: (await new Blob([wrappedContent]).arrayBuffer()), error: null };
+      return { data: (await new Blob([REAL_THESIS_BUSINESS_CASE_TEMPLATE]).arrayBuffer()), error: null };
+    };
+
+    const { dbClient, clearAllStubs } = setup({
+      genericMockResults: {
+        dialectic_contributions: { select: { data: contributions, error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_projects: { select: { data: [{ id: "project_123", selected_domain_id: "domain-1" }], error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_document_templates: { select: defaultTemplateSelect },
+      },
+    });
+
+    const params: RenderDocumentParams = {
+      projectId: "project_123",
+      sessionId: "session_concat",
+      iterationNumber: 1,
+      stageSlug: "thesis",
+      documentIdentity: baseContributionRow.id,
+      documentKey: FileType.business_case,
+      sourceContributionId: baseContributionRow.id,
+      template_filename: "thesis_business_case.md",
+    };
+
+    const result: RenderDocumentResult = await renderDocument(dbClient, {
+      downloadFromStorage: mockDownloadFromStorage,
+      fileManager: (() => {
+        const fm = new MockFileManagerService();
+        fm.setUploadAndRegisterFileResponse(createMockFileRecord(), null);
+        return fm;
+      })(),
+      notificationService: mockNotificationService,
+      notifyUserId: "user_123",
+      logger: logger,
+    }, params);
+
+    const rendered = new TextDecoder().decode(result.renderedBytes);
+    assert(rendered.includes("From backticks."), "content inside backtick wrappers must be extracted");
+    assert(rendered.includes("Market from backticks."), "market content inside backticks must appear");
+    clearAllStubs?.();
+  });
+
+  await t.step("multiple chunks each complete JSON objects use fallback per-chunk sanitize/parse and merge", async () => {
+    const path1 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json";
+    const path2 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_1_business_case_raw.json";
+    const json1 = JSON.stringify({ content: { executive_summary: "First chunk only." } });
+    const json2 = JSON.stringify({ content: { market_opportunity: "Second chunk only." } });
+
+    const contributions: Array<Database["public"]["Tables"]["dialectic_contributions"]["Row"]> = [
+      { ...baseContributionRow, id: "root-full", document_relationships: { thesis: "root-full" }, raw_response_storage_path: path1 },
+      {
+        ...baseContributionRow,
+        id: "cont-full",
+        file_name: "gpt-4o-mini_1_business_case_raw.json",
+        raw_response_storage_path: path2,
+        target_contribution_id: "root-full",
+        edit_version: 2,
+        created_at: new Date(2025, 0, 1, 12, 1, 0).toISOString(),
+        updated_at: new Date(2025, 0, 1, 12, 1, 0).toISOString(),
+        document_relationships: { thesis: "root-full" },
+      },
+    ];
+
+    const mockDownloadFromStorage = async (
+      _supabase: SupabaseClient<Database>,
+      _bucket: string,
+      path: string,
+    ): Promise<{ data: ArrayBuffer; error: null }> => {
+      if (path === path1) return { data: (await new Blob([json1]).arrayBuffer()), error: null };
+      if (path === path2) return { data: (await new Blob([json2]).arrayBuffer()), error: null };
+      return { data: (await new Blob([REAL_THESIS_BUSINESS_CASE_TEMPLATE]).arrayBuffer()), error: null };
+    };
+
+    const { dbClient, clearAllStubs } = setup({
+      genericMockResults: {
+        dialectic_contributions: { select: { data: contributions, error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_projects: { select: { data: [{ id: "project_123", selected_domain_id: "domain-1" }], error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_document_templates: { select: defaultTemplateSelect },
+      },
+    });
+
+    const params: RenderDocumentParams = {
+      projectId: "project_123",
+      sessionId: "session_concat",
+      iterationNumber: 1,
+      stageSlug: "thesis",
+      documentIdentity: "root-full",
+      documentKey: FileType.business_case,
+      sourceContributionId: "root-full",
+      template_filename: "thesis_business_case.md",
+    };
+
+    const result: RenderDocumentResult = await renderDocument(dbClient, {
+      downloadFromStorage: mockDownloadFromStorage,
+      fileManager: (() => {
+        const fm = new MockFileManagerService();
+        fm.setUploadAndRegisterFileResponse(createMockFileRecord(), null);
+        return fm;
+      })(),
+      notificationService: mockNotificationService,
+      notifyUserId: "user_123",
+      logger: logger,
+    }, params);
+
+    const rendered = new TextDecoder().decode(result.renderedBytes);
+    assert(rendered.includes("First chunk only."), "first complete-JSON chunk content must appear");
+    assert(rendered.includes("Second chunk only."), "second complete-JSON chunk content must appear");
+    clearAllStubs?.();
+  });
+
+  await t.step("non-JSON chunks (plain text not starting with { or [) are handled by plain-text path", async () => {
+    const path1 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json";
+    const plainText = "Plain markdown without JSON.\n\nNo curly braces at start.";
+
+    const contributions: Array<Database["public"]["Tables"]["dialectic_contributions"]["Row"]> = [
+      { ...baseContributionRow, raw_response_storage_path: path1 },
+    ];
+
+    const mockDownloadFromStorage = async (
+      _supabase: SupabaseClient<Database>,
+      _bucket: string,
+      path: string,
+    ): Promise<{ data: ArrayBuffer; error: null }> => {
+      if (path === path1) return { data: (await new Blob([plainText]).arrayBuffer()), error: null };
+      return { data: (await new Blob([REAL_THESIS_BUSINESS_CASE_TEMPLATE]).arrayBuffer()), error: null };
+    };
+
+    const { dbClient, clearAllStubs } = setup({
+      genericMockResults: {
+        dialectic_contributions: { select: { data: contributions, error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_projects: { select: { data: [{ id: "project_123", selected_domain_id: "domain-1" }], error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_document_templates: { select: defaultTemplateSelect },
+      },
+    });
+
+    const params: RenderDocumentParams = {
+      projectId: "project_123",
+      sessionId: "session_concat",
+      iterationNumber: 1,
+      stageSlug: "thesis",
+      documentIdentity: baseContributionRow.id,
+      documentKey: FileType.business_case,
+      sourceContributionId: baseContributionRow.id,
+      template_filename: "thesis_business_case.md",
+    };
+
+    const result: RenderDocumentResult = await renderDocument(dbClient, {
+      downloadFromStorage: mockDownloadFromStorage,
+      fileManager: (() => {
+        const fm = new MockFileManagerService();
+        fm.setUploadAndRegisterFileResponse(createMockFileRecord(), null);
+        return fm;
+      })(),
+      notificationService: mockNotificationService,
+      notifyUserId: "user_123",
+      logger: logger,
+    }, params);
+
+    const rendered = new TextDecoder().decode(result.renderedBytes);
+    assert(rendered.includes("Plain markdown without JSON."), "plain-text content must appear in _extra_content");
+    assert(rendered.includes("No curly braces at start."), "plain-text second line must appear");
+    clearAllStubs?.();
+  });
+
+  await t.step("when sanitization/parse fails, error is thrown with chunk IDs and storage paths", async () => {
+    const path1 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_0_business_case_raw.json";
+    const path2 = "proj_x/session_s/iteration_1/thesis/documents/gpt-4o-mini_1_business_case_raw.json";
+    const fragment1 = `{"content": "unclosed`;
+    const fragment2 = `string`;
+
+    const contributions: Array<Database["public"]["Tables"]["dialectic_contributions"]["Row"]> = [
+      { ...baseContributionRow, id: "chunk-err-1", document_relationships: { thesis: "chunk-err-1" }, raw_response_storage_path: path1 },
+      {
+        ...baseContributionRow,
+        id: "chunk-err-2",
+        file_name: "gpt-4o-mini_1_business_case_raw.json",
+        raw_response_storage_path: path2,
+        target_contribution_id: "chunk-err-1",
+        edit_version: 2,
+        created_at: new Date(2025, 0, 1, 12, 1, 0).toISOString(),
+        updated_at: new Date(2025, 0, 1, 12, 1, 0).toISOString(),
+        document_relationships: { thesis: "chunk-err-1" },
+      },
+    ];
+
+    const mockDownloadFromStorage = async (
+      _supabase: SupabaseClient<Database>,
+      _bucket: string,
+      path: string,
+    ): Promise<{ data: ArrayBuffer; error: null }> => {
+      if (path === path1) return { data: (await new Blob([fragment1]).arrayBuffer()), error: null };
+      if (path === path2) return { data: (await new Blob([fragment2]).arrayBuffer()), error: null };
+      return { data: (await new Blob([REAL_THESIS_BUSINESS_CASE_TEMPLATE]).arrayBuffer()), error: null };
+    };
+
+    const { dbClient, clearAllStubs } = setup({
+      genericMockResults: {
+        dialectic_contributions: { select: { data: contributions, error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_projects: { select: { data: [{ id: "project_123", selected_domain_id: "domain-1" }], error: null, count: null, status: 200, statusText: "OK" } },
+        dialectic_document_templates: { select: defaultTemplateSelect },
+      },
+    });
+
+    const params: RenderDocumentParams = {
+      projectId: "project_123",
+      sessionId: "session_concat",
+      iterationNumber: 1,
+      stageSlug: "thesis",
+      documentIdentity: "chunk-err-1",
+      documentKey: FileType.business_case,
+      sourceContributionId: "chunk-err-1",
+      template_filename: "thesis_business_case.md",
+    };
+
+    let thrown: Error | undefined;
+    try {
+      await renderDocument(dbClient, {
+        downloadFromStorage: mockDownloadFromStorage,
+        fileManager: (() => {
+          const fm = new MockFileManagerService();
+          fm.setUploadAndRegisterFileResponse(createMockFileRecord(), null);
+          return fm;
+        })(),
+        notificationService: mockNotificationService,
+        notifyUserId: "user_123",
+        logger: logger,
+      }, params);
+    } catch (e) {
+      thrown = e instanceof Error ? e : new Error(String(e));
+    }
+
+    assert(thrown !== undefined, "renderDocument must throw when concatenated content fails to parse");
+    const msg = thrown?.message ?? "";
+    assert(msg.includes("chunk-err-1") || msg.includes("chunk-err-2"), "error message must include chunk IDs");
+    assert(msg.includes(path1) || msg.includes(path2), "error message must include storage path");
+    assert(msg.includes("parse") || msg.includes("sanitiz"), "error message must include parse or sanitization failure details");
+    clearAllStubs?.();
+  });
+});
+

--- a/supabase/functions/_shared/services/document_renderer.ts
+++ b/supabase/functions/_shared/services/document_renderer.ts
@@ -8,12 +8,16 @@ import type {
   RenderDocumentParams,
   RenderDocumentResult,
   DocumentRendererDeps,
+  DownloadedChunkText,
 } from "./document_renderer.interface.ts";
 import type { ResourceUploadContext } from "../types/file_manager.types.ts";
 import type { DownloadFromStorageFn } from "../supabase_storage_utils.ts";
 import type { DialecticContributionRow } from "../../dialectic-service/dialectic.interface.ts";
 import { renderPrompt } from "../prompt-renderer.ts";
 import { isRecord } from "../utils/type_guards.ts";
+import { sanitizeJsonContent } from "../utils/jsonSanitizer.ts";
+import { isJsonSanitizationResult } from "../utils/type-guards/type_guards.jsonSanitizer.ts";
+import type { JsonSanitizationResult } from "../types/jsonSanitizer.interface.ts";
  
 function titleFromDocumentKey(documentKey: string): string {
   const withSpaces = documentKey.replace(/_/g, " ");
@@ -300,11 +304,12 @@ export async function renderDocument(
   }
   const template = new TextDecoder().decode(templateData);
 
-  // Collect structured data from all chunks
-  // The agent returns JSON where content field is a JSON string containing structured data
+  // Collect structured data from all chunks (Phase 1: download; Phase 2: concatenated sanitize/parse; Phase 3: per-chunk fallback)
   const mergedStructuredData: Record<string, unknown> = {};
   const contentBucket = base.storage_bucket;
-  
+
+  // Phase 1: download all chunks into ordered array
+  const downloadedChunks: DownloadedChunkText[] = [];
   for (const chunk of uniqueChunks) {
     const fileName = chunk.file_name;
     if (!fileName || typeof fileName !== 'string') {
@@ -312,76 +317,139 @@ export async function renderDocument(
     }
     const rawJsonPath = `${chunk.storage_path}/${fileName}`;
     const text = await downloadText(dbClient, deps.downloadFromStorage, contentBucket, rawJsonPath);
-    const trimmedText = text.trim();
-    
-    deps.logger?.info?.('[renderDocument] DEBUG: Raw text length', { 
-      chunkId: chunk.id, 
-      rawJsonPath, 
+    const entry: DownloadedChunkText = { chunkId: chunk.id, text, rawJsonPath };
+    downloadedChunks.push(entry);
+    deps.logger?.info?.('[renderDocument] DEBUG: Raw text length', {
+      chunkId: chunk.id,
+      rawJsonPath,
       textLength: text.length,
-      trimmedTextLength: trimmedText.length,
+      trimmedTextLength: text.trim().length,
       textFirst100: text.substring(0, 100),
       textLast100: text.substring(Math.max(0, text.length - 100)),
-      trimmedTextFirst100: trimmedText.substring(0, 100),
-      trimmedTextLast100: trimmedText.substring(Math.max(0, trimmedText.length - 100)),
     });
-    
-    if (trimmedText.startsWith('{') || trimmedText.startsWith('[')) {
-      try {
-        deps.logger?.info?.('[renderDocument] DEBUG: Attempting JSON.parse', { 
-          chunkId: chunk.id, 
-          rawJsonPath,
-          usingTrimmed: false,
-          textLength: text.length,
-        });
-        const parsed = JSON.parse(text);
-        if (typeof parsed !== 'object' || parsed === null) {
-          throw new Error(`Parsed JSON is not an object for contribution ${chunk.id}`);
+  }
+
+  function mergeParsedIntoMerged(merged: Record<string, unknown>, parsed: unknown): void {
+    if (!isRecord(parsed)) return;
+    const structuredData: Record<string, unknown> = isRecord(parsed.content) ? parsed.content : parsed;
+    delete structuredData.continuation_needed;
+    delete structuredData.stop_reason;
+    for (const key in structuredData) {
+      if (Object.prototype.hasOwnProperty.call(structuredData, key)) {
+        const value = structuredData[key];
+        if (typeof value === 'string' && key in merged && typeof merged[key] === 'string') {
+          merged[key] = (merged[key]) + '\n\n' + value;
+        } else {
+          merged[key] = value;
         }
-        // Unwrap optional "content" envelope if present; otherwise use top-level object directly.
-        // AI models may return { "content": { ... } } or { "field1": ..., "field2": ... } at the top level.
-        const structuredData: Record<string, unknown> = isRecord(parsed.content)
-          ? parsed.content
-          : parsed;
+      }
+    }
+  }
 
-        // Strip known AI metadata keys that are not template placeholders
-        delete structuredData.continuation_needed;
-        delete structuredData.stop_reason;
+  const allJsonLike = downloadedChunks.every(
+    (d) => d.text.trim().startsWith('{') || d.text.trim().startsWith('[')
+  );
+  const firstChunkJsonLike =
+    downloadedChunks.length > 0 &&
+    (downloadedChunks[0].text.trim().startsWith('{') || downloadedChunks[0].text.trim().startsWith('['));
+  const tryConcatenatedParse =
+    downloadedChunks.length > 0 && (allJsonLike || (downloadedChunks.length > 1 && firstChunkJsonLike));
+  let phase2Success = false;
 
-        // Merge structured data from this chunk into the merged data
-        // For string values, concatenate them to preserve order from multiple chunks
-        for (const key in structuredData) {
-          if (Object.prototype.hasOwnProperty.call(structuredData, key)) {
-            const value = structuredData[key];
-            if (typeof value === 'string' && key in mergedStructuredData && typeof mergedStructuredData[key] === 'string') {
-              // Concatenate string values to preserve order
-              mergedStructuredData[key] = (mergedStructuredData[key]) + '\n\n' + value;
-            } else {
-              // New keys are added
-              mergedStructuredData[key] = value;
-            }
+  // Phase 2: concatenated sanitize/parse (normal path for continuation fragments)
+  if (tryConcatenatedParse) {
+    const concatenated = downloadedChunks.map((d) => d.text).join('');
+    const sanitizationResult: JsonSanitizationResult = sanitizeJsonContent(concatenated);
+    if (isJsonSanitizationResult(sanitizationResult)) {
+      try {
+        const parsed: unknown = JSON.parse(sanitizationResult.sanitized);
+        if (typeof parsed === 'object' && parsed !== null) {
+          mergeParsedIntoMerged(mergedStructuredData, parsed);
+          phase2Success = true;
+          if (sanitizationResult.wasSanitized) {
+            deps.logger?.info?.('[renderDocument] JSON content sanitized (concatenated)', {
+              originalLength: sanitizationResult.originalLength,
+              sanitizedLength: sanitizationResult.sanitized.length,
+              wasStructurallyFixed: sanitizationResult.wasStructurallyFixed,
+              hasDuplicateKeys: sanitizationResult.hasDuplicateKeys,
+            });
           }
+          deps.logger?.info?.('[renderDocument] Extracted structured data from content object', {
+            chunkIds: downloadedChunks.map((d) => d.chunkId),
+            dataKeys: Object.keys(mergedStructuredData),
+          });
+        }
+      } catch (_) {
+        // Fall through to Phase 3
+      }
+    }
+  }
+
+  // Phase 3: per-chunk sanitize/parse (normal path for independently-complete chunks) or plain-text
+  if (!phase2Success) {
+    for (const d of downloadedChunks) {
+      const trimmedText = d.text.trim();
+      if (trimmedText.startsWith('{') || trimmedText.startsWith('[')) {
+        const sanitizationResult: JsonSanitizationResult = sanitizeJsonContent(d.text);
+        if (!isJsonSanitizationResult(sanitizationResult)) {
+          const chunkIds = downloadedChunks.map((c) => c.chunkId).join(', ');
+          const paths = downloadedChunks.map((c) => c.rawJsonPath).join('; ');
+          throw new Error(
+            `Failed to parse JSON content: invalid sanitization result (chunk IDs: ${chunkIds}; paths: ${paths})`
+          );
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(sanitizationResult.sanitized);
+        } catch (e) {
+          const chunkIds = downloadedChunks.map((c) => c.chunkId).join(', ');
+          const paths = downloadedChunks.map((c) => c.rawJsonPath).join('; ');
+          const parseMsg = e instanceof Error ? e.message : String(e);
+          throw new Error(
+            `Failed to parse JSON content from contribution ${d.chunkId} (path: ${d.rawJsonPath}): ${parseMsg}. Chunk IDs: ${chunkIds}; paths: ${paths}`
+          );
+        }
+        if (typeof parsed !== 'object' || parsed === null) {
+          throw new Error(`Parsed JSON is not an object for contribution ${d.chunkId}`);
+        }
+        mergeParsedIntoMerged(mergedStructuredData, parsed);
+        if (sanitizationResult.wasSanitized) {
+          deps.logger?.info?.('[renderDocument] JSON content sanitized (per-chunk)', {
+            chunkId: d.chunkId,
+            rawJsonPath: d.rawJsonPath,
+            originalLength: sanitizationResult.originalLength,
+            sanitizedLength: sanitizationResult.sanitized.length,
+            wasStructurallyFixed: sanitizationResult.wasStructurallyFixed,
+            hasDuplicateKeys: sanitizationResult.hasDuplicateKeys,
+          });
         }
         deps.logger?.info?.('[renderDocument] Extracted structured data from content object', {
-          chunkId: chunk.id,
-          rawJsonPath,
-          dataKeys: Object.keys(structuredData),
+          chunkId: d.chunkId,
+          rawJsonPath: d.rawJsonPath,
+          dataKeys: Object.keys(mergedStructuredData),
         });
-      } catch (e) {
-        if (e instanceof Error && e.message.includes('contribution')) {
-          throw e;
+      } else {
+        const extraContentKey = '_extra_content';
+        const current: unknown = mergedStructuredData[extraContentKey];
+        if (current === undefined || current === null) {
+          mergedStructuredData[extraContentKey] = [d.text];
+        } else if (Array.isArray(current)) {
+          const contentArray: string[] = [];
+          for (const item of current) {
+            contentArray.push(typeof item === 'string' ? item : JSON.stringify(item));
+          }
+          contentArray.push(d.text);
+          mergedStructuredData[extraContentKey] = contentArray;
+        } else {
+          // Agent included _extra_content with a non-array type; normalize so we keep the data and append this chunk
+          const serialized = typeof current === 'object' && current !== null ? JSON.stringify(current) : String(current);
+          mergedStructuredData[extraContentKey] = [serialized, d.text];
+          deps.logger?.warn?.('[renderDocument] _extra_content was not a string array (agent-supplied); normalized for chunk', {
+            chunkId: d.chunkId,
+            rawJsonPath: d.rawJsonPath,
+          });
         }
-        throw new Error(`Failed to parse JSON content from contribution ${chunk.id} (path: ${rawJsonPath}): ${e instanceof Error ? e.message : String(e)}`);
       }
-    } else {
-      // Non-JSON content: treat as plain text
-      // Append to _extra_content section if it exists in template
-      const extraContentKey = '_extra_content';
-      if (!mergedStructuredData[extraContentKey]) {
-        mergedStructuredData[extraContentKey] = [];
-      }
-      const contentArray = Array.isArray(mergedStructuredData[extraContentKey]) ? mergedStructuredData[extraContentKey] : [];
-      contentArray.push(text);
-      mergedStructuredData[extraContentKey] = contentArray;
     }
   }
 

--- a/supabase/functions/_shared/services/file_manager.assemble.test.ts
+++ b/supabase/functions/_shared/services/file_manager.assemble.test.ts
@@ -2427,4 +2427,554 @@ Deno.test('FileManagerService', async (t) => {
       afterEach();
     }
   });
+
+  await t.step('assembleAndSaveFinalDocument: two chunks as JSON fragments are concatenated, sanitized, and parsed successfully', async () => {
+    try {
+      const rootContributionId = 'root-frag-1';
+      const sessionId = 'session-frag-1';
+      const projectId = 'p1';
+      const shortSessionId = generateShortId(sessionId);
+      const documentRelationships: DocumentRelationships = { thesis: rootContributionId };
+
+      const rootChunk: DialecticContributionRow = {
+        id: rootContributionId,
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/raw_responses`,
+        file_name: 'model_0_header_context_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:00:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: null,
+        updated_at: '2025-01-01T12:00:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const continuationChunk: DialecticContributionRow = {
+        id: 'cont-frag-1',
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/_work/raw_responses`,
+        file_name: 'model_0_header_context_continuation_1_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:01:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: rootContributionId,
+        updated_at: '2025-01-01T12:01:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const fragment1 = '{"key": "val';
+      const fragment2 = 'ue", "key2": "v2"}';
+
+      const config: MockSupabaseDataConfig = {
+        genericMockResults: {
+          dialectic_contributions: {
+            select: (state: MockQueryBuilderState) => {
+              if (state.filters.some((f) => f.column === 'id' && f.value === rootContributionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              if (state.filters.some((f) => f.column === 'session_id' && f.value === sessionId)) {
+                return Promise.resolve({ data: [rootChunk, continuationChunk], error: null });
+              }
+              return Promise.resolve({ data: [], error: new Error('Unexpected select query in test') });
+            },
+          },
+        },
+      };
+      beforeEach(config);
+
+      const fullRootPath = `${rootChunk.storage_path}/${rootChunk.file_name}`;
+      const fullContPath = `${continuationChunk.storage_path}/${continuationChunk.file_name}`;
+      const originalStorageFrom = setup.client.storage.from;
+      setup.client.storage.from = (bucketName: string) => {
+        const bucket = originalStorageFrom(bucketName);
+        const originalDownload = bucket.download;
+        bucket.download = async (path: string) => {
+          if (path === fullRootPath) return { data: new Blob([fragment1]), error: null };
+          if (path === fullContPath) return { data: new Blob([fragment2]), error: null };
+          return originalDownload.call(bucket, path);
+        };
+        return bucket;
+      };
+
+      const uploadSpy = setup.spies.storage.from('test-bucket').uploadSpy;
+      const result = await fileManager.assembleAndSaveFinalDocument(rootContributionId);
+
+      assertEquals(result.error, null);
+      assertExists(uploadSpy);
+      assertEquals(uploadSpy.calls.length, 1);
+
+      const uploadBody = uploadSpy.calls[0].args[1];
+      const finalContent: string = typeof uploadBody === 'string' ? uploadBody : uploadBody instanceof Blob ? await uploadBody.text() : new TextDecoder().decode(uploadBody);
+      const parsed: Record<string, unknown> = JSON.parse(finalContent);
+      assert(!Array.isArray(parsed) && typeof parsed === 'object' && parsed !== null);
+      assertEquals(parsed.key, 'value');
+      assertEquals(parsed.key2, 'v2');
+    } finally {
+      afterEach();
+    }
+  });
+
+  await t.step('assembleAndSaveFinalDocument: single chunk with complete JSON still works (regression)', async () => {
+    try {
+      const rootContributionId = 'root-single-1';
+      const sessionId = 'session-single-1';
+      const projectId = 'p1';
+      const shortSessionId = generateShortId(sessionId);
+      const documentRelationships: DocumentRelationships = { thesis: rootContributionId };
+
+      const rootChunk: DialecticContributionRow = {
+        id: rootContributionId,
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/raw_responses`,
+        file_name: 'model_0_product_requirements_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:00:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: null,
+        updated_at: '2025-01-01T12:00:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const singleJson = '{"title":"Doc","content":"Hello"}';
+
+      const config: MockSupabaseDataConfig = {
+        genericMockResults: {
+          dialectic_contributions: {
+            select: (state: MockQueryBuilderState) => {
+              if (state.filters.some((f) => f.column === 'id' && f.value === rootContributionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              if (state.filters.some((f) => f.column === 'session_id' && f.value === sessionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              return Promise.resolve({ data: [], error: new Error('Unexpected select query in test') });
+            },
+          },
+        },
+      };
+      beforeEach(config);
+
+      const fullRootPath = `${rootChunk.storage_path}/${rootChunk.file_name}`;
+      const originalStorageFrom = setup.client.storage.from;
+      setup.client.storage.from = (bucketName: string) => {
+        const bucket = originalStorageFrom(bucketName);
+        const originalDownload = bucket.download;
+        bucket.download = async (path: string) => {
+          if (path === fullRootPath) return { data: new Blob([singleJson]), error: null };
+          return originalDownload.call(bucket, path);
+        };
+        return bucket;
+      };
+
+      const uploadSpy = setup.spies.storage.from('test-bucket').uploadSpy;
+      const result = await fileManager.assembleAndSaveFinalDocument(rootContributionId);
+
+      assertEquals(result.error, null);
+      assertEquals(uploadSpy.calls.length, 1);
+
+      const uploadBody = uploadSpy.calls[0].args[1];
+      const finalContent: string = typeof uploadBody === 'string' ? uploadBody : uploadBody instanceof Blob ? await uploadBody.text() : new TextDecoder().decode(uploadBody);
+      const parsed: Record<string, unknown> = JSON.parse(finalContent);
+      assert(!Array.isArray(parsed) && typeof parsed === 'object' && parsed !== null);
+      assertEquals(parsed.title, 'Doc');
+      assertEquals(parsed.content, 'Hello');
+    } finally {
+      afterEach();
+    }
+  });
+
+  await t.step('assembleAndSaveFinalDocument: concatenated result with backtick wrappers is sanitized before parse', async () => {
+    try {
+      const rootContributionId = 'root-backtick-1';
+      const sessionId = 'session-backtick-1';
+      const projectId = 'p1';
+      const shortSessionId = generateShortId(sessionId);
+      const documentRelationships: DocumentRelationships = { thesis: rootContributionId };
+
+      const rootChunk: DialecticContributionRow = {
+        id: rootContributionId,
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/raw_responses`,
+        file_name: 'model_0_header_context_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:00:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: null,
+        updated_at: '2025-01-01T12:00:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const wrappedContent = '```json\n{"x": 42}\n```';
+
+      const config: MockSupabaseDataConfig = {
+        genericMockResults: {
+          dialectic_contributions: {
+            select: (state: MockQueryBuilderState) => {
+              if (state.filters.some((f) => f.column === 'id' && f.value === rootContributionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              if (state.filters.some((f) => f.column === 'session_id' && f.value === sessionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              return Promise.resolve({ data: [], error: new Error('Unexpected select query in test') });
+            },
+          },
+        },
+      };
+      beforeEach(config);
+
+      const fullRootPath = `${rootChunk.storage_path}/${rootChunk.file_name}`;
+      const originalStorageFrom = setup.client.storage.from;
+      setup.client.storage.from = (bucketName: string) => {
+        const bucket = originalStorageFrom(bucketName);
+        const originalDownload = bucket.download;
+        bucket.download = async (path: string) => {
+          if (path === fullRootPath) return { data: new Blob([wrappedContent]), error: null };
+          return originalDownload.call(bucket, path);
+        };
+        return bucket;
+      };
+
+      const uploadSpy = setup.spies.storage.from('test-bucket').uploadSpy;
+      const result = await fileManager.assembleAndSaveFinalDocument(rootContributionId);
+
+      assertEquals(result.error, null);
+      assertEquals(uploadSpy.calls.length, 1);
+
+      const uploadBody = uploadSpy.calls[0].args[1];
+      const finalContent: string = typeof uploadBody === 'string' ? uploadBody : uploadBody instanceof Blob ? await uploadBody.text() : new TextDecoder().decode(uploadBody);
+      const parsed: Record<string, unknown> = JSON.parse(finalContent);
+      assert(!Array.isArray(parsed) && typeof parsed === 'object' && parsed !== null);
+      assertEquals(parsed.x, 42);
+    } finally {
+      afterEach();
+    }
+  });
+
+  await t.step('assembleAndSaveFinalDocument: multiple independently-complete chunks use per-chunk sanitize/parse and deep-merge', async () => {
+    try {
+      const rootContributionId = 'root-indep-1';
+      const sessionId = 'session-indep-1';
+      const projectId = 'p1';
+      const shortSessionId = generateShortId(sessionId);
+      const documentRelationships: DocumentRelationships = { thesis: rootContributionId };
+
+      const rootChunk: DialecticContributionRow = {
+        id: rootContributionId,
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/raw_responses`,
+        file_name: 'model_0_product_requirements_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:00:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: null,
+        updated_at: '2025-01-01T12:00:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const continuationChunk: DialecticContributionRow = {
+        id: 'cont-indep-1',
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/_work/raw_responses`,
+        file_name: 'model_0_product_requirements_continuation_1_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:01:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: rootContributionId,
+        updated_at: '2025-01-01T12:01:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const chunk1Json = '{"a": 1}';
+      const chunk2Json = '{"b": 2}';
+
+      const config: MockSupabaseDataConfig = {
+        genericMockResults: {
+          dialectic_contributions: {
+            select: (state: MockQueryBuilderState) => {
+              if (state.filters.some((f) => f.column === 'id' && f.value === rootContributionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              if (state.filters.some((f) => f.column === 'session_id' && f.value === sessionId)) {
+                return Promise.resolve({ data: [rootChunk, continuationChunk], error: null });
+              }
+              return Promise.resolve({ data: [], error: new Error('Unexpected select query in test') });
+            },
+          },
+        },
+      };
+      beforeEach(config);
+
+      const fullRootPath = `${rootChunk.storage_path}/${rootChunk.file_name}`;
+      const fullContPath = `${continuationChunk.storage_path}/${continuationChunk.file_name}`;
+      const originalStorageFrom = setup.client.storage.from;
+      setup.client.storage.from = (bucketName: string) => {
+        const bucket = originalStorageFrom(bucketName);
+        const originalDownload = bucket.download;
+        bucket.download = async (path: string) => {
+          if (path === fullRootPath) return { data: new Blob([chunk1Json]), error: null };
+          if (path === fullContPath) return { data: new Blob([chunk2Json]), error: null };
+          return originalDownload.call(bucket, path);
+        };
+        return bucket;
+      };
+
+      const uploadSpy = setup.spies.storage.from('test-bucket').uploadSpy;
+      const result = await fileManager.assembleAndSaveFinalDocument(rootContributionId);
+
+      assertEquals(result.error, null);
+      assertEquals(uploadSpy.calls.length, 1);
+
+      const uploadBody = uploadSpy.calls[0].args[1];
+      const finalContent: string = typeof uploadBody === 'string' ? uploadBody : uploadBody instanceof Blob ? await uploadBody.text() : new TextDecoder().decode(uploadBody);
+      const parsed: Record<string, unknown> = JSON.parse(finalContent);
+      assert(!Array.isArray(parsed) && typeof parsed === 'object' && parsed !== null);
+      assertEquals(parsed.a, 1);
+      assertEquals(parsed.b, 2);
+    } finally {
+      afterEach();
+    }
+  });
+
+  await t.step('assembleAndSaveFinalDocument: when both concatenated and per-chunk parse fail, error includes chunk IDs, storage paths, and parse details', async () => {
+    try {
+      const rootContributionId = 'root-fail-1';
+      const sessionId = 'session-fail-1';
+      const projectId = 'p1';
+      const shortSessionId = generateShortId(sessionId);
+      const documentRelationships: DocumentRelationships = { thesis: rootContributionId };
+
+      const rootChunk: DialecticContributionRow = {
+        id: rootContributionId,
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/raw_responses`,
+        file_name: 'model_0_fail_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:00:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: null,
+        updated_at: '2025-01-01T12:00:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const continuationChunk: DialecticContributionRow = {
+        id: 'cont-fail-1',
+        storage_bucket: 'test-bucket',
+        storage_path: `${projectId}/session_${shortSessionId}/iteration_1/3_synthesis/_work/raw_responses`,
+        file_name: 'model_0_fail_continuation_1_raw.json',
+        document_relationships: documentRelationships,
+        created_at: '2025-01-01T12:01:00Z',
+        citations: [],
+        contribution_type: 'synthesis',
+        edit_version: 1,
+        error: null,
+        user_id: 'user-id-123',
+        is_latest_edit: true,
+        iteration_number: 1,
+        mime_type: 'application/json',
+        model_id: 'model-id',
+        model_name: 'Model',
+        session_id: sessionId,
+        tokens_used_input: 0,
+        tokens_used_output: 0,
+        processing_time_ms: 0,
+        original_model_contribution_id: null,
+        prompt_template_id_used: null,
+        raw_response_storage_path: null,
+        seed_prompt_url: null,
+        size_bytes: 1,
+        stage: 'synthesis',
+        target_contribution_id: rootContributionId,
+        updated_at: '2025-01-01T12:01:00Z',
+        is_header: false,
+        source_prompt_resource_id: null,
+      };
+
+      const unparseable1 = '{"key": "incomplete';
+      const unparseable2 = 'truncated';
+
+      const config: MockSupabaseDataConfig = {
+        genericMockResults: {
+          dialectic_contributions: {
+            select: (state: MockQueryBuilderState) => {
+              if (state.filters.some((f) => f.column === 'id' && f.value === rootContributionId)) {
+                return Promise.resolve({ data: [rootChunk], error: null });
+              }
+              if (state.filters.some((f) => f.column === 'session_id' && f.value === sessionId)) {
+                return Promise.resolve({ data: [rootChunk, continuationChunk], error: null });
+              }
+              return Promise.resolve({ data: [], error: new Error('Unexpected select query in test') });
+            },
+          },
+        },
+      };
+      beforeEach(config);
+
+      const fullRootPath = `${rootChunk.storage_path}/${rootChunk.file_name}`;
+      const fullContPath = `${continuationChunk.storage_path}/${continuationChunk.file_name}`;
+      const originalStorageFrom = setup.client.storage.from;
+      setup.client.storage.from = (bucketName: string) => {
+        const bucket = originalStorageFrom(bucketName);
+        const originalDownload = bucket.download;
+        bucket.download = async (path: string) => {
+          if (path === fullRootPath) return { data: new Blob([unparseable1]), error: null };
+          if (path === fullContPath) return { data: new Blob([unparseable2]), error: null };
+          return originalDownload.call(bucket, path);
+        };
+        return bucket;
+      };
+
+      const result = await fileManager.assembleAndSaveFinalDocument(rootContributionId);
+
+      assert(result.error !== null);
+      assert(result.error instanceof Error);
+      const msg = result.error.message;
+      assert(msg.includes(rootContributionId) || msg.includes('root-fail-1'), 'Error should include root chunk ID');
+      assert(msg.includes(continuationChunk.id) || msg.includes('cont-fail-1'), 'Error should include continuation chunk ID');
+      assert(msg.includes(fullRootPath) || msg.includes('raw_responses'), 'Error should include storage path');
+      assert(msg.includes(fullContPath) || msg.includes('_work/raw_responses'), 'Error should include continuation storage path');
+    } finally {
+      afterEach();
+    }
+  });
 });

--- a/supabase/functions/_shared/services/file_manager.ts
+++ b/supabase/functions/_shared/services/file_manager.ts
@@ -10,12 +10,16 @@ import {
   isPostgrestError, 
   isRecord 
 } from '../utils/type_guards.ts'
+import { sanitizeJsonContent } from '../utils/jsonSanitizer.ts'
+import { isJsonSanitizationResult } from '../utils/type-guards/type_guards.jsonSanitizer.ts'
+import type { JsonSanitizationResult } from '../types/jsonSanitizer.interface.ts'
 import {
   FileManagerDependencies,
   FileType,
   CanonicalPathParams,
   PathContext,
   DocumentKey,
+  ModelContributionFileTypes,
   ResourceFileTypes,
   ModelContributionUploadContext,
   UserFeedbackUploadContext,
@@ -30,6 +34,7 @@ import {
 } from '../types/file_manager.types.ts'
 import {
   isModelContributionContext,
+  isModelContributionFileType,
   isUserFeedbackContext,
   isResourceContext,
   isFileType,
@@ -617,10 +622,9 @@ export class FileManagerService implements IFileManager {
         currentId = nextChunk ? nextChunk.id : null;
       }
 
-      // 3. Download and parse JSON content from storage_path/file_name (canonical access method).
-      const parsedChunks: Record<string, unknown>[] = [];
+      // 3. Phase 1: Download all chunks into ordered array (chunkId, text, fullPath).
+      const downloadedChunks: { chunkId: string; text: string; fullPath: string }[] = [];
       for (const chunk of orderedChunks) {
-        // Validate storage_path and file_name exist (canonical access method)
         if (!chunk.storage_path || typeof chunk.storage_path !== 'string') {
           throw new Error(`Chunk ${chunk.id} is missing storage_path. Storage path is required for JSON assembly.`);
         }
@@ -637,27 +641,11 @@ export class FileManagerService implements IFileManager {
           throw new Error(`Failed to download chunk ${chunk.id} from ${fullPath}: ${error?.message || 'No data returned'}`);
         }
 
-        try {
-          const textContent = await data.text();
-          const parsedJson = JSON.parse(textContent);
-          // Validate that parsed JSON is a record (object, not array, not primitive)
-          if (!isRecord(parsedJson)) {
-            throw new Error(`Chunk ${chunk.id} contains invalid JSON: expected object, got ${Array.isArray(parsedJson) ? 'array' : typeof parsedJson}`);
-          }
-          parsedChunks.push(parsedJson);
-        } catch (parseError) {
-          throw new Error(`Failed to parse JSON from chunk ${chunk.id} at ${fullPath}: ${parseError instanceof Error ? parseError.message : 'Invalid JSON'}`);
-        }
+        const textContent = await data.text();
+        downloadedChunks.push({ chunkId: chunk.id, text: textContent, fullPath });
       }
 
-      // 4. Merge parsed chunks into a single ordered JSON object.
-      // Merging strategy:
-      // - Start with root chunk object
-      // - For each continuation chunk: merge properties
-      //   - For 'content' key: concatenate string values directly (continuation content already includes separators if needed)
-      //   - For object values: deep merge recursively
-      //   - For other values: use continuation's value (override or add)
-      if (parsedChunks.length === 0) {
+      if (downloadedChunks.length === 0) {
         throw new Error('No chunks to assemble');
       }
 
@@ -668,19 +656,11 @@ export class FileManagerService implements IFileManager {
             const sourceValue = source[key];
             const targetValue = merged[key];
 
-            // Special handling for 'content' key: concatenate strings
             if (key === 'content' && typeof targetValue === 'string' && typeof sourceValue === 'string') {
               merged[key] = targetValue + sourceValue;
-            }
-            // Deep merge objects (but not arrays)
-            else if (
-              isRecord(targetValue) &&
-              isRecord(sourceValue)
-            ) {
+            } else if (isRecord(targetValue) && isRecord(sourceValue)) {
               merged[key] = mergeObjects(targetValue, sourceValue);
-            }
-            // For all other cases: use source value (override or add)
-            else {
+            } else {
               merged[key] = sourceValue;
             }
           }
@@ -688,9 +668,79 @@ export class FileManagerService implements IFileManager {
         return merged;
       };
 
-      let mergedObject = parsedChunks[0];
-      for (let i = 1; i < parsedChunks.length; i++) {
-        mergedObject = mergeObjects(mergedObject, parsedChunks[i]);
+      const chunkIdsForError = downloadedChunks.map((c) => c.chunkId).join(', ');
+      const pathsForError = downloadedChunks.map((c) => c.fullPath).join('; ');
+
+      // Phase 2: Concatenated sanitize/parse (handles continuation fragments and backtick-wrapped content).
+      let mergedObject: Record<string, unknown> | null = null;
+
+      {
+        const concatenated = downloadedChunks.map((d) => d.text).join('');
+        const sanitizationResult: JsonSanitizationResult = sanitizeJsonContent(concatenated);
+        if (isJsonSanitizationResult(sanitizationResult)) {
+          try {
+            const parsed: unknown = JSON.parse(sanitizationResult.sanitized);
+            if (isRecord(parsed)) {
+              mergedObject = parsed;
+              if (sanitizationResult.wasSanitized) {
+                this.logger.info('[FileManagerService] assembleAndSaveFinalDocument JSON content sanitized (concatenated)', {
+                  wasSanitized: true,
+                  wasStructurallyFixed: sanitizationResult.wasStructurallyFixed,
+                  hasDuplicateKeys: sanitizationResult.hasDuplicateKeys,
+                });
+              }
+            }
+          } catch (_) {
+            // Fall through to Phase 3
+          }
+        }
+      }
+
+      // Phase 3: Per-chunk sanitize/parse (normal path for independently-complete chunks).
+      if (mergedObject === null) {
+        const parsedChunks: Record<string, unknown>[] = [];
+        for (const d of downloadedChunks) {
+          const sanitizationResult: JsonSanitizationResult = sanitizeJsonContent(d.text);
+          if (!isJsonSanitizationResult(sanitizationResult)) {
+            throw new Error(
+              `Failed to parse JSON from chunks: invalid sanitization result for chunk ${d.chunkId}. Chunk IDs: ${chunkIdsForError}; paths: ${pathsForError}`
+            );
+          }
+          try {
+            const parsed: unknown = JSON.parse(sanitizationResult.sanitized);
+            if (!isRecord(parsed)) {
+              throw new Error(
+                `Failed to parse JSON from chunks: chunk ${d.chunkId} parsed value is not a record. Chunk IDs: ${chunkIdsForError}; paths: ${pathsForError}`
+              );
+            }
+            parsedChunks.push(parsed);
+            if (sanitizationResult.wasSanitized) {
+              this.logger.info('[FileManagerService] assembleAndSaveFinalDocument JSON content sanitized (per-chunk)', {
+                chunkId: d.chunkId,
+                wasStructurallyFixed: sanitizationResult.wasStructurallyFixed,
+                hasDuplicateKeys: sanitizationResult.hasDuplicateKeys,
+              });
+            }
+          } catch (parseErr: unknown) {
+            const parseMsg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+            throw new Error(
+              `Failed to parse JSON from chunk ${d.chunkId} at ${d.fullPath}: ${parseMsg}. Chunk IDs: ${chunkIdsForError}; paths: ${pathsForError}`
+            );
+          }
+        }
+
+        if (parsedChunks.length === 0) {
+          throw new Error(`No chunks to assemble. Chunk IDs: ${chunkIdsForError}; paths: ${pathsForError}`);
+        }
+
+        mergedObject = parsedChunks[0];
+        for (let i = 1; i < parsedChunks.length; i++) {
+          mergedObject = mergeObjects(mergedObject, parsedChunks[i]);
+        }
+      }
+
+      if (mergedObject === null) {
+        throw new Error(`No chunks to assemble. Chunk IDs: ${chunkIdsForError}; paths: ${pathsForError}`);
       }
 
       const finalContent = JSON.stringify(mergedObject);
@@ -729,13 +779,10 @@ export class FileManagerService implements IFileManager {
         throw new Error(`Cannot construct AssembledDocumentJson path: missing required path context. ProjectId: ${pathInfo.originalProjectId}, StageSlug: ${pathInfo.stageSlug}, ModelSlug: ${pathInfo.modelSlug}, AttemptCount: ${pathInfo.attemptCount}, DocumentKey: ${pathInfo.documentKey}`);
       }
 
-      if (!isFileType(pathInfo.documentKey)) {
-        throw new Error(`Invalid documentKey: ${pathInfo.documentKey}`);
+      if (!isModelContributionFileType(pathInfo.documentKey)) {
+        throw new Error(`Invalid model contribution file type: ${pathInfo.documentKey}`);
       }
-      if (!isDocumentKey(pathInfo.documentKey)) {
-        throw new Error(`Invalid documentKey: ${pathInfo.documentKey}`);
-      }
-      const docKey: DocumentKey = pathInfo.documentKey
+      const artifactType: ModelContributionFileTypes = pathInfo.documentKey;
       const pathParams: CanonicalPathParams = {
         stageSlug: pathInfo.stageSlug,
         contributionType: 'synthesis',
@@ -749,7 +796,7 @@ export class FileManagerService implements IFileManager {
         stageSlug: pathParams.stageSlug,
         modelSlug: pathInfo.modelSlug,
         attemptCount: pathInfo.attemptCount,
-        documentKey: docKey,
+        documentKey: artifactType,
       };
 
       const constructedPath = this.constructStoragePath(pathContext);

--- a/supabase/functions/_shared/supabase.mock.ts
+++ b/supabase/functions/_shared/supabase.mock.ts
@@ -251,7 +251,7 @@ export interface IMockClientSpies {
           };
       };
       rpcResults?: {
-          [functionName: string]: { data?: object | object[] | null; error?: Error | null } | (() => Promise<{ data?: object | object[] | null; error?: Error | null }>);
+          [functionName: string]: { data?: object | object[] | number | null; error?: Error | null } | (() => Promise<{ data?: object | object[] | number | null; error?: Error | null }>);
       };
       mockRpc?: {
         [functionName: string]: () => Promise<{ data: any; error: any }>;

--- a/supabase/functions/_shared/types/notification.service.types.ts
+++ b/supabase/functions/_shared/types/notification.service.types.ts
@@ -10,6 +10,7 @@ export interface NotificationServiceType {
     sendContributionGenerationContinuedEvent(payload: ContributionGenerationContinuedPayload, targetUserId: string): Promise<void>;
     sendContributionGenerationFailedEvent(payload: ContributionGenerationFailedInternalPayload, targetUserId: string): Promise<void>;
     sendJobNotificationEvent(payload: JobNotificationEvent, targetUserId: string): Promise<void>;
+    sendContributionGenerationPausedNsfEvent(payload: ContributionGenerationPausedNsfPayload, targetUserId: string): Promise<void>;
 }
 
 export interface RpcNotification<T> {
@@ -106,6 +107,14 @@ export interface ContributionGenerationStartedPayload {
     projectId: string;
     job_id: string;
   }
+
+  export interface ContributionGenerationPausedNsfPayload {
+    type: 'contribution_generation_paused_nsf';
+    sessionId: string;
+    projectId: string;
+    stageSlug: string;
+    iterationNumber: number;
+  }
   
   export type DialecticLifecycleEvent = 
   ContributionGenerationStartedPayload 
@@ -114,7 +123,8 @@ export interface ContributionGenerationStartedPayload {
   | DialecticContributionReceivedPayload 
   | ContributionGenerationFailedPayload 
   | ContributionGenerationContinuedPayload
-  | ContributionGenerationCompletePayload;
+  | ContributionGenerationCompletePayload
+  | ContributionGenerationPausedNsfPayload;
 
 // ------------------------------
 // Job notification type hierarchy (PLAN / EXECUTE / RENDER lifecycle, unified job_failed)

--- a/supabase/functions/_shared/utils/notification.service.mock.ts
+++ b/supabase/functions/_shared/utils/notification.service.mock.ts
@@ -8,6 +8,7 @@ import type {
     ContributionGenerationStartedPayload,
     ContributionGenerationContinuedPayload,
     ContributionGenerationCompletePayload,
+    ContributionGenerationPausedNsfPayload,
     ContributionGenerationFailedPayload,
     ContributionGenerationFailedInternalPayload,
     ApiError,
@@ -26,6 +27,7 @@ function createMockService(): MockNotificationService {
         sendContributionReceivedEvent: spy(() => Promise.resolve()),
         sendContributionGenerationContinuedEvent: spy(() => Promise.resolve()),
         sendContributionGenerationCompleteEvent: spy(() => Promise.resolve()),
+        sendContributionGenerationPausedNsfEvent: spy(() => Promise.resolve()),
         sendContributionGenerationFailedEvent: spy(() => Promise.resolve()),
         sendContributionFailedNotification: spy(() => Promise.resolve()),
         sendJobNotificationEvent: spy(() => Promise.resolve()),
@@ -122,6 +124,14 @@ export const mockContributionGenerationCompletePayload: ContributionGenerationCo
     type: 'contribution_generation_complete',
     job_id: 'job-uuid-123',
   };
+
+export const mockContributionGenerationPausedNsfPayload: ContributionGenerationPausedNsfPayload = {
+  type: 'contribution_generation_paused_nsf',
+  sessionId: 'session-uuid-456',
+  projectId: 'project-uuid-abc',
+  stageSlug: 'antithesis',
+  iterationNumber: 1,
+};
 
 export const mockContributionGenerationFailedApiError: ApiError = {
     code: 'AI_ERROR',

--- a/supabase/functions/_shared/utils/notification.service.test.ts
+++ b/supabase/functions/_shared/utils/notification.service.test.ts
@@ -13,6 +13,7 @@ import {
   mockDialecticContributionReceivedPayload,
   mockContributionGenerationContinuedPayload,
   mockContributionGenerationCompletePayload,
+  mockContributionGenerationPausedNsfPayload,
   mockContributionGenerationFailedPayload,
   mockContributionGenerationFailedApiError,
   mockContributionGenerationFailedInternalPayload,
@@ -223,6 +224,52 @@ Deno.test('NotificationService - should send a valid internal event for contribu
   assertEquals(
     rpcParams.p_notification_data.projectId,
     mockContributionGenerationCompletePayload.projectId,
+  );
+});
+
+Deno.test('NotificationService - should send a valid internal event for contribution_generation_paused_nsf', async () => {
+  // Arrange
+  const mockUserId = 'user-123';
+  const { client, spies } = createMockSupabaseClient(mockUserId, {
+    rpcResults: {
+      create_notification_for_user: { data: null, error: null },
+    },
+  });
+  const service = new NotificationService(
+    client as unknown as SupabaseClient<Database>,
+  );
+  // Act
+  await service.sendContributionGenerationPausedNsfEvent(
+    mockContributionGenerationPausedNsfPayload,
+    mockUserId,
+  );
+
+  // Assert
+  assertEquals(spies.rpcSpy.calls.length, 1);
+  const rpcArgs = spies.rpcSpy.calls[0].args;
+  const rpcParams = rpcArgs[1];
+  assertEquals(rpcArgs[0], 'create_notification_for_user');
+  assertEquals(rpcParams.p_target_user_id, mockUserId);
+  assertEquals(
+    rpcParams.p_notification_type,
+    'contribution_generation_paused_nsf',
+  );
+  assertEquals(rpcParams.p_is_internal_event, true);
+  assertEquals(
+    rpcParams.p_notification_data.sessionId,
+    mockContributionGenerationPausedNsfPayload.sessionId,
+  );
+  assertEquals(
+    rpcParams.p_notification_data.projectId,
+    mockContributionGenerationPausedNsfPayload.projectId,
+  );
+  assertEquals(
+    rpcParams.p_notification_data.stageSlug,
+    mockContributionGenerationPausedNsfPayload.stageSlug,
+  );
+  assertEquals(
+    rpcParams.p_notification_data.iterationNumber,
+    mockContributionGenerationPausedNsfPayload.iterationNumber,
   );
 });
 

--- a/supabase/functions/_shared/utils/notification.service.ts
+++ b/supabase/functions/_shared/utils/notification.service.ts
@@ -9,6 +9,7 @@ import type {
   ContributionGenerationRetryingPayload,
   ContributionGenerationContinuedPayload,
   ContributionGenerationCompletePayload,
+  ContributionGenerationPausedNsfPayload,
   DialecticContributionReceivedPayload,
   ContributionGenerationFailedPayload,
   ContributionGenerationFailedInternalPayload,
@@ -122,6 +123,18 @@ export class NotificationService implements NotificationServiceType {
     await this._sendNotification({
       target_user_id: targetUserId,
       notification_type: 'contribution_generation_complete',
+      is_internal_event: true,
+      notification_data: payload,
+    });
+  }
+
+  public async sendContributionGenerationPausedNsfEvent(
+    payload: ContributionGenerationPausedNsfPayload,
+    targetUserId: string,
+  ): Promise<void> {
+    await this._sendNotification({
+      target_user_id: targetUserId,
+      notification_type: 'contribution_generation_paused_nsf',
       is_internal_event: true,
       notification_data: payload,
     });

--- a/supabase/functions/_shared/utils/type-guards/type_guards.dialectic.progress.test.ts
+++ b/supabase/functions/_shared/utils/type-guards/type_guards.dialectic.progress.test.ts
@@ -313,7 +313,7 @@ Deno.test("Type Guard: isStepProgressDto", async (t) => {
 	});
 
 	await t.step("returns true for each valid UnifiedStageStatus", () => {
-		const statuses: StepProgressDto["status"][] = ["not_started", "in_progress", "completed", "failed"];
+		const statuses: StepProgressDto["status"][] = ["not_started", "in_progress", "completed", "failed", "paused_nsf"];
 		for (const status of statuses) {
 			const s: StepProgressDto = { stepKey: validStep.stepKey, status };
 			assertEquals(isStepProgressDto(s), true);

--- a/supabase/functions/_shared/utils/type-guards/type_guards.dialectic.progress.ts
+++ b/supabase/functions/_shared/utils/type-guards/type_guards.dialectic.progress.ts
@@ -18,6 +18,7 @@ const validUnifiedStageStatus = new Set<string>([
 	"in_progress",
 	"completed",
 	"failed",
+	"paused_nsf",
 ]);
 
 function isFiniteNonNegativeInteger(n: unknown): n is number {

--- a/supabase/functions/dialectic-service/deriveStepStatuses.test.ts
+++ b/supabase/functions/dialectic-service/deriveStepStatuses.test.ts
@@ -353,4 +353,51 @@ Deno.test("deriveStepStatuses", async (t) => {
 		assertEquals(resultPerModel.get("step_per_model"), "completed");
 		assertEquals(resultAllToOne.get("step_all_to_one"), "completed");
 	});
+
+	await t.step("step with all jobs paused_nsf → status paused_nsf", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_paused", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_paused"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "paused_nsf", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_paused"), "paused_nsf");
+	});
+
+	await t.step("step with paused_nsf and completed jobs → status paused_nsf (paused takes priority over completed)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_mixed", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_mixed"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "paused_nsf", execPayload("e1"), null),
+			job("j2", "EXECUTE", "completed", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_mixed"), "paused_nsf");
+	});
+
+	await t.step("step with paused_nsf and active jobs (pending) → status in_progress (active takes priority over paused)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_mixed_active", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_mixed_active"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "paused_nsf", execPayload("e1"), null),
+			job("j2", "EXECUTE", "pending", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_mixed_active"), "in_progress");
+	});
+
+	await t.step("step with paused_nsf and failed jobs → status paused_nsf (paused takes priority over failed)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_mixed_fail", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_mixed_fail"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "paused_nsf", execPayload("e1"), null),
+			job("j2", "EXECUTE", "failed", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_mixed_fail"), "paused_nsf");
+	});
 });

--- a/supabase/functions/dialectic-service/deriveStepStatuses.test.ts
+++ b/supabase/functions/dialectic-service/deriveStepStatuses.test.ts
@@ -400,4 +400,52 @@ Deno.test("deriveStepStatuses", async (t) => {
 		const result = deriveStepStatuses(deps, params);
 		assertEquals(result.get("step_mixed_fail"), "paused_nsf");
 	});
+
+	await t.step("step with one superseded job and one completed job → step status is completed (superseded job is invisible)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_superseded_completed", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_superseded_completed"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "superseded", execPayload("e1"), null),
+			job("j2", "EXECUTE", "completed", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_superseded_completed"), "completed");
+	});
+
+	await t.step("step with one superseded job and one pending job → step status is in_progress (active clone is visible)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_superseded_pending", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_superseded_pending"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "superseded", execPayload("e1"), null),
+			job("j2", "EXECUTE", "pending", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_superseded_pending"), "in_progress");
+	});
+
+	await t.step("step with only superseded jobs and no other jobs → step status is not_started (all evidence invisible)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_superseded_only", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_superseded_only"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "superseded", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_superseded_only"), "not_started");
+	});
+
+	await t.step("step with one superseded job, one failed job, and one completed job → step status is failed (the non-superseded failed job still counts)", () => {
+		const steps: ProgressRecipeStep[] = [step("e1", "step_superseded_failed_completed", "EXECUTE", "per_model")];
+		const stepIdToStepKey: Map<string, string> = new Map([["e1", "step_superseded_failed_completed"]]);
+		const jobs: DialecticJobRow[] = [
+			job("j1", "EXECUTE", "superseded", execPayload("e1"), null),
+			job("j2", "EXECUTE", "failed", execPayload("e1"), null),
+			job("j3", "EXECUTE", "completed", execPayload("e1"), null),
+		];
+		const params: DeriveStepStatusesParams = { steps, edges: [], jobs, stepIdToStepKey };
+		const result = deriveStepStatuses(deps, params);
+		assertEquals(result.get("step_superseded_failed_completed"), "failed");
+	});
 });

--- a/supabase/functions/dialectic-service/deriveStepStatuses.ts
+++ b/supabase/functions/dialectic-service/deriveStepStatuses.ts
@@ -18,6 +18,8 @@ const FAILED_STATUSES: Set<string> = new Set(["failed", "retry_loop_failed"]);
 
 const PAUSED_NSF_STATUSES: Set<string> = new Set(["paused_nsf"]);
 
+const SUPERSEDED_STATUSES: Set<string> = new Set(["superseded"]);
+
 function getRecipeStepIdFromPayload(payload: unknown): string | undefined {
 	if (!isRecord(payload)) return undefined;
 	const planner_metadata: unknown = payload.planner_metadata;
@@ -49,6 +51,7 @@ export function deriveStepStatuses(
 	for (const job of jobs) {
 		if (job.job_type === "RENDER") continue;
 		if (job.target_contribution_id !== null) continue;
+		if (SUPERSEDED_STATUSES.has(job.status)) continue;
 		const recipeStepId: string | undefined = getRecipeStepIdFromPayload(job.payload);
 		if (recipeStepId === undefined) continue;
 		const stepKey: string | undefined = stepIdToStepKey.get(recipeStepId);

--- a/supabase/functions/dialectic-service/deriveStepStatuses.ts
+++ b/supabase/functions/dialectic-service/deriveStepStatuses.ts
@@ -16,6 +16,8 @@ const ACTIVE_STATUSES: Set<string> = new Set([
 
 const FAILED_STATUSES: Set<string> = new Set(["failed", "retry_loop_failed"]);
 
+const PAUSED_NSF_STATUSES: Set<string> = new Set(["paused_nsf"]);
+
 function getRecipeStepIdFromPayload(payload: unknown): string | undefined {
 	if (!isRecord(payload)) return undefined;
 	const planner_metadata: unknown = payload.planner_metadata;
@@ -42,6 +44,7 @@ export function deriveStepStatuses(
 	const stepKeyToHasActive: Map<string, boolean> = new Map<string, boolean>();
 	const stepKeyToHasCompleted: Map<string, boolean> = new Map<string, boolean>();
 	const stepKeyToHasFailed: Map<string, boolean> = new Map<string, boolean>();
+	const stepKeyToHasPausedNsf: Map<string, boolean> = new Map<string, boolean>();
 
 	for (const job of jobs) {
 		if (job.job_type === "RENDER") continue;
@@ -53,6 +56,8 @@ export function deriveStepStatuses(
 
 		if (ACTIVE_STATUSES.has(job.status)) {
 			stepKeyToHasActive.set(stepKey, true);
+		} else if (PAUSED_NSF_STATUSES.has(job.status)) {
+			stepKeyToHasPausedNsf.set(stepKey, true);
 		} else if (job.status === "completed") {
 			stepKeyToHasCompleted.set(stepKey, true);
 		} else if (FAILED_STATUSES.has(job.status)) {
@@ -64,6 +69,7 @@ export function deriveStepStatuses(
 	for (const stepKey of stepKeyToHasActive.keys()) stepsWithJobs.add(stepKey);
 	for (const stepKey of stepKeyToHasCompleted.keys()) stepsWithJobs.add(stepKey);
 	for (const stepKey of stepKeyToHasFailed.keys()) stepsWithJobs.add(stepKey);
+	for (const stepKey of stepKeyToHasPausedNsf.keys()) stepsWithJobs.add(stepKey);
 
 	const stepKeyToStepId: Map<string, string> = new Map<string, string>();
 	for (const s of steps) {
@@ -75,11 +81,14 @@ export function deriveStepStatuses(
 		const hasActive: boolean = stepKeyToHasActive.get(sk) === true;
 		const hasCompleted: boolean = stepKeyToHasCompleted.get(sk) === true;
 		const hasFailed: boolean = stepKeyToHasFailed.get(sk) === true;
-		const hasEvidence: boolean = hasActive || hasCompleted || hasFailed;
+		const hasPausedNsf: boolean = stepKeyToHasPausedNsf.get(sk) === true;
+		const hasEvidence: boolean = hasActive || hasCompleted || hasFailed || hasPausedNsf;
 
 		if (hasEvidence) {
 			if (hasActive) {
 				result.set(sk, "in_progress");
+			} else if (hasPausedNsf) {
+				result.set(sk, "paused_nsf");
 			} else if (hasFailed) {
 				result.set(sk, "failed");
 			} else {

--- a/supabase/functions/dialectic-service/dialectic.interface.ts
+++ b/supabase/functions/dialectic-service/dialectic.interface.ts
@@ -674,7 +674,8 @@ export type UnifiedStageStatus =
 	| "not_started"
 	| "in_progress"
 	| "completed"
-	| "failed";
+	| "failed"
+	| "paused_nsf";
 
 export interface DagProgressDto {
 	completedStages: number;

--- a/supabase/functions/dialectic-service/dialectic.interface.ts
+++ b/supabase/functions/dialectic-service/dialectic.interface.ts
@@ -515,6 +515,26 @@ type GetAllStageProgressAction = {
 	payload: GetAllStageProgressPayload;
 };
 
+export interface ResumePausedNsfJobsPayload {
+	sessionId: string;
+	stageSlug: string;
+	iterationNumber: number;
+}
+export interface ResumePausedNsfJobsResponse {
+	resumedCount: number;
+}
+
+export interface ResumePausedNsfJobsResult {
+	data?: ResumePausedNsfJobsResponse;
+	error?: ServiceError;
+	status?: number;
+}
+
+type ResumePausedNsfJobsAction = {
+	action: "resumePausedNsfJobs";
+	payload: ResumePausedNsfJobsPayload;
+};
+
 // DAG progress computation — step ordering (topologicalSortSteps)
 export interface ProgressRecipeStep {
 	id: string;
@@ -620,6 +640,7 @@ export type DialecticServiceRequest =
 	| GetStageRecipeAction
 	| ListStageDocumentsAction
 	| GetAllStageProgressAction
+	| ResumePausedNsfJobsAction
 	| GetStageDocumentFeedbackAction
 	| SubmitStageDocumentFeedbackAction;
 

--- a/supabase/functions/dialectic-service/dialectic.interface.ts
+++ b/supabase/functions/dialectic-service/dialectic.interface.ts
@@ -539,7 +539,7 @@ export interface RegenerateDocumentPayload {
 	sessionId: string;
 	stageSlug: string;
 	iterationNumber: number;
-	jobs: Array<{ jobId: string; modelId: string }>;
+	documents: Array<{ documentKey: string; modelId: string }>;
 }
 
 export interface RegenerateDocumentResponse {

--- a/supabase/functions/dialectic-service/dialectic.interface.ts
+++ b/supabase/functions/dialectic-service/dialectic.interface.ts
@@ -1118,6 +1118,27 @@ export interface ResolveNextBlockerResult {
 	status: string;
 }
 
+/**
+ * Parameters for pauseJobsForNsf (NSF pause: failing job + active siblings, single notification).
+ */
+export interface PauseJobsForNsfParams {
+	failingJobId: string;
+	sessionId: string;
+	stageSlug: string;
+	iterationNumber: number;
+	projectId: string;
+	projectOwnerUserId: string;
+}
+
+/**
+ * Dependencies for pauseJobsForNsf.
+ */
+export interface PauseJobsForNsfDeps {
+	adminClient: SupabaseClient<Database>;
+	notificationService: NotificationServiceType;
+	logger: ILogger;
+}
+
 export interface PromptConstructionPayload {
 	systemInstruction?: SystemInstruction;
 	conversationHistory: Messages[];

--- a/supabase/functions/dialectic-service/dialectic.interface.ts
+++ b/supabase/functions/dialectic-service/dialectic.interface.ts
@@ -535,6 +535,28 @@ type ResumePausedNsfJobsAction = {
 	payload: ResumePausedNsfJobsPayload;
 };
 
+export interface RegenerateDocumentPayload {
+	sessionId: string;
+	stageSlug: string;
+	iterationNumber: number;
+	jobs: Array<{ jobId: string; modelId: string }>;
+}
+
+export interface RegenerateDocumentResponse {
+	jobIds: string[];
+}
+
+export interface RegenerateDocumentResult {
+	data?: RegenerateDocumentResponse;
+	error?: ServiceError;
+	status?: number;
+}
+
+type RegenerateDocumentAction = {
+	action: "regenerateDocument";
+	payload: RegenerateDocumentPayload;
+};
+
 // DAG progress computation — step ordering (topologicalSortSteps)
 export interface ProgressRecipeStep {
 	id: string;
@@ -641,6 +663,7 @@ export type DialecticServiceRequest =
 	| ListStageDocumentsAction
 	| GetAllStageProgressAction
 	| ResumePausedNsfJobsAction
+	| RegenerateDocumentAction
 	| GetStageDocumentFeedbackAction
 	| SubmitStageDocumentFeedbackAction;
 

--- a/supabase/functions/dialectic-service/getAllStageProgress.test.ts
+++ b/supabase/functions/dialectic-service/getAllStageProgress.test.ts
@@ -19,6 +19,7 @@ import {
   DialecticRenderJobPayload,
   DialecticStage,
   DialecticStageRecipeInstance,
+  DialecticStageTransition,
   GranularityStrategy,
   GranularityStrategies,
   GetAllStageProgressPayload,
@@ -652,7 +653,7 @@ Deno.test("getAllStageProgress: progress calculates correctly for every stage in
     const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
     const params: GetAllStageProgressParams = { payload: basePayload };
     const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(result.status, 200, result.error?.message ?? "non-200 response");
+    assertEquals(result.status, 200, "expected status 200");
     assertExists(result.data);
     if (!result.data) throw new Error("result.data missing");
     const data: GetAllStageProgressResponse = result.data;
@@ -870,7 +871,7 @@ Deno.test("getAllStageProgress: RENDER jobs excluded from step status derivation
     const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
     const params: GetAllStageProgressParams = { payload: basePayload };
     const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(result.status, 200, result.error?.message ?? "non-200 response");
+    assertEquals(result.status, 200, "expected status 200");
     if (!result.data) throw new Error("result.data missing");
     const entry: StageProgressEntry | undefined = result.data.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
     assertExists(entry);
@@ -1004,7 +1005,7 @@ Deno.test("getAllStageProgress: continuation jobs excluded from step status deri
     const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
     const params: GetAllStageProgressParams = { payload: basePayload };
     const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(result.status, 200, result.error?.message ?? "non-200 response");
+    assertEquals(result.status, 200, "expected status 200");
     if (!result.data) throw new Error("result.data missing");
     const entry: StageProgressEntry | undefined = result.data.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
     assertExists(entry);
@@ -1111,8 +1112,8 @@ Deno.test("getAllStageProgress: spec invariant progress never decreases across s
     const params: GetAllStageProgressParams = { payload: basePayload };
     const first: GetAllStageProgressResult = await getAllStageProgress(deps, params);
     const second: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(first.status, 200, first.error?.message ?? "first call non-200");
-    assertEquals(second.status, 200, second.error?.message ?? "second call non-200");
+    assertEquals(first.status, 200, "first call expected status 200");
+    assertEquals(second.status, 200, "second call expected status 200");
     if (!first.data || !second.data) throw new Error("data missing");
     const firstData: GetAllStageProgressResponse = first.data;
     const secondData: GetAllStageProgressResponse = second.data;
@@ -1224,8 +1225,8 @@ Deno.test("getAllStageProgress: progress independent of model count", async (t) 
     const params: GetAllStageProgressParams = { payload: basePayload };
     const resultN2: GetAllStageProgressResult = await getAllStageProgress(deps, params);
     const resultN3: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(resultN2.status, 200, resultN2.error?.message ?? "resultN2 non-200");
-    assertEquals(resultN3.status, 200, resultN3.error?.message ?? "resultN3 non-200");
+    assertEquals(resultN2.status, 200, "resultN2 expected status 200");
+    assertEquals(resultN3.status, 200, "resultN3 expected status 200");
     if (!resultN2.data || !resultN3.data) throw new Error("data missing");
     const entryN2: StageProgressEntry | undefined = resultN2.data.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
     const entryN3: StageProgressEntry | undefined = resultN3.data.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
@@ -1333,7 +1334,7 @@ Deno.test("getAllStageProgress: step with zero jobs whose successors have been r
     const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
     const params: GetAllStageProgressParams = { payload: basePayload };
     const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(result.status, 200, result.error?.message ?? "non-200 response");
+    assertEquals(result.status, 200, "expected status 200");
     if (!result.data) throw new Error("result.data missing");
     const entry: StageProgressEntry | undefined = result.data.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
     assertExists(entry);
@@ -1532,7 +1533,7 @@ Deno.test("getAllStageProgress: randomized DAG test and progress for any valid D
     const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
     const params: GetAllStageProgressParams = { payload: basePayload };
     const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
-    assertEquals(result.status, 200, result.error?.message ?? "non-200 response");
+    assertEquals(result.status, 200, "expected status 200");
     if (!result.data) throw new Error("result.data missing");
     const entryA: StageProgressEntry | undefined = result.data.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
     const entryB: StageProgressEntry | undefined = result.data.stages.find((s: StageProgressEntry) => s.stageSlug === SYNTHESIS_STAGE_SLUG);
@@ -1569,4 +1570,309 @@ Deno.test("getAllStageProgress: randomized DAG test and progress for any valid D
   } finally {
     restoreFetch();
   }
+});
+
+Deno.test("getAllStageProgress: paused_nsf step status drives stage status (NSF Pause and Resume Node 6)", async (t) => {
+  const stageId: string = "stage-paused-nsf-id";
+  const instanceId: string = "instance-paused-nsf-id";
+  const templateId: string = "template-paused-nsf-id";
+  const modelId: string = "model-1";
+  const stepAId: string = "step-paused-a";
+  const stepBId: string = "step-paused-b";
+  const iso: string = new Date().toISOString();
+  const recipeSteps: Tables<"dialectic_stage_recipe_steps">[] = [
+    buildClonedStepRow(stepAId, instanceId, "step_paused_a", "EXECUTE", "all_to_one"),
+    buildClonedStepRow(stepBId, instanceId, "step_paused_b", "EXECUTE", "all_to_one"),
+  ];
+  const edges: Tables<"dialectic_stage_recipe_edges">[] = [
+    { id: "edge-paused-1", created_at: iso, instance_id: instanceId, from_step_id: stepAId, to_step_id: stepBId },
+  ];
+  const sessionRow: Tables<"dialectic_sessions"> = {
+    id: basePayload.sessionId,
+    project_id: basePayload.projectId,
+    selected_model_ids: [modelId],
+    associated_chat_id: null,
+    created_at: iso,
+    current_stage_id: stageId,
+    iteration_count: 1,
+    session_description: null,
+    status: "active",
+    updated_at: iso,
+    user_input_reference_url: null,
+  };
+  const projectRow: Tables<"dialectic_projects"> = {
+    id: basePayload.projectId,
+    process_template_id: "process-1",
+    created_at: iso,
+    initial_prompt_resource_id: null,
+    initial_user_prompt: "",
+    project_name: "test",
+    repo_url: null,
+    selected_domain_id: "domain-1",
+    selected_domain_overlay_id: null,
+    status: "active",
+    updated_at: iso,
+    user_domain_overlay_values: null,
+    user_id: basePayload.userId,
+  };
+  const transitions: DialecticStageTransition[] = [
+    { id: "trans-1", process_template_id: "process-1", source_stage_id: stageId, target_stage_id: stageId, condition_description: null, created_at: iso },
+  ];
+  const templateStages: DialecticStage[] = [
+    { id: stageId, slug: THESIS_STAGE_SLUG, display_name: "Thesis", description: null, created_at: iso, expected_output_template_ids: [], active_recipe_instance_id: instanceId, default_system_prompt_id: null, recipe_template_id: templateId },
+  ];
+  const stages: DialecticStage[] = [
+    { id: stageId, slug: THESIS_STAGE_SLUG, display_name: "Thesis", description: null, created_at: iso, expected_output_template_ids: [], active_recipe_instance_id: instanceId, default_system_prompt_id: null, recipe_template_id: templateId },
+  ];
+  const instances: DialecticStageRecipeInstance[] = [
+    { id: instanceId, stage_id: stageId, template_id: templateId, is_cloned: true, cloned_at: null, created_at: iso, updated_at: iso },
+  ];
+  const headers: HeadersInit = { "Content-Type": "application/json" };
+
+  await t.step("when any step has status paused_nsf, stage status is paused_nsf", async () => {
+    const jobs: DialecticJobRow[] = [{
+      id: "job-paused-only",
+      created_at: iso,
+      session_id: basePayload.sessionId,
+      stage_slug: THESIS_STAGE_SLUG,
+      iteration_number: basePayload.iterationNumber,
+      status: "paused_nsf",
+      payload: {
+          sessionId: basePayload.sessionId,
+          projectId: basePayload.projectId,
+          model_id: modelId,
+          walletId: "wallet-1",
+          user_jwt: "jwt",
+          stageSlug: THESIS_STAGE_SLUG,
+          iterationNumber: basePayload.iterationNumber,
+          planner_metadata: { recipe_step_id: stepAId, stage_slug: THESIS_STAGE_SLUG },
+        },
+      user_id: basePayload.userId,
+      is_test_job: false,
+      attempt_count: 0,
+      max_retries: 0,
+      job_type: "EXECUTE",
+      parent_job_id: null,
+      prerequisite_job_id: null,
+      target_contribution_id: null,
+      started_at: null,
+      completed_at: null,
+      results: null,
+      error_details: null,
+    }];
+    mockFetch([
+      new Response(JSON.stringify(sessionRow), { status: 200, headers }),
+      new Response(JSON.stringify(projectRow), { status: 200, headers }),
+      new Response(JSON.stringify(transitions), { status: 200, headers }),
+      new Response(JSON.stringify(templateStages), { status: 200, headers }),
+      new Response(JSON.stringify(jobs), { status: 200, headers }),
+      new Response(JSON.stringify(stages), { status: 200, headers }),
+      new Response(JSON.stringify(instances), { status: 200, headers }),
+      new Response(JSON.stringify(recipeSteps), { status: 200, headers }),
+      new Response(JSON.stringify(edges), { status: 200, headers }),
+      new Response(JSON.stringify([]), { status: 200, headers }),
+      new Response(JSON.stringify([]), { status: 200, headers }),
+    ]);
+    const dbClient: SupabaseClient<Database> = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    });
+    try {
+      const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
+      const params: GetAllStageProgressParams = { payload: basePayload };
+      const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
+      assertEquals(result.status, 200, "expected status 200");
+      assertExists(result.data);
+      const entry: StageProgressEntry | undefined = result.data!.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
+      assertExists(entry);
+      assertEquals(entry!.status, "paused_nsf");
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  await t.step("when steps have mix of paused_nsf and completed, stage status is paused_nsf", async () => {
+    const jobs: DialecticJobRow[] = [
+      {
+        id: "job-completed-a",
+        created_at: iso,
+        session_id: basePayload.sessionId,
+        stage_slug: THESIS_STAGE_SLUG,
+        iteration_number: basePayload.iterationNumber,
+        status: "completed",
+        payload: {
+          sessionId: basePayload.sessionId,
+          projectId: basePayload.projectId,
+          model_id: modelId,
+          walletId: "wallet-1",
+          user_jwt: "jwt",
+          stageSlug: THESIS_STAGE_SLUG,
+          iterationNumber: basePayload.iterationNumber,
+          planner_metadata: { recipe_step_id: stepAId, stage_slug: THESIS_STAGE_SLUG },
+        },
+        user_id: basePayload.userId,
+        is_test_job: false,
+        attempt_count: 0,
+        max_retries: 0,
+        job_type: "EXECUTE",
+        parent_job_id: null,
+        prerequisite_job_id: null,
+        target_contribution_id: null,
+        started_at: null,
+        completed_at: iso,
+        results: null,
+        error_details: null,
+      },
+      {
+        id: "job-paused-b",
+        created_at: iso,
+        session_id: basePayload.sessionId,
+        stage_slug: THESIS_STAGE_SLUG,
+        iteration_number: basePayload.iterationNumber,
+        status: "paused_nsf",
+        payload: {
+          sessionId: basePayload.sessionId,
+          projectId: basePayload.projectId,
+          model_id: modelId,
+          walletId: "wallet-1",
+          user_jwt: "jwt",
+          stageSlug: THESIS_STAGE_SLUG,
+          iterationNumber: basePayload.iterationNumber,
+          planner_metadata: { recipe_step_id: stepBId, stage_slug: THESIS_STAGE_SLUG },
+        },
+        user_id: basePayload.userId,
+        is_test_job: false,
+        attempt_count: 0,
+        max_retries: 0,
+        job_type: "EXECUTE",
+        parent_job_id: null,
+        prerequisite_job_id: null,
+        target_contribution_id: null,
+        started_at: null,
+        completed_at: null,
+        results: null,
+        error_details: null,
+      },
+    ];
+    mockFetch([
+      new Response(JSON.stringify(sessionRow), { status: 200, headers }),
+      new Response(JSON.stringify(projectRow), { status: 200, headers }),
+      new Response(JSON.stringify(transitions), { status: 200, headers }),
+      new Response(JSON.stringify(templateStages), { status: 200, headers }),
+      new Response(JSON.stringify(jobs), { status: 200, headers }),
+      new Response(JSON.stringify(stages), { status: 200, headers }),
+      new Response(JSON.stringify(instances), { status: 200, headers }),
+      new Response(JSON.stringify(recipeSteps), { status: 200, headers }),
+      new Response(JSON.stringify(edges), { status: 200, headers }),
+      new Response(JSON.stringify([]), { status: 200, headers }),
+      new Response(JSON.stringify([]), { status: 200, headers }),
+    ]);
+    const dbClient: SupabaseClient<Database> = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    });
+    try {
+      const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
+      const params: GetAllStageProgressParams = { payload: basePayload };
+      const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
+      assertEquals(result.status, 200, "expected status 200");
+      assertExists(result.data);
+      const entry: StageProgressEntry | undefined = result.data!.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
+      assertExists(entry);
+      assertEquals(entry!.status, "paused_nsf");
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  await t.step("when steps have mix of paused_nsf and failed, stage status is failed", async () => {
+    const jobs: DialecticJobRow[] = [
+      {
+        id: "job-paused-a",
+        created_at: iso,
+        session_id: basePayload.sessionId,
+        stage_slug: THESIS_STAGE_SLUG,
+        iteration_number: basePayload.iterationNumber,
+        status: "paused_nsf",
+        payload: {
+          sessionId: basePayload.sessionId,
+          projectId: basePayload.projectId,
+          model_id: modelId,
+          walletId: "wallet-1",
+          user_jwt: "jwt",
+          stageSlug: THESIS_STAGE_SLUG,
+          iterationNumber: basePayload.iterationNumber,
+          planner_metadata: { recipe_step_id: stepAId, stage_slug: THESIS_STAGE_SLUG },
+        },
+        user_id: basePayload.userId,
+        is_test_job: false,
+        attempt_count: 0,
+        max_retries: 0,
+        job_type: "EXECUTE",
+        parent_job_id: null,
+        prerequisite_job_id: null,
+        target_contribution_id: null,
+        started_at: null,
+        completed_at: null,
+        results: null,
+        error_details: null,
+      },
+      {
+        id: "job-failed-b",
+        created_at: iso,
+        session_id: basePayload.sessionId,
+        stage_slug: THESIS_STAGE_SLUG,
+        iteration_number: basePayload.iterationNumber,
+        status: "failed",
+        payload: {
+          sessionId: basePayload.sessionId,
+          projectId: basePayload.projectId,
+          model_id: modelId,
+          walletId: "wallet-1",
+          user_jwt: "jwt",
+          stageSlug: THESIS_STAGE_SLUG,
+          iterationNumber: basePayload.iterationNumber,
+          planner_metadata: { recipe_step_id: stepBId, stage_slug: THESIS_STAGE_SLUG },
+        },
+        user_id: basePayload.userId,
+        is_test_job: false,
+        attempt_count: 0,
+        max_retries: 0,
+        job_type: "EXECUTE",
+        parent_job_id: null,
+        prerequisite_job_id: null,
+        target_contribution_id: null,
+        started_at: null,
+        completed_at: null,
+        results: null,
+        error_details: null,
+      },
+    ];
+    mockFetch([
+      new Response(JSON.stringify(sessionRow), { status: 200, headers }),
+      new Response(JSON.stringify(projectRow), { status: 200, headers }),
+      new Response(JSON.stringify(transitions), { status: 200, headers }),
+      new Response(JSON.stringify(templateStages), { status: 200, headers }),
+      new Response(JSON.stringify(jobs), { status: 200, headers }),
+      new Response(JSON.stringify(stages), { status: 200, headers }),
+      new Response(JSON.stringify(instances), { status: 200, headers }),
+      new Response(JSON.stringify(recipeSteps), { status: 200, headers }),
+      new Response(JSON.stringify(edges), { status: 200, headers }),
+      new Response(JSON.stringify([]), { status: 200, headers }),
+      new Response(JSON.stringify([]), { status: 200, headers }),
+    ]);
+    const dbClient: SupabaseClient<Database> = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    });
+    try {
+      const deps: GetAllStageProgressDeps = createGetAllStageProgressDeps(dbClient, baseUser);
+      const params: GetAllStageProgressParams = { payload: basePayload };
+      const result: GetAllStageProgressResult = await getAllStageProgress(deps, params);
+      assertEquals(result.status, 200, "expected status 200");
+      assertExists(result.data);
+      const entry: StageProgressEntry | undefined = result.data!.stages.find((s: StageProgressEntry) => s.stageSlug === THESIS_STAGE_SLUG);
+      assertExists(entry);
+      assertEquals(entry!.status, "failed");
+    } finally {
+      restoreFetch();
+    }
+  });
 });

--- a/supabase/functions/dialectic-service/getAllStageProgress.ts
+++ b/supabase/functions/dialectic-service/getAllStageProgress.ts
@@ -837,17 +837,21 @@ export async function getAllStageProgress(
     const totalSteps: number = steps.length;
     let completedSteps: number = 0;
     let failedSteps: number = 0;
+    let pausedNsfSteps: number = 0;
     const stepDtos: StepProgressDto[] = [];
     for (const step of steps) {
       const status: UnifiedStageStatus = stepStatusMap.get(step.step_key) ?? "not_started";
       if (status === "completed") completedSteps += 1;
       if (status === "failed") failedSteps += 1;
+      if (status === "paused_nsf") pausedNsfSteps += 1;
       stepDtos.push({ stepKey: step.step_key, status });
     }
 
     let stageStatus: UnifiedStageStatus = "not_started";
     if (failedSteps > 0) {
       stageStatus = "failed";
+    } else if (pausedNsfSteps > 0) {
+      stageStatus = "paused_nsf";
     } else if (completedSteps === totalSteps && failedSteps === 0) {
       stageStatus = "completed";
     } else if (completedSteps > 0 || failedSteps > 0) {

--- a/supabase/functions/dialectic-service/index.test.ts
+++ b/supabase/functions/dialectic-service/index.test.ts
@@ -36,6 +36,9 @@ import {
   ResumePausedNsfJobsPayload,
   ResumePausedNsfJobsResponse,
   ResumePausedNsfJobsResult,
+  RegenerateDocumentPayload,
+  RegenerateDocumentResponse,
+  RegenerateDocumentResult,
   StartSessionSuccessResponse,
   DialecticProcessTemplate,
 } from "./dialectic.interface.ts";
@@ -124,6 +127,7 @@ const createMockHandlers = (overrides?: Partial<ActionHandlers> & {
   getStageRecipe?: (...args: unknown[]) => Promise<{ data?: unknown; error?: { message: string }; status?: number }>;
   getAllStageProgress?: (payload: GetAllStageProgressPayload, dbClient: SupabaseClient<Database>, user: User) => Promise<GetAllStageProgressResult>;
   resumePausedNsfJobs?: (payload: ResumePausedNsfJobsPayload, dbClient: SupabaseClient, user: User) => Promise<ResumePausedNsfJobsResult>;
+  regenerateDocument?: (payload: RegenerateDocumentPayload, dbClient: SupabaseClient, user: User) => Promise<RegenerateDocumentResult>;
 }): ActionHandlers => {
     return {
         createProject: overrides?.createProject || (() => Promise.resolve({ data: { id: 'mock-project-id', user_id: 'mock-user-id', project_name: 'mock-project-name', initial_user_prompt: 'mock-initial-user-prompt', selected_domain_id: 'mock-domain-id', repo_url: null, status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), initial_prompt_resource_id: null, selected_domain_overlay_id: null, process_template_id: null, user_domain_overlay_values: null }, status: 201 })),
@@ -151,6 +155,7 @@ const createMockHandlers = (overrides?: Partial<ActionHandlers> & {
         getStageDocumentFeedback: overrides?.getStageDocumentFeedback || (() => Promise.resolve({ data: [] })),
         getAllStageProgress: overrides?.getAllStageProgress || (() => Promise.resolve({ data: { dagProgress: { completedStages: 0, totalStages: 0 }, stages: [] }, status: 200 })),
         resumePausedNsfJobs: overrides?.resumePausedNsfJobs || (() => Promise.resolve({ data: { resumedCount: 0 }, status: 200 })),
+        regenerateDocument: overrides?.regenerateDocument || (() => Promise.resolve({ data: { jobIds: [] }, status: 200 })),
         ...overrides,
     };
 };
@@ -1867,6 +1872,113 @@ withSupabaseEnv("handleRequest - resumePausedNsfJobs", async (t) => {
 
         assertEquals(response.status, 401);
         assertEquals(resumeSpy.calls.length, 0);
+    });
+});
+
+withSupabaseEnv("handleRequest - regenerateDocument", async (t) => {
+    const payload: RegenerateDocumentPayload = {
+        sessionId: 'sess-regen-123',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+        jobs: [{ jobId: 'job-1', modelId: 'model-1' }],
+    };
+
+    await t.step("should route action 'regenerateDocument' to handler and return 200 with jobIds", async () => {
+        const jobIds = ['new-job-id-1'];
+        const regenerateSpy = spy(() => Promise.resolve({ data: { jobIds }, status: 200 }));
+        const mockHandlers = createMockHandlers({ regenerateDocument: regenerateSpy });
+
+        const mockToken = "mock-jwt";
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: mockUser }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("regenerateDocument", payload, mockToken);
+        const response = await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(response.status, 200);
+        const body = await response.json();
+        assertExists(body.jobIds);
+        assertEquals(Array.isArray(body.jobIds), true);
+        assertEquals(body.jobIds, jobIds);
+        assertEquals(regenerateSpy.calls.length, 1);
+    });
+
+    await t.step("should pass correct payload, dbClient, and user to regenerateDocument handler", async () => {
+        const regenerateSpy = spy((_p: RegenerateDocumentPayload, _db: SupabaseClient, _u: User): Promise<RegenerateDocumentResult> =>
+            Promise.resolve({ data: { jobIds: [] }, status: 200 }));
+        const mockHandlers = createMockHandlers({ regenerateDocument: regenerateSpy });
+
+        const mockToken = "mock-jwt";
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: mockUser }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("regenerateDocument", payload, mockToken);
+        await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(regenerateSpy.calls.length, 1);
+        assertEquals(regenerateSpy.calls[0].args[0], payload);
+        assert((regenerateSpy.calls[0].args[1]) === (mockAdminClient as unknown), "handler should receive adminClient as dbClient");
+        assertEquals(regenerateSpy.calls[0].args[2].id, mockUser.id);
+    });
+
+    await t.step("should return 401 if not authenticated", async () => {
+        const regenerateSpy = spy(() => Promise.resolve({ data: { jobIds: [] }, status: 200 }));
+        const mockHandlers = createMockHandlers({ regenerateDocument: regenerateSpy });
+
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: null }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("regenerateDocument", payload);
+        const response = await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(response.status, 401);
+        assertEquals(regenerateSpy.calls.length, 0);
+    });
+
+    await t.step("should return error status and message when handler returns error", async () => {
+        const handlerError: ServiceError = { message: "Session not found", status: 404, code: "NOT_FOUND" };
+        const regenerateSpy = spy(() => Promise.resolve({ error: handlerError, status: 404 }));
+        const mockHandlers = createMockHandlers({ regenerateDocument: regenerateSpy });
+
+        const mockToken = "mock-jwt";
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: mockUser }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("regenerateDocument", payload, mockToken);
+        const response = await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(response.status, 404);
+        const body = await response.json();
+        assertEquals(body.error, handlerError.message);
+        assertEquals(regenerateSpy.calls.length, 1);
     });
 });
 

--- a/supabase/functions/dialectic-service/index.test.ts
+++ b/supabase/functions/dialectic-service/index.test.ts
@@ -33,6 +33,9 @@ import {
   GetStageDocumentFeedbackResponse,
   GetAllStageProgressPayload,
   GetAllStageProgressResult,
+  ResumePausedNsfJobsPayload,
+  ResumePausedNsfJobsResponse,
+  ResumePausedNsfJobsResult,
   StartSessionSuccessResponse,
   DialecticProcessTemplate,
 } from "./dialectic.interface.ts";
@@ -120,6 +123,7 @@ const mockFeedbackRow: DialecticFeedbackRow = {
 const createMockHandlers = (overrides?: Partial<ActionHandlers> & {
   getStageRecipe?: (...args: unknown[]) => Promise<{ data?: unknown; error?: { message: string }; status?: number }>;
   getAllStageProgress?: (payload: GetAllStageProgressPayload, dbClient: SupabaseClient<Database>, user: User) => Promise<GetAllStageProgressResult>;
+  resumePausedNsfJobs?: (payload: ResumePausedNsfJobsPayload, dbClient: SupabaseClient, user: User) => Promise<ResumePausedNsfJobsResult>;
 }): ActionHandlers => {
     return {
         createProject: overrides?.createProject || (() => Promise.resolve({ data: { id: 'mock-project-id', user_id: 'mock-user-id', project_name: 'mock-project-name', initial_user_prompt: 'mock-initial-user-prompt', selected_domain_id: 'mock-domain-id', repo_url: null, status: 'active', created_at: new Date().toISOString(), updated_at: new Date().toISOString(), initial_prompt_resource_id: null, selected_domain_overlay_id: null, process_template_id: null, user_domain_overlay_values: null }, status: 201 })),
@@ -146,6 +150,7 @@ const createMockHandlers = (overrides?: Partial<ActionHandlers> & {
         submitStageDocumentFeedback: overrides?.submitStageDocumentFeedback || (() => Promise.resolve({ data: mockFeedbackRow })),
         getStageDocumentFeedback: overrides?.getStageDocumentFeedback || (() => Promise.resolve({ data: [] })),
         getAllStageProgress: overrides?.getAllStageProgress || (() => Promise.resolve({ data: { dagProgress: { completedStages: 0, totalStages: 0 }, stages: [] }, status: 200 })),
+        resumePausedNsfJobs: overrides?.resumePausedNsfJobs || (() => Promise.resolve({ data: { resumedCount: 0 }, status: 200 })),
         ...overrides,
     };
 };
@@ -1781,6 +1786,87 @@ withSupabaseEnv("handleRequest - getAllStageProgress", async (t) => {
 
         assertEquals(response.status, 401);
         assertEquals(getAllStageProgressSpy.calls.length, 0);
+    });
+});
+
+withSupabaseEnv("handleRequest - resumePausedNsfJobs", async (t) => {
+    const payload: ResumePausedNsfJobsPayload = {
+        sessionId: 'sess-resume-123',
+        stageSlug: 'thesis',
+        iterationNumber: 1,
+    };
+
+    await t.step("should route action 'resumePausedNsfJobs' to handler and return 200 with resumedCount", async () => {
+        const resumedCount = 3;
+        const resumeSpy = spy(() => Promise.resolve({ data: { resumedCount }, status: 200 }));
+        const mockHandlers = createMockHandlers({ resumePausedNsfJobs: resumeSpy });
+
+        const mockToken = "mock-jwt";
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: mockUser }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("resumePausedNsfJobs", payload, mockToken);
+        const response = await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(response.status, 200);
+        const body = await response.json();
+        assertExists(body.resumedCount);
+        assertEquals(typeof body.resumedCount, 'number');
+        assertEquals(body.resumedCount, resumedCount);
+        assertEquals(resumeSpy.calls.length, 1);
+    });
+
+    await t.step("should pass correct payload, dbClient, and user to resumePausedNsfJobs handler", async () => {
+        const resumeSpy = spy((_p: ResumePausedNsfJobsPayload, _db: SupabaseClient, _u: User): Promise<ResumePausedNsfJobsResult> =>
+            Promise.resolve({ data: { resumedCount: 0 }, status: 200 }));
+        const mockHandlers = createMockHandlers({ resumePausedNsfJobs: resumeSpy });
+
+        const mockToken = "mock-jwt";
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: mockUser }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("resumePausedNsfJobs", payload, mockToken);
+        await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(resumeSpy.calls.length, 1);
+        assertEquals(resumeSpy.calls[0].args[0], payload);
+        assert((resumeSpy.calls[0].args[1]) === (mockAdminClient as unknown), "handler should receive adminClient as dbClient");
+        assertEquals(resumeSpy.calls[0].args[2].id, mockUser.id);
+    });
+
+    await t.step("should return 401 if not authenticated", async () => {
+        const resumeSpy = spy(() => Promise.resolve({ data: { resumedCount: 0 }, status: 200 }));
+        const mockHandlers = createMockHandlers({ resumePausedNsfJobs: resumeSpy });
+
+        const { client: mockUserClient } = createMockSupabaseClient('test-user-id', {
+            getUserResult: { data: { user: null }, error: null }
+        });
+        const { client: mockAdminClient } = createMockSupabaseClient();
+
+        const req = createJsonRequest("resumePausedNsfJobs", payload);
+        const response = await handleRequest(
+            req,
+            mockHandlers,
+            mockUserClient as unknown as SupabaseClient<Database>,
+            mockAdminClient as unknown as SupabaseClient<Database>
+        );
+
+        assertEquals(response.status, 401);
+        assertEquals(resumeSpy.calls.length, 0);
     });
 });
 

--- a/supabase/functions/dialectic-service/index.ts
+++ b/supabase/functions/dialectic-service/index.ts
@@ -38,6 +38,8 @@ import {
   GetAllStageProgressResult,
   ResumePausedNsfJobsPayload,
   ResumePausedNsfJobsResponse,
+  RegenerateDocumentPayload,
+  RegenerateDocumentResponse,
 } from "./dialectic.interface.ts";
 import { getStageRecipe } from "./getStageRecipe.ts";
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
@@ -82,6 +84,7 @@ import { listStageDocuments } from './listStageDocuments.ts';
 import { submitStageDocumentFeedback, type SubmitStageDocumentFeedbackDeps } from './submitStageDocumentFeedback.ts';
 import { getAllStageProgress } from './getAllStageProgress.ts';
 import { handleResumePausedNsfJobs } from './resumePausedNsfJobs.ts';
+import { regenerateDocument } from './regenerateDocument.ts';
 import { topologicalSortSteps } from './topologicalSortSteps.ts';
 import { deriveStepStatuses } from './deriveStepStatuses.ts';
 import { computeExpectedCounts } from './computeExpectedCounts.ts';
@@ -199,6 +202,7 @@ export interface ActionHandlers {
   getStageDocumentFeedback: (payload: GetStageDocumentFeedbackPayload, dbClient: SupabaseClient<Database>, deps: GetStageDocumentFeedbackDeps) => Promise<DialecticServiceResponse<GetStageDocumentFeedbackResponse>>;
   getAllStageProgress: (payload: GetAllStageProgressPayload, dbClient: SupabaseClient<Database>, user: User) => Promise<GetAllStageProgressResult>;
   resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload, dbClient: SupabaseClient, user: User) => Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>;
+  regenerateDocument: (payload: RegenerateDocumentPayload, dbClient: SupabaseClient, user: User) => Promise<{ data?: RegenerateDocumentResponse; error?: ServiceError; status?: number }>;
 }
 
 export async function handleRequest(
@@ -278,6 +282,7 @@ export async function handleRequest(
         'getStageDocumentFeedback',
         'getAllStageProgress',
         'resumePausedNsfJobs',
+        'regenerateDocument',
       ];
 
       let userForJson: User | null = null;
@@ -610,6 +615,17 @@ export async function handleRequest(
           }
           return createSuccessResponse(result.data, result.status, req);
         }
+        case "regenerateDocument": {
+          if (!userForJson) {
+            return createErrorResponse('User not authenticated for regenerateDocument', 401, req, { message: 'User not authenticated', status: 401, code: 'USER_AUTH_FAILED' });
+          }
+          const payload: RegenerateDocumentPayload = requestBody.payload;
+          const result = await handlers.regenerateDocument(payload, adminClient, userForJson);
+          if (result.error) {
+            return createErrorResponse(result.error.message, result.status, req, result.error);
+          }
+          return createSuccessResponse(result.data, result.status, req);
+        }
         default: {
           const errorMessage = `Unknown action for application/json.`;
           logger.warn(errorMessage, { action });
@@ -676,6 +692,7 @@ export const defaultHandlers: ActionHandlers = {
   getStageDocumentFeedback,
   getAllStageProgress: handleGetAllStageProgress,
   resumePausedNsfJobs: handleResumePausedNsfJobs,
+  regenerateDocument,
 };
 
 export function createDialecticServiceHandler(

--- a/supabase/functions/dialectic-service/index.ts
+++ b/supabase/functions/dialectic-service/index.ts
@@ -36,6 +36,8 @@ import {
   SubmitStageDocumentFeedbackPayload,
   GetAllStageProgressPayload,
   GetAllStageProgressResult,
+  ResumePausedNsfJobsPayload,
+  ResumePausedNsfJobsResponse,
 } from "./dialectic.interface.ts";
 import { getStageRecipe } from "./getStageRecipe.ts";
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
@@ -79,6 +81,7 @@ import { handleUpdateSessionModels } from './updateSessionModels.ts';
 import { listStageDocuments } from './listStageDocuments.ts';
 import { submitStageDocumentFeedback, type SubmitStageDocumentFeedbackDeps } from './submitStageDocumentFeedback.ts';
 import { getAllStageProgress } from './getAllStageProgress.ts';
+import { handleResumePausedNsfJobs } from './resumePausedNsfJobs.ts';
 import { topologicalSortSteps } from './topologicalSortSteps.ts';
 import { deriveStepStatuses } from './deriveStepStatuses.ts';
 import { computeExpectedCounts } from './computeExpectedCounts.ts';
@@ -195,6 +198,7 @@ export interface ActionHandlers {
   submitStageDocumentFeedback: (payload: SubmitStageDocumentFeedbackPayload, dbClient: SupabaseClient, deps: SubmitStageDocumentFeedbackDeps) => Promise<DialecticServiceResponse<DialecticFeedbackRow>>;
   getStageDocumentFeedback: (payload: GetStageDocumentFeedbackPayload, dbClient: SupabaseClient<Database>, deps: GetStageDocumentFeedbackDeps) => Promise<DialecticServiceResponse<GetStageDocumentFeedbackResponse>>;
   getAllStageProgress: (payload: GetAllStageProgressPayload, dbClient: SupabaseClient<Database>, user: User) => Promise<GetAllStageProgressResult>;
+  resumePausedNsfJobs: (payload: ResumePausedNsfJobsPayload, dbClient: SupabaseClient, user: User) => Promise<{ data?: ResumePausedNsfJobsResponse; error?: ServiceError; status?: number }>;
 }
 
 export async function handleRequest(
@@ -273,6 +277,7 @@ export async function handleRequest(
         'submitStageDocumentFeedback',
         'getStageDocumentFeedback',
         'getAllStageProgress',
+        'resumePausedNsfJobs',
       ];
 
       let userForJson: User | null = null;
@@ -594,6 +599,17 @@ export async function handleRequest(
           }
           return createSuccessResponse(result.data, result.status || 200, req);
         }
+        case "resumePausedNsfJobs": {
+          if (!userForJson) {
+            return createErrorResponse('User not authenticated for resumePausedNsfJobs', 401, req, { message: 'User not authenticated', status: 401, code: 'USER_AUTH_FAILED' });
+          }
+          const payload: ResumePausedNsfJobsPayload = requestBody.payload;
+          const result = await handlers.resumePausedNsfJobs(payload, adminClient, userForJson);
+          if (result.error) {
+            return createErrorResponse(result.error.message, result.status, req, result.error);
+          }
+          return createSuccessResponse(result.data, result.status, req);
+        }
         default: {
           const errorMessage = `Unknown action for application/json.`;
           logger.warn(errorMessage, { action });
@@ -659,6 +675,7 @@ export const defaultHandlers: ActionHandlers = {
   submitStageDocumentFeedback,
   getStageDocumentFeedback,
   getAllStageProgress: handleGetAllStageProgress,
+  resumePausedNsfJobs: handleResumePausedNsfJobs,
 };
 
 export function createDialecticServiceHandler(

--- a/supabase/functions/dialectic-service/regenerateDocument.test.ts
+++ b/supabase/functions/dialectic-service/regenerateDocument.test.ts
@@ -1,0 +1,552 @@
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import {
+  describe,
+  it,
+  afterEach,
+} from "https://deno.land/std@0.208.0/testing/bdd.ts";
+import type { SupabaseClient, User } from "npm:@supabase/supabase-js";
+import type {
+  RegenerateDocumentPayload,
+  RegenerateDocumentResponse,
+  RegenerateDocumentResult,
+} from "./dialectic.interface.ts";
+import { regenerateDocument } from "./regenerateDocument.ts";
+import {
+  createMockSupabaseClient,
+  type MockSupabaseDataConfig,
+  type MockSupabaseClientSetup,
+  type MockQueryBuilderState,
+} from "../_shared/supabase.mock.ts";
+import { isRecord } from "../_shared/utils/type-guards/type_guards.common.ts";
+
+function getMockUser(id: string): User {
+  return {
+    id,
+    app_metadata: {},
+    user_metadata: {},
+    aud: "authenticated",
+    created_at: new Date().toISOString(),
+  };
+}
+
+const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+const stageSlug = "thesis";
+const iterationNumber = 1;
+const userId = "user-owner-id";
+const jobId1 = "job-id-1";
+const jobId2 = "job-id-2";
+const cloneId1 = "clone-id-1";
+const cloneId2 = "clone-id-2";
+
+interface MockJobRow {
+  id: string;
+  created_at: string;
+  session_id: string;
+  user_id: string;
+  stage_slug: string;
+  iteration_number: number;
+  payload: Record<string, unknown>;
+  status: string;
+  attempt_count: number;
+  max_retries: number;
+  job_type: string;
+  parent_job_id: string | null;
+  prerequisite_job_id: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  results: unknown;
+  error_details: unknown;
+  target_contribution_id: string | null;
+  is_test_job: boolean;
+}
+
+function createMockJobRow(overrides: Partial<MockJobRow> & { id: string }): MockJobRow {
+  return {
+    id: overrides.id,
+    created_at: overrides.created_at ?? new Date().toISOString(),
+    session_id: overrides.session_id ?? sessionId,
+    user_id: overrides.user_id ?? userId,
+    stage_slug: overrides.stage_slug ?? stageSlug,
+    iteration_number: overrides.iteration_number ?? iterationNumber,
+    payload: overrides.payload ?? { modelId: "model-1" },
+    status: overrides.status ?? "completed",
+    attempt_count: overrides.attempt_count ?? 1,
+    max_retries: overrides.max_retries ?? 3,
+    job_type: overrides.job_type ?? "EXECUTE",
+    parent_job_id: overrides.parent_job_id ?? null,
+    prerequisite_job_id: overrides.prerequisite_job_id ?? null,
+    started_at: overrides.started_at ?? null,
+    completed_at: overrides.completed_at ?? null,
+    results: overrides.results ?? null,
+    error_details: overrides.error_details ?? null,
+    target_contribution_id: overrides.target_contribution_id ?? null,
+    is_test_job: overrides.is_test_job ?? false,
+  };
+}
+
+describe("regenerateDocument", () => {
+  let mockSetup: MockSupabaseClientSetup | null = null;
+
+  afterEach(() => {
+    mockSetup?.clearAllStubs?.();
+  });
+
+  it("valid request with one job: original marked superseded, clone inserted as pending, returns new job ID", async () => {
+    const originalJob: MockJobRow = createMockJobRow({ id: jobId1 });
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            if (idFilter?.value === jobId1) {
+              return { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+          update: { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" },
+          insert: {
+            data: [{ ...originalJob, id: cloneId1, status: "pending", attempt_count: 0, started_at: null, completed_at: null, results: null, error_details: null, target_contribution_id: null }],
+            error: null,
+            count: 1,
+            status: 201,
+            statusText: "Created",
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 200);
+    assertExists(result.data);
+    const data: RegenerateDocumentResponse = result.data;
+    assertEquals(data.jobIds.length, 1);
+    assertEquals(data.jobIds[0], cloneId1);
+    const updateSpy = mockSetup.client.getSpiesForTableQueryMethod("dialectic_generation_jobs", "update", 1);
+    assertExists(updateSpy);
+    assertEquals(updateSpy.calls[0]?.args[0]?.status, "superseded");
+  });
+
+  it("valid request with multiple jobs: all originals marked superseded, all clones inserted, returns array of new job IDs", async () => {
+    const job1: MockJobRow = createMockJobRow({ id: jobId1 });
+    const job2: MockJobRow = createMockJobRow({ id: jobId2 });
+    const jobsById: Record<string, MockJobRow> = { [jobId1]: job1, [jobId2]: job2 };
+    const cloneIdsToReturn: string[] = [cloneId1, cloneId2];
+    let insertCallCount = 0;
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            const job = idFilter && typeof idFilter.value === "string" ? jobsById[idFilter.value] : null;
+            if (job) {
+              return { data: [job], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+          update: { data: [], error: null, count: 1, status: 200, statusText: "OK" },
+          insert: async (state: MockQueryBuilderState) => {
+            const insertData = state.insertData;
+            const newId = cloneIdsToReturn[insertCallCount];
+            insertCallCount += 1;
+            return { data: [{ ...insertData, id: newId }], error: null, count: 1, status: 201, statusText: "Created" };
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [
+        { jobId: jobId1, modelId: "model-1" },
+        { jobId: jobId2, modelId: "model-2" },
+      ],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 200);
+    assertExists(result.data);
+    assertEquals(result.data.jobIds.length, 2);
+    assertEquals(result.data.jobIds, [cloneId1, cloneId2]);
+  });
+
+  it("stage mismatch (requested stage ≠ session current stage) returns 400, no jobs modified", async () => {
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: "antithesis" } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 400);
+    assertExists(result.error);
+    assertEquals(result.error?.message.includes("stage") || result.error?.message.includes("Stage"), true);
+    const fromSpy = mockSetup.spies.fromSpy;
+    assertEquals(fromSpy.calls.some((c) => c.args[0] === "dialectic_generation_jobs"), false);
+  });
+
+  it("job not found returns 404", async () => {
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: { data: null, error: Object.assign(new Error("Job not found"), { code: "PGRST116" }), count: 0, status: 404, statusText: "Not Found" },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: "non-existent-job-id", modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 404);
+    assertExists(result.error);
+  });
+
+  it("job belongs to different session returns 403", async () => {
+    const otherSessionId = "other-session-id";
+    const jobWrongSession: MockJobRow = createMockJobRow({ id: jobId1, session_id: otherSessionId });
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            if (idFilter?.value === jobId1) {
+              return { data: [jobWrongSession], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 403);
+    assertExists(result.error);
+  });
+
+  it("job is not an EXECUTE job returns 400", async () => {
+    const planJob: MockJobRow = createMockJobRow({ id: jobId1, job_type: "PLAN" });
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            if (idFilter?.value === jobId1) {
+              return { data: [planJob], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 400);
+    assertExists(result.error);
+  });
+
+  it("user does not own the job returns 403", async () => {
+    const otherUserId = "other-user-id";
+    const jobOtherUser: MockJobRow = createMockJobRow({ id: jobId1, user_id: otherUserId });
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            if (idFilter?.value === jobId1) {
+              return { data: [jobOtherUser], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    const result: RegenerateDocumentResult = await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 403);
+    assertExists(result.error);
+  });
+
+  it("cloned job has attempt_count 0, status pending, and preserves parent_job_id and prerequisite_job_id from original", async () => {
+    const originalJob: MockJobRow = createMockJobRow({
+      id: jobId1,
+      parent_job_id: "parent-id",
+      prerequisite_job_id: "prereq-id",
+      attempt_count: 2,
+      status: "failed",
+    });
+    let capturedInsert: object | unknown[] | null = null;
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            if (idFilter?.value === jobId1) {
+              return { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+          update: { data: [], error: null, count: 1, status: 200, statusText: "OK" },
+          insert: async (state: MockQueryBuilderState) => {
+            capturedInsert = state.insertData;
+            return {
+              data: [{ ...state.insertData, id: cloneId1 }],
+              error: null,
+              count: 1,
+              status: 201,
+              statusText: "Created",
+            };
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber,
+      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+    };
+    const user: User = getMockUser(userId);
+
+    await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertExists(capturedInsert);
+    assert(isRecord(capturedInsert), "insert data must be a record");
+    assertEquals(capturedInsert["parent_job_id"], "parent-id");
+    assertEquals(capturedInsert["prerequisite_job_id"], "prereq-id");
+    assertEquals(capturedInsert["attempt_count"], 0);
+    assertEquals(capturedInsert["status"], "pending");
+  });
+
+  it("cloned job preserves original payload, stage_slug, iteration_number, session_id, job_type, max_retries", async () => {
+    const originalPayload = { modelId: "model-xyz", stepKey: "thesis_1" };
+    const originalJob: MockJobRow = createMockJobRow({
+      id: jobId1,
+      payload: originalPayload,
+      stage_slug: "thesis",
+      iteration_number: 2,
+      session_id: sessionId,
+      job_type: "EXECUTE",
+      max_retries: 5,
+    });
+    let capturedInsert: object | unknown[] | null = null;
+    const config: MockSupabaseDataConfig = {
+      genericMockResults: {
+        dialectic_sessions: {
+          select: {
+            data: [{ id: sessionId, current_stage: { slug: stageSlug } }],
+            error: null,
+            count: 1,
+            status: 200,
+            statusText: "OK",
+          },
+        },
+        dialectic_generation_jobs: {
+          select: async (state: MockQueryBuilderState) => {
+            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
+            if (idFilter?.value === jobId1) {
+              return { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" };
+            }
+            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+          },
+          update: { data: [], error: null, count: 1, status: 200, statusText: "OK" },
+          insert: async (state: MockQueryBuilderState) => {
+            capturedInsert = state.insertData;
+            return {
+              data: [{ ...state.insertData, id: cloneId1 }],
+              error: null,
+              count: 1,
+              status: 201,
+              statusText: "Created",
+            };
+          },
+        },
+      },
+    };
+    mockSetup = createMockSupabaseClient(userId, config);
+    const payload: RegenerateDocumentPayload = {
+      sessionId,
+      stageSlug,
+      iterationNumber: 2,
+      jobs: [{ jobId: jobId1, modelId: "model-xyz" }],
+    };
+    const user: User = getMockUser(userId);
+
+    await regenerateDocument(
+      payload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertExists(capturedInsert);
+    assert(isRecord(capturedInsert), "insert data must be a record");
+    assertEquals(capturedInsert["payload"], originalPayload);
+    assertEquals(capturedInsert["stage_slug"], originalJob.stage_slug);
+    assertEquals(capturedInsert["iteration_number"], originalJob.iteration_number);
+    assertEquals(capturedInsert["session_id"], originalJob.session_id);
+    assertEquals(capturedInsert["job_type"], originalJob.job_type);
+    assertEquals(capturedInsert["max_retries"], originalJob.max_retries);
+  });
+});

--- a/supabase/functions/dialectic-service/regenerateDocument.test.ts
+++ b/supabase/functions/dialectic-service/regenerateDocument.test.ts
@@ -64,6 +64,14 @@ interface MockJobRow {
   is_test_job: boolean;
 }
 
+function getDocIdentityFromSelectState(state: MockQueryBuilderState): { documentKey: string; modelId: string } | null {
+  const docKeyF = state.filters.find((f) => f.type === "filter" && f.column === "payload->>document_key");
+  const modelIdF = state.filters.find((f) => f.type === "filter" && f.column === "payload->>model_id");
+  if (!docKeyF?.value || !modelIdF?.value || typeof docKeyF.value !== "string" || typeof modelIdF.value !== "string")
+    return null;
+  return { documentKey: docKeyF.value, modelId: modelIdF.value };
+}
+
 function createMockJobRow(overrides: Partial<MockJobRow> & { id: string }): MockJobRow {
   return {
     id: overrides.id,
@@ -95,8 +103,13 @@ describe("regenerateDocument", () => {
     mockSetup?.clearAllStubs?.();
   });
 
-  it("valid request with one job: original marked superseded, clone inserted as pending, returns new job ID", async () => {
-    const originalJob: MockJobRow = createMockJobRow({ id: jobId1 });
+  it("valid request with one document: original marked superseded, clone inserted as pending, returns new job ID", async () => {
+    const documentKey = "business_case";
+    const modelId = "model-1";
+    const originalJob: MockJobRow = createMockJobRow({
+      id: jobId1,
+      payload: { document_key: documentKey, model_id: modelId },
+    });
     const config: MockSupabaseDataConfig = {
       genericMockResults: {
         dialectic_sessions: {
@@ -110,11 +123,11 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            if (idFilter?.value === jobId1) {
+            const docId = getDocIdentityFromSelectState(state);
+            if (docId && docId.documentKey === documentKey && docId.modelId === modelId) {
               return { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
           update: { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" },
           insert: {
@@ -132,7 +145,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+      documents: [{ documentKey, modelId }],
     };
     const user: User = getMockUser(userId);
 
@@ -152,10 +165,19 @@ describe("regenerateDocument", () => {
     assertEquals(updateSpy.calls[0]?.args[0]?.status, "superseded");
   });
 
-  it("valid request with multiple jobs: all originals marked superseded, all clones inserted, returns array of new job IDs", async () => {
-    const job1: MockJobRow = createMockJobRow({ id: jobId1 });
-    const job2: MockJobRow = createMockJobRow({ id: jobId2 });
-    const jobsById: Record<string, MockJobRow> = { [jobId1]: job1, [jobId2]: job2 };
+  it("valid request with multiple documents: all originals marked superseded, all clones inserted, returns array of new job IDs", async () => {
+    const job1: MockJobRow = createMockJobRow({
+      id: jobId1,
+      payload: { document_key: "business_case", model_id: "model-1" },
+    });
+    const job2: MockJobRow = createMockJobRow({
+      id: jobId2,
+      payload: { document_key: "feature_spec", model_id: "model-2" },
+    });
+    const jobsByDocIdentity: Record<string, MockJobRow> = {
+      "business_case_model-1": job1,
+      "feature_spec_model-2": job2,
+    };
     const cloneIdsToReturn: string[] = [cloneId1, cloneId2];
     let insertCallCount = 0;
     const config: MockSupabaseDataConfig = {
@@ -171,12 +193,12 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            const job = idFilter && typeof idFilter.value === "string" ? jobsById[idFilter.value] : null;
+            const docId = getDocIdentityFromSelectState(state);
+            const job = docId ? jobsByDocIdentity[`${docId.documentKey}_${docId.modelId}`] ?? null : null;
             if (job) {
               return { data: [job], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
           update: { data: [], error: null, count: 1, status: 200, statusText: "OK" },
           insert: async (state: MockQueryBuilderState) => {
@@ -193,9 +215,9 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [
-        { jobId: jobId1, modelId: "model-1" },
-        { jobId: jobId2, modelId: "model-2" },
+      documents: [
+        { documentKey: "business_case", modelId: "model-1" },
+        { documentKey: "feature_spec", modelId: "model-2" },
       ],
     };
     const user: User = getMockUser(userId);
@@ -231,7 +253,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+      documents: [{ documentKey: "business_case", modelId: "model-1" }],
     };
     const user: User = getMockUser(userId);
 
@@ -248,7 +270,7 @@ describe("regenerateDocument", () => {
     assertEquals(fromSpy.calls.some((c) => c.args[0] === "dialectic_generation_jobs"), false);
   });
 
-  it("job not found returns 404", async () => {
+  it("no matching EXECUTE job for documentKey and modelId returns 404", async () => {
     const config: MockSupabaseDataConfig = {
       genericMockResults: {
         dialectic_sessions: {
@@ -261,7 +283,7 @@ describe("regenerateDocument", () => {
           },
         },
         dialectic_generation_jobs: {
-          select: { data: null, error: Object.assign(new Error("Job not found"), { code: "PGRST116" }), count: 0, status: 404, statusText: "Not Found" },
+          select: { data: [], error: null, count: 0, status: 200, statusText: "OK" },
         },
       },
     };
@@ -270,7 +292,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: "non-existent-job-id", modelId: "model-1" }],
+      documents: [{ documentKey: "business_case", modelId: "model-1" }],
     };
     const user: User = getMockUser(userId);
 
@@ -282,11 +304,16 @@ describe("regenerateDocument", () => {
 
     assertEquals(result.status, 404);
     assertExists(result.error);
+    assert(result.error?.message?.includes("business_case") || result.error?.message?.includes("model-1"), "error message should identify documentKey or modelId");
   });
 
   it("job belongs to different session returns 403", async () => {
     const otherSessionId = "other-session-id";
-    const jobWrongSession: MockJobRow = createMockJobRow({ id: jobId1, session_id: otherSessionId });
+    const jobWrongSession: MockJobRow = createMockJobRow({
+      id: jobId1,
+      session_id: otherSessionId,
+      payload: { document_key: "business_case", model_id: "model-1" },
+    });
     const config: MockSupabaseDataConfig = {
       genericMockResults: {
         dialectic_sessions: {
@@ -300,11 +327,11 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            if (idFilter?.value === jobId1) {
+            const docId = getDocIdentityFromSelectState(state);
+            if (docId && docId.documentKey === "business_case" && docId.modelId === "model-1") {
               return { data: [jobWrongSession], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
         },
       },
@@ -314,7 +341,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+      documents: [{ documentKey: "business_case", modelId: "model-1" }],
     };
     const user: User = getMockUser(userId);
 
@@ -329,7 +356,11 @@ describe("regenerateDocument", () => {
   });
 
   it("job is not an EXECUTE job returns 400", async () => {
-    const planJob: MockJobRow = createMockJobRow({ id: jobId1, job_type: "PLAN" });
+    const planJob: MockJobRow = createMockJobRow({
+      id: jobId1,
+      job_type: "PLAN",
+      payload: { document_key: "business_case", model_id: "model-1" },
+    });
     const config: MockSupabaseDataConfig = {
       genericMockResults: {
         dialectic_sessions: {
@@ -343,11 +374,11 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            if (idFilter?.value === jobId1) {
+            const docId = getDocIdentityFromSelectState(state);
+            if (docId && docId.documentKey === "business_case" && docId.modelId === "model-1") {
               return { data: [planJob], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
         },
       },
@@ -357,7 +388,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+      documents: [{ documentKey: "business_case", modelId: "model-1" }],
     };
     const user: User = getMockUser(userId);
 
@@ -373,7 +404,11 @@ describe("regenerateDocument", () => {
 
   it("user does not own the job returns 403", async () => {
     const otherUserId = "other-user-id";
-    const jobOtherUser: MockJobRow = createMockJobRow({ id: jobId1, user_id: otherUserId });
+    const jobOtherUser: MockJobRow = createMockJobRow({
+      id: jobId1,
+      user_id: otherUserId,
+      payload: { document_key: "business_case", model_id: "model-1" },
+    });
     const config: MockSupabaseDataConfig = {
       genericMockResults: {
         dialectic_sessions: {
@@ -387,11 +422,11 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            if (idFilter?.value === jobId1) {
+            const docId = getDocIdentityFromSelectState(state);
+            if (docId && docId.documentKey === "business_case" && docId.modelId === "model-1") {
               return { data: [jobOtherUser], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
         },
       },
@@ -401,7 +436,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+      documents: [{ documentKey: "business_case", modelId: "model-1" }],
     };
     const user: User = getMockUser(userId);
 
@@ -422,6 +457,7 @@ describe("regenerateDocument", () => {
       prerequisite_job_id: "prereq-id",
       attempt_count: 2,
       status: "failed",
+      payload: { document_key: "business_case", model_id: "model-1" },
     });
     let capturedInsert: object | unknown[] | null = null;
     const config: MockSupabaseDataConfig = {
@@ -437,11 +473,11 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            if (idFilter?.value === jobId1) {
+            const docId = getDocIdentityFromSelectState(state);
+            if (docId && docId.documentKey === "business_case" && docId.modelId === "model-1") {
               return { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
           update: { data: [], error: null, count: 1, status: 200, statusText: "OK" },
           insert: async (state: MockQueryBuilderState) => {
@@ -462,7 +498,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber,
-      jobs: [{ jobId: jobId1, modelId: "model-1" }],
+      documents: [{ documentKey: "business_case", modelId: "model-1" }],
     };
     const user: User = getMockUser(userId);
 
@@ -481,7 +517,7 @@ describe("regenerateDocument", () => {
   });
 
   it("cloned job preserves original payload, stage_slug, iteration_number, session_id, job_type, max_retries", async () => {
-    const originalPayload = { modelId: "model-xyz", stepKey: "thesis_1" };
+    const originalPayload: Record<string, unknown> = { document_key: "business_case", model_id: "model-xyz", stepKey: "thesis_1" };
     const originalJob: MockJobRow = createMockJobRow({
       id: jobId1,
       payload: originalPayload,
@@ -505,11 +541,11 @@ describe("regenerateDocument", () => {
         },
         dialectic_generation_jobs: {
           select: async (state: MockQueryBuilderState) => {
-            const idFilter = state.filters.find((f) => f.column === "id" && f.type === "eq");
-            if (idFilter?.value === jobId1) {
+            const docId = getDocIdentityFromSelectState(state);
+            if (docId && docId.documentKey === "business_case" && docId.modelId === "model-xyz") {
               return { data: [originalJob], error: null, count: 1, status: 200, statusText: "OK" };
             }
-            return { data: null, error: new Error("Job not found"), count: 0, status: 404, statusText: "Not Found" };
+            return { data: [], error: null, count: 0, status: 200, statusText: "OK" };
           },
           update: { data: [], error: null, count: 1, status: 200, statusText: "OK" },
           insert: async (state: MockQueryBuilderState) => {
@@ -530,7 +566,7 @@ describe("regenerateDocument", () => {
       sessionId,
       stageSlug,
       iterationNumber: 2,
-      jobs: [{ jobId: jobId1, modelId: "model-xyz" }],
+      documents: [{ documentKey: "business_case", modelId: "model-xyz" }],
     };
     const user: User = getMockUser(userId);
 

--- a/supabase/functions/dialectic-service/regenerateDocument.ts
+++ b/supabase/functions/dialectic-service/regenerateDocument.ts
@@ -19,11 +19,11 @@ function isValidRegeneratePayload(
   if (typeof value["stageSlug"] !== "string" || value["stageSlug"].length === 0)
     return false;
   if (typeof value["iterationNumber"] !== "number") return false;
-  const jobs = value["jobs"];
-  if (!Array.isArray(jobs)) return false;
-  for (const entry of jobs) {
+  const documents = value["documents"];
+  if (!Array.isArray(documents)) return false;
+  for (const entry of documents) {
     if (!isRecord(entry)) return false;
-    if (typeof entry["jobId"] !== "string" || entry["jobId"].length === 0)
+    if (typeof entry["documentKey"] !== "string" || entry["documentKey"].length === 0)
       return false;
     if (typeof entry["modelId"] !== "string" || entry["modelId"].length === 0)
       return false;
@@ -47,7 +47,7 @@ export async function regenerateDocument(
 
   if (!isValidRegeneratePayload(payload)) {
     const error: ServiceError = {
-      message: "Invalid payload: sessionId, stageSlug, iterationNumber, and jobs array with jobId and modelId required",
+      message: "Invalid payload: sessionId, stageSlug, iterationNumber, and documents array with documentKey and modelId required",
       status: 400,
       code: "VALIDATION_ERROR",
     };
@@ -109,24 +109,25 @@ export async function regenerateDocument(
 
   const jobIds: string[] = [];
 
-  for (const jobRef of payload.jobs) {
-    const { data: jobData, error: jobError } = await dbClient
+  for (const docRef of payload.documents) {
+    const { data: jobRows, error: jobError } = await dbClient
       .from("dialectic_generation_jobs")
       .select("*")
-      .eq("id", jobRef.jobId)
-      .single();
+      .eq("session_id", payload.sessionId)
+      .eq("stage_slug", payload.stageSlug)
+      .eq("iteration_number", payload.iterationNumber)
+      .eq("user_id", user.id)
+      .eq("job_type", "EXECUTE")
+      .neq("status", "superseded")
+      .filter("payload->>document_key", "eq", docRef.documentKey)
+      .filter("payload->>model_id", "eq", docRef.modelId)
+      .order("created_at", { ascending: false })
+      .limit(1);
 
     if (jobError) {
-      if (jobError.code === "PGRST116") {
-        const error: ServiceError = {
-          message: "Job not found",
-          status: 404,
-          code: "NOT_FOUND",
-        };
-        return { status: 404, error };
-      }
       logger.error("regenerateDocument: failed to fetch job", {
-        jobId: jobRef.jobId,
+        documentKey: docRef.documentKey,
+        modelId: docRef.modelId,
         error: jobError.message,
       });
       const error: ServiceError = {
@@ -137,9 +138,10 @@ export async function regenerateDocument(
       return { status: 500, error };
     }
 
+    const jobData = jobRows?.[0] ?? null;
     if (!jobData) {
       const error: ServiceError = {
-        message: "Job not found",
+        message: `No EXECUTE job found for documentKey '${docRef.documentKey}' and modelId '${docRef.modelId}'`,
         status: 404,
         code: "NOT_FOUND",
       };
@@ -148,7 +150,8 @@ export async function regenerateDocument(
 
     if (!isDialecticJobRow(jobData)) {
       logger.error("regenerateDocument: job row shape invalid", {
-        jobId: jobRef.jobId,
+        documentKey: docRef.documentKey,
+        modelId: docRef.modelId,
       });
       const error: ServiceError = {
         message: "Invalid job data",
@@ -167,24 +170,6 @@ export async function regenerateDocument(
         code: "FORBIDDEN",
       };
       return { status: 403, error };
-    }
-
-    if (job.stage_slug !== payload.stageSlug) {
-      const error: ServiceError = {
-        message: "Job stage does not match requested stage",
-        status: 400,
-        code: "STAGE_MISMATCH",
-      };
-      return { status: 400, error };
-    }
-
-    if (job.iteration_number !== payload.iterationNumber) {
-      const error: ServiceError = {
-        message: "Job iteration does not match requested iteration",
-        status: 400,
-        code: "ITERATION_MISMATCH",
-      };
-      return { status: 400, error };
     }
 
     if (job.user_id !== user.id) {
@@ -208,12 +193,14 @@ export async function regenerateDocument(
     const updateError = await dbClient
       .from("dialectic_generation_jobs")
       .update({ status: "superseded" })
-      .eq("id", jobRef.jobId)
+      .eq("id", job.id)
       .then((r) => r.error);
 
     if (updateError) {
       logger.error("regenerateDocument: failed to mark job superseded", {
-        jobId: jobRef.jobId,
+        jobId: job.id,
+        documentKey: docRef.documentKey,
+        modelId: docRef.modelId,
         error: updateError.message,
       });
       const error: ServiceError = {
@@ -252,7 +239,9 @@ export async function regenerateDocument(
 
     if (insertError) {
       logger.error("regenerateDocument: failed to insert clone job", {
-        originalJobId: jobRef.jobId,
+        originalJobId: job.id,
+        documentKey: docRef.documentKey,
+        modelId: docRef.modelId,
         error: insertError.message,
       });
       const error: ServiceError = {

--- a/supabase/functions/dialectic-service/regenerateDocument.ts
+++ b/supabase/functions/dialectic-service/regenerateDocument.ts
@@ -1,0 +1,280 @@
+import type { SupabaseClient, User } from "npm:@supabase/supabase-js";
+import type {
+  RegenerateDocumentPayload,
+  RegenerateDocumentResponse,
+  RegenerateDocumentResult,
+} from "./dialectic.interface.ts";
+import type { TablesInsert } from "../types_db.ts";
+import type { ServiceError } from "../_shared/types.ts";
+import { logger } from "../_shared/logger.ts";
+import { isRecord } from "../_shared/utils/type-guards/type_guards.common.ts";
+import { isDialecticJobRow } from "../_shared/utils/type-guards/type_guards.dialectic.ts";
+
+function isValidRegeneratePayload(
+  value: unknown,
+): value is RegenerateDocumentPayload {
+  if (!isRecord(value)) return false;
+  if (typeof value["sessionId"] !== "string" || value["sessionId"].length === 0)
+    return false;
+  if (typeof value["stageSlug"] !== "string" || value["stageSlug"].length === 0)
+    return false;
+  if (typeof value["iterationNumber"] !== "number") return false;
+  const jobs = value["jobs"];
+  if (!Array.isArray(jobs)) return false;
+  for (const entry of jobs) {
+    if (!isRecord(entry)) return false;
+    if (typeof entry["jobId"] !== "string" || entry["jobId"].length === 0)
+      return false;
+    if (typeof entry["modelId"] !== "string" || entry["modelId"].length === 0)
+      return false;
+  }
+  return true;
+}
+
+export async function regenerateDocument(
+  payload: RegenerateDocumentPayload,
+  dbClient: SupabaseClient,
+  user: User | null,
+): Promise<RegenerateDocumentResult> {
+  if (!user) {
+    const error: ServiceError = {
+      message: "User not authenticated",
+      status: 401,
+      code: "USER_AUTH_FAILED",
+    };
+    return { status: 401, error };
+  }
+
+  if (!isValidRegeneratePayload(payload)) {
+    const error: ServiceError = {
+      message: "Invalid payload: sessionId, stageSlug, iterationNumber, and jobs array with jobId and modelId required",
+      status: 400,
+      code: "VALIDATION_ERROR",
+    };
+    return { status: 400, error };
+  }
+
+  const { data: sessionData, error: sessionError } = await dbClient
+    .from("dialectic_sessions")
+    .select("id, current_stage:current_stage_id(slug)")
+    .eq("id", payload.sessionId)
+    .single();
+
+  if (sessionError) {
+    if (sessionError.code === "PGRST116") {
+      const error: ServiceError = {
+        message: "Session not found",
+        status: 404,
+        code: "NOT_FOUND",
+      };
+      return { status: 404, error };
+    }
+    logger.error("regenerateDocument: failed to fetch session", {
+      sessionId: payload.sessionId,
+      error: sessionError.message,
+    });
+    const error: ServiceError = {
+      message: sessionError.message,
+      status: 500,
+      code: "DB_ERROR",
+    };
+    return { status: 500, error };
+  }
+
+  if (!sessionData) {
+    const error: ServiceError = {
+      message: "Session not found",
+      status: 404,
+      code: "NOT_FOUND",
+    };
+    return { status: 404, error };
+  }
+
+  const currentStage = sessionData.current_stage;
+  const stageSlug =
+    currentStage &&
+    !Array.isArray(currentStage) &&
+    isRecord(currentStage) &&
+    typeof currentStage["slug"] === "string"
+      ? currentStage["slug"]
+      : null;
+  if (stageSlug !== payload.stageSlug) {
+    const error: ServiceError = {
+      message: "Session current stage does not match the requested stage",
+      status: 400,
+      code: "STAGE_MISMATCH",
+    };
+    return { status: 400, error };
+  }
+
+  const jobIds: string[] = [];
+
+  for (const jobRef of payload.jobs) {
+    const { data: jobData, error: jobError } = await dbClient
+      .from("dialectic_generation_jobs")
+      .select("*")
+      .eq("id", jobRef.jobId)
+      .single();
+
+    if (jobError) {
+      if (jobError.code === "PGRST116") {
+        const error: ServiceError = {
+          message: "Job not found",
+          status: 404,
+          code: "NOT_FOUND",
+        };
+        return { status: 404, error };
+      }
+      logger.error("regenerateDocument: failed to fetch job", {
+        jobId: jobRef.jobId,
+        error: jobError.message,
+      });
+      const error: ServiceError = {
+        message: jobError.message,
+        status: 500,
+        code: "DB_ERROR",
+      };
+      return { status: 500, error };
+    }
+
+    if (!jobData) {
+      const error: ServiceError = {
+        message: "Job not found",
+        status: 404,
+        code: "NOT_FOUND",
+      };
+      return { status: 404, error };
+    }
+
+    if (!isDialecticJobRow(jobData)) {
+      logger.error("regenerateDocument: job row shape invalid", {
+        jobId: jobRef.jobId,
+      });
+      const error: ServiceError = {
+        message: "Invalid job data",
+        status: 500,
+        code: "DB_ERROR",
+      };
+      return { status: 500, error };
+    }
+
+    const job = jobData;
+
+    if (job.session_id !== payload.sessionId) {
+      const error: ServiceError = {
+        message: "Job does not belong to this session",
+        status: 403,
+        code: "FORBIDDEN",
+      };
+      return { status: 403, error };
+    }
+
+    if (job.stage_slug !== payload.stageSlug) {
+      const error: ServiceError = {
+        message: "Job stage does not match requested stage",
+        status: 400,
+        code: "STAGE_MISMATCH",
+      };
+      return { status: 400, error };
+    }
+
+    if (job.iteration_number !== payload.iterationNumber) {
+      const error: ServiceError = {
+        message: "Job iteration does not match requested iteration",
+        status: 400,
+        code: "ITERATION_MISMATCH",
+      };
+      return { status: 400, error };
+    }
+
+    if (job.user_id !== user.id) {
+      const error: ServiceError = {
+        message: "You do not own this job",
+        status: 403,
+        code: "FORBIDDEN",
+      };
+      return { status: 403, error };
+    }
+
+    if (job.job_type !== "EXECUTE") {
+      const error: ServiceError = {
+        message: "Only EXECUTE jobs can be regenerated",
+        status: 400,
+        code: "INVALID_JOB_TYPE",
+      };
+      return { status: 400, error };
+    }
+
+    const updateError = await dbClient
+      .from("dialectic_generation_jobs")
+      .update({ status: "superseded" })
+      .eq("id", jobRef.jobId)
+      .then((r) => r.error);
+
+    if (updateError) {
+      logger.error("regenerateDocument: failed to mark job superseded", {
+        jobId: jobRef.jobId,
+        error: updateError.message,
+      });
+      const error: ServiceError = {
+        message: updateError.message,
+        status: 500,
+        code: "DB_ERROR",
+      };
+      return { status: 500, error };
+    }
+
+    const cloneRow: TablesInsert<"dialectic_generation_jobs"> = {
+      session_id: job.session_id,
+      user_id: job.user_id,
+      stage_slug: job.stage_slug,
+      iteration_number: job.iteration_number,
+      payload: job.payload,
+      status: "pending",
+      attempt_count: 0,
+      max_retries: job.max_retries,
+      job_type: job.job_type,
+      parent_job_id: job.parent_job_id,
+      prerequisite_job_id: job.prerequisite_job_id,
+      started_at: null,
+      completed_at: null,
+      results: null,
+      error_details: null,
+      target_contribution_id: null,
+      is_test_job: job.is_test_job,
+    };
+
+    const { data: inserted, error: insertError } = await dbClient
+      .from("dialectic_generation_jobs")
+      .insert(cloneRow)
+      .select("id")
+      .single();
+
+    if (insertError) {
+      logger.error("regenerateDocument: failed to insert clone job", {
+        originalJobId: jobRef.jobId,
+        error: insertError.message,
+      });
+      const error: ServiceError = {
+        message: insertError.message,
+        status: 500,
+        code: "DB_ERROR",
+      };
+      return { status: 500, error };
+    }
+
+    if (!inserted || typeof inserted.id !== "string") {
+      const error: ServiceError = {
+        message: "Insert did not return job id",
+        status: 500,
+        code: "DB_ERROR",
+      };
+      return { status: 500, error };
+    }
+
+    jobIds.push(inserted.id);
+  }
+
+  const response: RegenerateDocumentResponse = { jobIds };
+  return { status: 200, data: response };
+}

--- a/supabase/functions/dialectic-service/resumePausedNsfJobs.test.ts
+++ b/supabase/functions/dialectic-service/resumePausedNsfJobs.test.ts
@@ -1,0 +1,147 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { stub } from "https://deno.land/std@0.208.0/testing/mock.ts";
+import {
+  describe,
+  it,
+  afterEach,
+} from "https://deno.land/std@0.208.0/testing/bdd.ts";
+import type { SupabaseClient, User } from "npm:@supabase/supabase-js";
+import type {
+  ResumePausedNsfJobsPayload,
+  ResumePausedNsfJobsResponse,
+  ResumePausedNsfJobsResult,
+} from "./dialectic.interface.ts";
+import { handleResumePausedNsfJobs } from "./resumePausedNsfJobs.ts";
+import { logger } from "../_shared/logger.ts";
+import {
+  createMockSupabaseClient,
+  type MockSupabaseClientSetup,
+  type MockSupabaseDataConfig,
+} from "../_shared/supabase.mock.ts";
+
+function getMockUser(id: string): User {
+  return {
+    id,
+    app_metadata: {},
+    user_metadata: {},
+    aud: "authenticated",
+    created_at: new Date().toISOString(),
+  };
+}
+
+const validPayload: ResumePausedNsfJobsPayload = {
+  sessionId: "550e8400-e29b-41d4-a716-446655440000",
+  stageSlug: "thesis",
+  iterationNumber: 1,
+};
+
+describe("handleResumePausedNsfJobs", () => {
+  let mockSetup: MockSupabaseClientSetup | null = null;
+  let errorStub: { restore: () => void; calls: { length: number } } | undefined = undefined;
+
+  afterEach(() => {
+    if (errorStub) errorStub.restore();
+    mockSetup?.clearAllStubs?.();
+  });
+
+  it("calls adminClient.rpc('resume_paused_nsf_jobs', { p_session_id, p_stage_slug, p_iteration_number }) with correct parameters", async () => {
+    const resumedCount: number = 2;
+    const config: MockSupabaseDataConfig = {
+      rpcResults: {
+        resume_paused_nsf_jobs: (): Promise<{ data: number; error: null }> =>
+          Promise.resolve({ data: resumedCount, error: null }),
+      },
+    };
+    mockSetup = createMockSupabaseClient("user-id", config);
+    const user: User = getMockUser("user-id");
+
+    await handleResumePausedNsfJobs(
+      validPayload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(mockSetup.spies.rpcSpy.calls.length, 1);
+    assertEquals(mockSetup.spies.rpcSpy.calls[0].args[0], "resume_paused_nsf_jobs");
+    assertEquals(mockSetup.spies.rpcSpy.calls[0].args[1], {
+      p_session_id: validPayload.sessionId,
+      p_stage_slug: validPayload.stageSlug,
+      p_iteration_number: validPayload.iterationNumber,
+    });
+  });
+
+  it("returns { resumedCount: N } and status 200 on success where N is the RPC return value", async () => {
+    const resumedCount: number = 3;
+    const config: MockSupabaseDataConfig = {
+      rpcResults: {
+        resume_paused_nsf_jobs: (): Promise<{ data: number; error: null }> =>
+          Promise.resolve({ data: resumedCount, error: null }),
+      },
+    };
+    mockSetup = createMockSupabaseClient("user-id", config);
+    const user: User = getMockUser("user-id");
+
+    const result: ResumePausedNsfJobsResult = await handleResumePausedNsfJobs(
+      validPayload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 200);
+    assertExists(result.data);
+    const data: ResumePausedNsfJobsResponse = result.data;
+    assertEquals(data.resumedCount, resumedCount);
+    assertEquals(result.error, undefined);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const config: MockSupabaseDataConfig = {
+      rpcResults: {
+        resume_paused_nsf_jobs: (): Promise<{ data: number; error: null }> =>
+          Promise.resolve({ data: 0, error: null }),
+      },
+    };
+    mockSetup = createMockSupabaseClient("user-id", config);
+    const userOrNull: User | null = null;
+
+    const result: ResumePausedNsfJobsResult = await handleResumePausedNsfJobs(
+      validPayload,
+      mockSetup.client as unknown as SupabaseClient,
+      userOrNull,
+    );
+
+    assertEquals(result.status, 401);
+    assertExists(result.error);
+    assertEquals(result.error?.message, "User not authenticated");
+    assertEquals(mockSetup.spies.rpcSpy.calls.length, 0);
+  });
+
+  it("returns 500 when RPC fails and logs the error", async () => {
+    const stubInstance = stub(logger, "error", () => {});
+    errorStub = { restore: () => stubInstance.restore(), calls: stubInstance.calls };
+    const rpcError: Error = new Error("resume_paused_nsf_jobs failed");
+    const config: MockSupabaseDataConfig = {
+      rpcResults: {
+        resume_paused_nsf_jobs: () =>
+          Promise.resolve({ data: null, error: rpcError }),
+      },
+    };
+    mockSetup = createMockSupabaseClient("user-id", config);
+    const user: User = getMockUser("user-id");
+
+    const result: ResumePausedNsfJobsResult = await handleResumePausedNsfJobs(
+      validPayload,
+      mockSetup.client as unknown as SupabaseClient,
+      user,
+    );
+
+    assertEquals(result.status, 500);
+    assertExists(result.error);
+    assertEquals(result.error?.message, rpcError.message);
+    assertEquals(result.error?.code, "RESUME_FAILED");
+    assertEquals(errorStub.calls.length, 1);
+  });
+});

--- a/supabase/functions/dialectic-service/resumePausedNsfJobs.ts
+++ b/supabase/functions/dialectic-service/resumePausedNsfJobs.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient, User } from "npm:@supabase/supabase-js";
+import type {
+  ResumePausedNsfJobsPayload,
+  ResumePausedNsfJobsResponse,
+  ResumePausedNsfJobsResult,
+} from "./dialectic.interface.ts";
+import type { ServiceError } from "../_shared/types.ts";
+import { logger } from "../_shared/logger.ts";
+
+export async function handleResumePausedNsfJobs(
+  payload: ResumePausedNsfJobsPayload,
+  adminClient: SupabaseClient,
+  user: User | null,
+): Promise<ResumePausedNsfJobsResult> {
+  if (!user) {
+    const error: ServiceError = {
+      message: "User not authenticated",
+      status: 401,
+      code: "USER_AUTH_FAILED",
+    };
+    return { status: 401, error };
+  }
+
+  const { data, error } = await adminClient.rpc("resume_paused_nsf_jobs", {
+    p_session_id: payload.sessionId,
+    p_stage_slug: payload.stageSlug,
+    p_iteration_number: payload.iterationNumber,
+  });
+
+  if (error) {
+    logger.error("resumePausedNsfJobs: RPC failed", {
+      error: error.message,
+      sessionId: payload.sessionId,
+      stageSlug: payload.stageSlug,
+      iterationNumber: payload.iterationNumber,
+    });
+    const serviceError: ServiceError = {
+      message: error.message,
+      status: 500,
+      code: "RESUME_FAILED",
+    };
+    return { status: 500, error: serviceError };
+  }
+
+  if (typeof data !== "number") {
+    logger.error("resumePausedNsfJobs: RPC returned non-number", {
+      sessionId: payload.sessionId,
+      stageSlug: payload.stageSlug,
+      iterationNumber: payload.iterationNumber,
+    });
+    const serviceError: ServiceError = {
+      message: "resume_paused_nsf_jobs returned invalid result",
+      status: 500,
+      code: "RESUME_FAILED",
+    };
+    return { status: 500, error: serviceError };
+  }
+
+  const response: ResumePausedNsfJobsResponse = { resumedCount: data };
+  return { status: 200, data: response };
+}

--- a/supabase/functions/dialectic-worker/executeModelCallAndSave.render.test.ts
+++ b/supabase/functions/dialectic-worker/executeModelCallAndSave.render.test.ts
@@ -4,7 +4,7 @@ import {
     assertExists,
     assertRejects,
 } from 'https://deno.land/std@0.170.0/testing/asserts.ts';
-import { stub } from 'https://deno.land/std@0.224.0/testing/mock.ts';
+import { stub, spy } from 'https://deno.land/std@0.224.0/testing/mock.ts';
 import { Database, Tables } from '../types_db.ts';
 import { SupabaseClient } from 'npm:@supabase/supabase-js@2';
 import { MockFileManagerService } from '../_shared/services/file_manager.mock.ts';
@@ -198,26 +198,24 @@ Deno.test('should not enqueue RENDER job for header_context output type', async 
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: No RENDER job should be inserted because header_context is not a markdown document
+    // Assert: Target — non-markdown output types must not enqueue RENDER
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     if (insertCalls) {
-        // Filter for RENDER job inserts only
         const renderInserts = insertCalls.callsArgs.filter((callArg) => {
             const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
             return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
         });
-        assertEquals(renderInserts.length, 0, 'Should not enqueue RENDER job for non-markdown output type like header_context');
+        assertEquals(renderInserts.length, 0, 'Target: non-markdown output type must not enqueue RENDER');
     } else {
-        // If no inserts at all, that's also correct (no RENDER job enqueued)
-        assert(true, 'No RENDER job enqueued for header_context output type');
+        assert(true, 'Target: no RENDER job enqueued for non-markdown output type');
     }
 
     clearAllStubs?.();
 });
 
-Deno.test('should enqueue RENDER job for markdown document output type', async () => {
-    // Arrange: Mock a job with output_type: 'business_case' and a stage where business_case
-    // is defined as a markdown document in recipe steps
+Deno.test('should enqueue RENDER job for markdown document output type (single complete chunk)', async () => {
+    // Arrange: Target — single complete chunk (finish_reason stop, no continuation). Markdown output must enqueue one RENDER job.
+    // Mock output_type: 'business_case' with stage where business_case is a markdown document in recipe steps.
     const mockStage: Tables<'dialectic_stages'> = {
         id: 'stage-1',
         slug: DialecticStageSlug.Thesis,
@@ -332,17 +330,16 @@ Deno.test('should enqueue RENDER job for markdown document output type', async (
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: A RENDER job should be inserted with correct payload
+    // Assert: Target — single complete chunk (needsContinuation false) with markdown output must enqueue exactly one RENDER job
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
 
-    // Filter for RENDER job inserts only
     const renderInserts = insertCalls.callsArgs.filter((callArg) => {
         const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job for markdown document output type');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg = renderInserts[0];
     const inserted = Array.isArray(insertedArg) ? (insertedArg[0]) : (insertedArg);
@@ -367,10 +364,9 @@ Deno.test('should enqueue RENDER job for markdown document output type', async (
     clearAllStubs?.();
 });
 
-Deno.test('should enqueue RENDER job on every chunk completion, not just final completion', async () => {
-    // Arrange: Mock a continuation job (with target_contribution_id set in job payload)
-    // that produces markdown (output_type: 'business_case')
-    // Mock the AI response with finish_reason: 'length' (indicating continuation needed)
+Deno.test('should NOT enqueue RENDER job for intermediate continuation chunk when needsContinuation is true', async () => {
+    // Arrange: Mock a continuation job (continueUntilComplete: true, finish_reason: 'length')
+    // so needsContinuation is true. RENDER must only run on the final chunk, not on intermediate chunks.
     const mockStage: Tables<'dialectic_stages'> = {
         id: 'stage-1',
         slug: DialecticStageSlug.Thesis,
@@ -486,42 +482,127 @@ Deno.test('should enqueue RENDER job on every chunk completion, not just final c
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: A RENDER job should be enqueued even though needsContinuation is true
-    // This proves rendering happens on every chunk, not just final completion
+    // Assert: Target — intermediate continuation chunk (needsContinuation true) must not enqueue RENDER
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
 
-    // Filter for RENDER job inserts only
     const renderInserts = insertCalls.callsArgs.filter((callArg) => {
         const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue RENDER job on chunk completion even when continuation is needed');
+    assertEquals(renderInserts.length, 0, 'Target: intermediate continuation chunk (needsContinuation true) must not enqueue RENDER');
 
-    const insertedArg = renderInserts[0];
-    const inserted = Array.isArray(insertedArg) ? (insertedArg[0]) : (insertedArg);
+    clearAllStubs?.();
+});
 
-    assert(isRecord(inserted), 'Inserted payload must be an object');
+Deno.test('intermediate continuation chunk with invalid JSON fragment must skip sanitize/parse (no retry)', async () => {
+    // Target: decide intermediate before sanitize/parse; run sanitize/parse only when not intermediate.
+    // If we ran parse on this chunk we would retry (malformed JSON). Assert retryJob not called and no RENDER.
+    const mockStage: Tables<'dialectic_stages'> = {
+        id: 'stage-1',
+        slug: DialecticStageSlug.Thesis,
+        display_name: 'Test Stage',
+        description: null,
+        default_system_prompt_id: null,
+        recipe_template_id: 'template-1',
+        active_recipe_instance_id: 'instance-1',
+        expected_output_template_ids: [],
+        created_at: new Date().toISOString(),
+    };
 
-    // Verify it's a RENDER job
-    assertEquals(inserted['job_type'], 'RENDER', 'RENDER job must have job_type: RENDER');
+    const mockInstance: Tables<'dialectic_stage_recipe_instances'> = {
+        id: 'instance-1',
+        stage_id: 'stage-1',
+        template_id: 'template-1',
+        is_cloned: false,
+        cloned_at: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+    };
 
-    // Parent must associate to the just-completed EXECUTE job
-    assertEquals(inserted['parent_job_id'], job.id, 'Parent job id must point to completed EXECUTE job');
+    const mockStep: Tables<'dialectic_recipe_template_steps'> = {
+        id: 'step-1',
+        template_id: 'template-1',
+        step_number: 1,
+        step_key: 'execute_business_case',
+        step_slug: 'execute-business-case',
+        step_name: 'Execute Business Case',
+        step_description: null,
+        job_type: 'EXECUTE',
+        prompt_type: 'Turn',
+        prompt_template_id: null,
+        output_type: 'business_case',
+        granularity_strategy: 'per_source_document',
+        inputs_required: [],
+        inputs_relevance: [],
+        outputs_required: {
+            files_to_generate: [{ from_document_key: 'business_case', template_filename: 'thesis_business_case.md' }],
+        },
+        parallel_group: null,
+        branch_key: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+    };
 
-    // Payload must include required renderer identity fields
-    const pl = inserted['payload'];
-    assert(isRecord(pl), 'Inserted payload.payload must be an object');
-    assertEquals(pl['documentIdentity'], 'doc-root-xyz', 'Payload must include documentIdentity derived from document_relationships[thesis]');
-    
-    // For continuation chunks, sourceContributionId must be THIS chunk's contribution.id, not the root's ID
-    // The saved contribution has id = mockContribution.id (this chunk's ID)
-    // documentIdentity is 'doc-root-xyz' (the root's ID from document_relationships)
-    // They should NOT be equal for continuation chunks
-    assert('sourceContributionId' in pl, 'RENDER job payload must include sourceContributionId field');
-    assertEquals(pl['sourceContributionId'], mockContribution.id, 'sourceContributionId must be this continuation chunk\'s contribution.id, not the root\'s ID');
-    assert(pl['sourceContributionId'] !== pl['documentIdentity'], 'For continuation chunks, sourceContributionId (this chunk\'s ID) must NOT equal documentIdentity (root\'s ID)');
+    const { client: dbClient, spies, clearAllStubs } = setupMockClient({
+        'ai_providers': { select: { data: [mockFullProviderData], error: null } },
+        'dialectic_stages': { select: { data: [mockStage], error: null } },
+        'dialectic_stage_recipe_instances': { select: { data: [mockInstance], error: null } },
+        'dialectic_recipe_template_steps': { select: { data: [mockStep], error: null } },
+        'dialectic_generation_jobs': { insert: { data: [mockRenderJob], error: null } },
+    });
+
+    const deps = getMockDeps();
+    assert(deps.fileManager instanceof MockFileManagerService, 'Expected deps.fileManager to be a MockFileManagerService');
+    const documentRelationships: DocumentRelationships = { [DialecticStageSlug.Thesis]: 'doc-root-xyz' };
+    const savedWithIdentity: DialecticContributionRow = { ...mockContribution, document_relationships: documentRelationships };
+    deps.fileManager.setUploadAndRegisterFileResponse(savedWithIdentity, null);
+
+    const retryJobSpy = spy(deps, 'retryJob');
+    stubShouldEnqueueRenderJobForMarkdown(deps);
+
+    // Invalid JSON fragment — would throw if we ran JSON.parse; intermediate chunk must skip parse
+    const invalidJsonFragment = '{"content": "incomplete';
+    stub(deps, 'callUnifiedAIModel', () => Promise.resolve(
+        createMockUnifiedAIResponse({
+            content: invalidJsonFragment,
+            contentType: 'application/json',
+            inputTokens: 10,
+            outputTokens: 5,
+            processingTimeMs: 50,
+            rawProviderResponse: { finish_reason: 'length' },
+        })
+    ));
+
+    const continuationPayload: DialecticExecuteJobPayload = {
+        ...testPayload,
+        output_type: FileType.business_case,
+        document_key: 'business_case',
+        target_contribution_id: 'contrib-root-123',
+        continueUntilComplete: true,
+        continuation_count: 1,
+        stageSlug: DialecticStageSlug.Thesis,
+        document_relationships: {
+            source_group: '550e8400-e29b-41d4-a716-446655440000',
+            [DialecticStageSlug.Thesis]: 'doc-root-xyz',
+        },
+    };
+
+    const job = createMockJob(continuationPayload);
+    const params = buildExecuteParams(dbClient as unknown as SupabaseClient<Database>, deps, { job });
+
+    await executeModelCallAndSave(params);
+
+    assertEquals(retryJobSpy.calls.length, 0, 'Target: intermediate chunk must skip sanitize/parse so invalid JSON fragment must not trigger retry');
+
+    const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
+    assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
+    const renderInserts = insertCalls.callsArgs.filter((callArg) => {
+        const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
+        return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
+    });
+    assertEquals(renderInserts.length, 0, 'Target: intermediate continuation chunk must not enqueue RENDER');
 
     clearAllStubs?.();
 });
@@ -636,7 +717,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload includes documentKey wit
     };
     deps.fileManager.setUploadAndRegisterFileResponse(savedWithIdentity, null);
 
-    // This test asserts a RENDER job is enqueued; force the markdown rendering decision path.
+    // Target: single complete chunk (needsContinuation false) with markdown output enqueues one RENDER job.
     stubShouldEnqueueRenderJobForMarkdown(deps);
 
     stub(deps, 'callUnifiedAIModel', () => Promise.resolve(
@@ -650,7 +731,6 @@ Deno.test('executeModelCallAndSave - RENDER job payload includes documentKey wit
         })
     ));
 
-    // Use business_case with document_key set to 'business_case'
     const businessCasePayload: DialecticExecuteJobPayload = {
         ...testPayload,
         output_type: FileType.business_case,
@@ -668,7 +748,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload includes documentKey wit
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: RENDER job payload must include documentKey with value from validatedDocumentKey
+    // Assert: Target — RENDER job payload must include documentKey from validatedDocumentKey
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
 
@@ -677,7 +757,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload includes documentKey wit
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg: unknown = renderInserts[0];
     const insertedUnknown: unknown = Array.isArray(insertedArg) ? insertedArg[0] : insertedArg;
@@ -829,7 +909,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload contains all required fi
     };
     deps.fileManager.setUploadAndRegisterFileResponse(savedContribution, null);
 
-    // This test asserts a RENDER job is enqueued; force the markdown rendering decision path.
+    // Target: single complete chunk (needsContinuation false) with markdown output enqueues one RENDER job.
     stubShouldEnqueueRenderJobForMarkdown(deps);
 
     stub(deps, 'callUnifiedAIModel', () => Promise.resolve(
@@ -859,7 +939,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload contains all required fi
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: RENDER job payload must contain all 7 required fields
+    // Assert: Target — RENDER job payload must contain all required fields when single complete chunk enqueues RENDER
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
 
@@ -868,7 +948,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload contains all required fi
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg: unknown = renderInserts[0];
     const insertedUnknown: unknown = Array.isArray(insertedArg) ? insertedArg[0] : insertedArg;
@@ -1078,7 +1158,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload sourceContributionId mus
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: RENDER job payload must have sourceContributionId set to the ACTUAL contribution.id,
+    // Assert: Target — RENDER job payload must have sourceContributionId set to the ACTUAL contribution.id
     // NOT the semantic identifier from document_relationships
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
@@ -1088,7 +1168,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload sourceContributionId mus
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg: unknown = renderInserts[0];
     const insertedUnknown: unknown = Array.isArray(insertedArg) ? insertedArg[0] : insertedArg;
@@ -1180,6 +1260,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload sourceContributionId mus
 });
 
 Deno.test('executeModelCallAndSave - RENDER jobs for root and continuation chunks render complete document and replace original', async () => {
+    // Target: each final chunk (needsContinuation false) enqueues one RENDER job. Root and continuation both use finish_reason stop and continueUntilComplete false.
     // This test proves that:
     // 1. Root chunk creates a RENDER job with correct payload (sourceContributionId === documentIdentity)
     // 2. Continuation chunk creates a RENDER job with correct payload (sourceContributionId !== documentIdentity)
@@ -1343,7 +1424,7 @@ Deno.test('executeModelCallAndSave - RENDER jobs for root and continuation chunk
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
     
-    assertEquals(rootRenderInserts.length, 1, 'Should enqueue RENDER job for root chunk');
+    assertEquals(rootRenderInserts.length, 1, 'Target: root chunk as final chunk (needsContinuation false) must enqueue exactly one RENDER job');
     
     const rootInserted = Array.isArray(rootRenderInserts[0]) ? rootRenderInserts[0][0] : rootRenderInserts[0];
     assert(isRecord(rootInserted), 'Root inserted payload must be an object');
@@ -1403,8 +1484,8 @@ Deno.test('executeModelCallAndSave - RENDER jobs for root and continuation chunk
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
     
-    // Should have 2 RENDER jobs total (one for root, one for continuation)
-    assertEquals(continuationRenderInserts.length, 2, 'Should have RENDER jobs for both root and continuation chunks');
+    // Target: each final chunk (needsContinuation false) enqueues one RENDER job; root and continuation each completed as final
+    assertEquals(continuationRenderInserts.length, 2, 'Target: root and continuation as final chunks must each enqueue one RENDER job (total 2)');
     
     // Get the continuation chunk's RENDER job (the second one)
     const continuationInserted = Array.isArray(continuationRenderInserts[1]) ? continuationRenderInserts[1][0] : continuationRenderInserts[1];
@@ -1560,7 +1641,7 @@ Deno.test('executeModelCallAndSave - enqueues RENDER job with ALL required paylo
     // Act
     await executeModelCallAndSave(params);
 
-    // Assert: RENDER job insert includes payload with ALL 8 required fields
+    // Assert: Target — RENDER job insert includes payload with ALL required fields when single complete chunk enqueues RENDER
     const insertCalls = spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'insert');
     assertExists(insertCalls, 'Expected to track insert calls for dialectic_generation_jobs');
 
@@ -1569,7 +1650,7 @@ Deno.test('executeModelCallAndSave - enqueues RENDER job with ALL required paylo
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg: unknown = renderInserts[0];
     const insertedUnknown: unknown = Array.isArray(insertedArg) ? insertedArg[0] : insertedArg;
@@ -1797,7 +1878,7 @@ Deno.test('executeModelCallAndSave - throws error when parent job payload lacks 
             const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
             return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
         });
-        assertEquals(renderInserts.length, 0, 'Should not enqueue RENDER job when user_jwt is missing');
+        assertEquals(renderInserts.length, 0, 'Target: must not enqueue RENDER when user_jwt is missing');
     }
 
     clearAllStubs?.();
@@ -1922,7 +2003,7 @@ Deno.test('executeModelCallAndSave - RENDER job payload user_jwt matches parent 
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg: unknown = renderInserts[0];
     const insertedUnknown: unknown = Array.isArray(insertedArg) ? insertedArg[0] : insertedArg;
@@ -2118,7 +2199,7 @@ Deno.test('extracts documentIdentity from document_relationships[stageSlug] for 
         const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     // Assert: RENDER job payload contains documentIdentity extracted from document_relationships[stageSlug] after initialization
     const insertedArg: unknown = renderInserts[0];
@@ -2271,7 +2352,7 @@ Deno.test('extracts documentIdentity from document_relationships[stageSlug] for 
         const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     // Assert: RENDER job payload contains documentIdentity extracted from document_relationships[stageSlug] after persistence
     const insertedArg: unknown = renderInserts[0];
@@ -2433,7 +2514,7 @@ Deno.test('extracts documentIdentity using stageSlug key specifically, not first
         const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg: unknown = renderInserts[0];
     const insertedUnknown: unknown = Array.isArray(insertedArg) ? insertedArg[0] : insertedArg;
@@ -2586,7 +2667,7 @@ Deno.test('throws error when document_relationships is null after persistence', 
             const inserted = Array.isArray(callArg) ? callArg[0] : callArg;
             return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
         });
-        assertEquals(renderInserts.length, 0, 'Should not enqueue RENDER job when document_relationships is null after persistence');
+        assertEquals(renderInserts.length, 0, 'Target: must not enqueue RENDER when document_relationships is null after persistence');
     }
 
     clearAllStubs?.();
@@ -2810,7 +2891,7 @@ Deno.test('skips RENDER job when shouldEnqueueRenderJob returns { shouldRender: 
         assertEquals(
             renderInserts.length,
             0,
-            'Should not enqueue RENDER job when shouldEnqueueRenderJob returns { shouldRender: false, reason: \'is_json\' }'
+            'Target: must not enqueue RENDER when shouldEnqueueRenderJob returns { shouldRender: false, reason: \'is_json\' }'
         );
     }
 
@@ -2999,7 +3080,7 @@ Deno.test('should query recipe step and extract template_filename for RENDER job
         return inserted && typeof inserted === 'object' && 'job_type' in inserted && inserted.job_type === 'RENDER';
     });
 
-    assertEquals(renderInserts.length, 1, 'Should enqueue exactly one RENDER job for markdown document output type');
+    assertEquals(renderInserts.length, 1, 'Target: single complete chunk with markdown output must enqueue exactly one RENDER job');
 
     const insertedArg = renderInserts[0];
     const inserted = Array.isArray(insertedArg) ? (insertedArg[0]) : (insertedArg);

--- a/supabase/functions/dialectic-worker/executeModelCallAndSave.ts
+++ b/supabase/functions/dialectic-worker/executeModelCallAndSave.ts
@@ -1101,15 +1101,14 @@ export async function executeModelCallAndSave(
 
     let shouldContinue = isDialecticContinueReason(resolvedFinish);
 
-    // When finish_reason indicates truncation and the job opts into continuation,
-    // skip sanitization and JSON parsing — the content is intentionally incomplete.
-    // Only the final chunk (finish_reason indicating completion) gets validated.
-    const skipSanitizeForContinuation = shouldContinue && !!job.payload.continueUntilComplete;
+    // Decide intermediate vs not before sanitize/parse. Run sanitize/parse only when the chunk
+    // is not an intermediate continuation chunk (single-complete and final paths still get validated).
+    const isIntermediateChunk = shouldContinue && !!job.payload.continueUntilComplete;
 
     let contentForStorage: string;
-    if (skipSanitizeForContinuation) {
+    if (isIntermediateChunk) {
         contentForStorage = aiResponse.content;
-        deps.logger.info(`[executeModelCallAndSave] Skipping sanitize/parse for continuation chunk (finish_reason: ${resolvedFinish})`, { jobId });
+        deps.logger.info(`[executeModelCallAndSave] Skipping sanitize/parse for intermediate continuation chunk (finish_reason: ${resolvedFinish})`, { jobId });
     } else {
         const sanitizationResult: JsonSanitizationResult = sanitizeJsonContent(aiResponse.content);
         
@@ -1176,7 +1175,9 @@ export async function executeModelCallAndSave(
             }
         }
     }
-    
+
+    const needsContinuation = job.payload.continueUntilComplete && shouldContinue;
+
     // This is the correct implementation. The semantic relationships are inherited
     // directly from the job payload. The structural link for continuations is
     // handled by the `target_contribution_id` field on the contribution record,
@@ -1501,25 +1502,28 @@ export async function executeModelCallAndSave(
         );
     }
 
-    // Conditionally enqueue RENDER job for markdown document outputs on every chunk completion
-    const { shouldRender, reason, details } = await deps.shouldEnqueueRenderJob(
-        { dbClient, logger: deps.logger },
-        { outputType: output_type, stageSlug }
-    );
+    let shouldRender = false;
+    if (!needsContinuation) {
+        // Conditionally enqueue RENDER job for markdown document outputs on every chunk completion
+        const renderDecision = await deps.shouldEnqueueRenderJob(
+            { dbClient, logger: deps.logger },
+            { outputType: output_type, stageSlug }
+        );
+        shouldRender = renderDecision.shouldRender;
 
-    // Handle error reasons: fail the EXECUTE job for transient/config errors
-    if (!shouldRender && ['stage_not_found', 'instance_not_found', 'steps_not_found', 'parse_error', 'query_error', 'no_active_recipe'].includes(reason)) {
-        deps.logger.error('[executeModelCallAndSave] Failed to determine if RENDER job required due to query/config error', { reason, details, outputType: output_type, stageSlug });
-        throw new Error(`Cannot determine render requirement: ${reason}${details ? ` - ${details}` : ''}`);
-    }
+        // Handle error reasons: fail the EXECUTE job for transient/config errors
+        if (!renderDecision.shouldRender && ['stage_not_found', 'instance_not_found', 'steps_not_found', 'parse_error', 'query_error', 'no_active_recipe'].includes(renderDecision.reason)) {
+            deps.logger.error('[executeModelCallAndSave] Failed to determine if RENDER job required due to query/config error', { reason: renderDecision.reason, details: renderDecision.details, outputType: output_type, stageSlug });
+            throw new Error(`Cannot determine render requirement: ${renderDecision.reason}${renderDecision.details ? ` - ${renderDecision.details}` : ''}`);
+        }
 
-    // Log successful skip for JSON outputs (normal flow, not an error)
-    if (!shouldRender && reason === 'is_json') {
-        deps.logger.info('[executeModelCallAndSave] Skipping RENDER job for JSON output', { outputType: output_type });
-    }
+        // Log successful skip for JSON outputs (normal flow, not an error)
+        if (!renderDecision.shouldRender && renderDecision.reason === 'is_json') {
+            deps.logger.info('[executeModelCallAndSave] Skipping RENDER job for JSON output', { outputType: output_type });
+        }
 
-    // Proceed with RENDER job creation only for markdown documents
-    if (shouldRender && reason === 'is_markdown') {
+        // Proceed with RENDER job creation only for markdown documents
+        if (renderDecision.shouldRender && renderDecision.reason === 'is_markdown') {
         deps.logger.info('[executeModelCallAndSave] Preparing to enqueue RENDER job', {
             jobId,
             output_type,
@@ -1749,6 +1753,7 @@ export async function executeModelCallAndSave(
             deps.logger.info('[executeModelCallAndSave] Enqueued RENDER job', { parent_job_id: jobId, render_job_id: newId });
         }
     }
+    }
 
     if (typeof promptConstructionPayload.source_prompt_resource_id === 'string' && promptConstructionPayload.source_prompt_resource_id.trim().length > 0) {
         const { error: promptLinkUpdateError } = await dbClient
@@ -1785,8 +1790,6 @@ export async function executeModelCallAndSave(
             document_key: job.payload.document_key,
         }, projectOwnerUserId);
     }
-    
-    const needsContinuation = job.payload.continueUntilComplete && shouldContinue;
 
     const modelProcessingResult: ModelProcessingResult = { 
         modelId: model_id, 

--- a/supabase/functions/dialectic-worker/index.nsf-pause.integration.test.ts
+++ b/supabase/functions/dialectic-worker/index.nsf-pause.integration.test.ts
@@ -1,0 +1,175 @@
+// supabase/functions/dialectic-worker/index.nsf-pause.integration.test.ts
+// Node 4: end-to-end NSF pause flow — when first job hits NSF, siblings paused, parent stays waiting_for_children, one notification.
+
+import { assert, assertEquals, assertExists } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { spy } from 'jsr:@std/testing@0.225.1/mock';
+import { type SupabaseClient } from 'npm:@supabase/supabase-js@2';
+import { handleJob } from './index.ts';
+import { createMockSupabaseClient, type MockSupabaseClientSetup, type MockQueryBuilderState } from '../_shared/supabase.mock.ts';
+import type { Database } from '../types_db.ts';
+import { createJobContext } from './createJobContext.ts';
+import { createMockJobContextParams } from './JobContext.mock.ts';
+import { createMockJobProcessors } from '../_shared/dialectic.mock.ts';
+import { NotificationService } from '../_shared/utils/notification.service.ts';
+import { MockLogger } from '../_shared/logger.mock.ts';
+import { MockFileManagerService } from '../_shared/services/file_manager.mock.ts';
+import { isRecord } from '../_shared/utils/type_guards.ts';
+import type { ContributionGenerationPausedNsfPayload } from '../_shared/types/notification.service.types.ts';
+
+type JobRow = Database['public']['Tables']['dialectic_generation_jobs']['Row'];
+type UpdateJobRecord = Database['public']['Tables']['dialectic_generation_jobs']['Update'];
+
+function isUpdateJobRecord(record: unknown): record is UpdateJobRecord {
+	if (!isRecord(record)) return false;
+	if ('status' in record && typeof record.status !== 'string') return false;
+	if ('error_details' in record && record.error_details !== null && typeof record.error_details !== 'object') return false;
+	return true;
+}
+
+function hasOriginalStatus(ed: unknown): ed is { original_status: string } {
+	if (!isRecord(ed)) return false;
+	if (!('original_status' in ed)) return false;
+	const v = ed.original_status;
+	return typeof v === 'string';
+}
+
+function isContributionGenerationPausedNsfPayload(p: unknown): p is ContributionGenerationPausedNsfPayload {
+	if (!isRecord(p)) return false;
+	if (p.type !== 'contribution_generation_paused_nsf') return false;
+	const sessionId = p.sessionId;
+	const projectId = p.projectId;
+	const stageSlug = p.stageSlug;
+	const iterationNumber = p.iterationNumber;
+	return typeof sessionId === 'string' && typeof projectId === 'string' && typeof stageSlug === 'string' && typeof iterationNumber === 'number';
+}
+
+Deno.test('index NSF pause integration - end-to-end: NSF error pauses failing job and active siblings, parent untouched, exactly one notification', async (t) => {
+	const failingJobId = 'job-nsf-e2e';
+	const sessionId = 'session-nsf-e2e';
+	const stageSlug = 'thesis';
+	const iterationNumber = 1;
+	const projectId = 'project-nsf-e2e';
+	const projectOwnerUserId = 'user-nsf-e2e';
+
+	const jobRow: JobRow = {
+		id: failingJobId,
+		user_id: projectOwnerUserId,
+		session_id: sessionId,
+		stage_slug: stageSlug,
+		payload: {
+			job_type: 'PLAN',
+			sessionId,
+			projectId,
+			stageSlug,
+			model_id: 'model-id',
+			iterationNumber,
+		},
+		iteration_number: iterationNumber,
+		status: 'pending',
+		attempt_count: 0,
+		max_retries: 3,
+		created_at: new Date().toISOString(),
+		started_at: null,
+		completed_at: null,
+		results: null,
+		error_details: null,
+		parent_job_id: null,
+		target_contribution_id: null,
+		prerequisite_job_id: null,
+		is_test_job: false,
+		job_type: 'PLAN',
+	};
+
+	const siblingsFromDb: Pick<JobRow, 'id' | 'status'>[] = [
+		{ id: 'sib-p1', status: 'pending' },
+		{ id: 'sib-p2', status: 'pending' },
+		{ id: 'sib-done', status: 'completed' },
+		{ id: 'sib-wfp', status: 'waiting_for_prerequisite' },
+	];
+
+	// Use mock's function form so we return the right rows per query: claim select gets [jobRow], sibling select gets only siblings.
+	const dialecticJobsSelect = async (state: MockQueryBuilderState): Promise<{ data: object[] | null; error: null }> => {
+		const isSiblingQuery = state.filters.some((f) => f.column === 'session_id' && f.type === 'eq');
+		if (isSiblingQuery) {
+			return { data: siblingsFromDb, error: null };
+		}
+		return { data: [jobRow], error: null };
+	};
+
+	const mockSupabase: MockSupabaseClientSetup = createMockSupabaseClient(undefined, {
+		genericMockResults: {
+			'dialectic_generation_jobs': {
+				select: dialecticJobsSelect,
+				update: { data: [{}], error: null },
+			},
+			'dialectic_stages': {
+				select: {
+					data: [{ id: 1, slug: stageSlug, name: 'Thesis', display_name: 'Thesis' }],
+					error: null,
+				},
+			},
+		},
+		rpcResults: {
+			'create_notification_for_user': { data: null, error: null },
+		},
+	});
+
+	const mockLogger = new MockLogger();
+	const adminClient: SupabaseClient<Database> = mockSupabase.client as unknown as SupabaseClient<Database>;
+	const notificationService = new NotificationService(adminClient);
+	const testDeps = createJobContext(createMockJobContextParams({
+		...createMockJobContextParams(),
+		logger: mockLogger,
+		fileManager: new MockFileManagerService(),
+		notificationService,
+	}));
+
+	const pausedNsfSpy = spy(notificationService, 'sendContributionGenerationPausedNsfEvent');
+	const { processors } = createMockJobProcessors();
+	processors.processComplexJob = async () => {
+		throw new Error('Insufficient funds to cover the input prompt cost.');
+	};
+
+	await t.step('handleJob with NSF error: failing job and active siblings paused, parent remains waiting_for_children, no failure path', async () => {
+		mockSupabase.client.clearAllTrackedBuilders();
+
+		await handleJob(
+			adminClient,
+			jobRow,
+			testDeps,
+			'mock-token',
+			processors,
+		);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy, 'Update spy should exist');
+		assert(updateSpy.callCount >= 2, 'At least claim update + failing job paused_nsf; siblings may add more');
+		const updateCalls = updateSpy.callsArgs;
+		let seenPausedNsf = 0;
+		const originalStatuses: string[] = [];
+		for (let i = 0; i < updateCalls.length; i++) {
+			const payload = updateCalls[i][0];
+			assert(isUpdateJobRecord(payload));
+			if (payload.status === 'paused_nsf') {
+				seenPausedNsf += 1;
+				if (hasOriginalStatus(payload.error_details)) {
+					originalStatuses.push(payload.error_details.original_status);
+				}
+			}
+		}
+		assert(seenPausedNsf >= 3, 'Expect at least 3 paused_nsf updates: failing job + 2 pending siblings');
+		assert(originalStatuses.includes('processing'), 'Failing job must have original_status processing');
+		assertEquals(originalStatuses.filter((s) => s === 'pending').length, 2, 'Two siblings must have original_status pending');
+
+		assertEquals(pausedNsfSpy.calls.length, 1, 'Exactly one contribution_generation_paused_nsf notification must be sent');
+		const [payload, targetUserId] = pausedNsfSpy.calls[0].args;
+		assertEquals(targetUserId, projectOwnerUserId);
+		assert(isContributionGenerationPausedNsfPayload(payload));
+		assertEquals(payload.sessionId, sessionId);
+		assertEquals(payload.projectId, projectId);
+		assertEquals(payload.stageSlug, stageSlug);
+		assertEquals(payload.iterationNumber, iterationNumber);
+	});
+
+	pausedNsfSpy.restore();
+});

--- a/supabase/functions/dialectic-worker/index.test.ts
+++ b/supabase/functions/dialectic-worker/index.test.ts
@@ -34,7 +34,6 @@ import { OpenAiAdapter } from '../_shared/ai_service/openai_adapter.ts';
 import { renderDocument } from '../_shared/services/document_renderer.ts';
 import { createMockJobContextParams } from './JobContext.mock.ts';
 import { createJobContext } from './createJobContext.ts';
-
 type MockJob = Database['public']['Tables']['dialectic_generation_jobs']['Row'];
 
 // Global mock objects
@@ -1144,4 +1143,184 @@ Deno.test('handleJob - prevents concurrent processing of the same job atomically
         1,
         'Only one update attempt should succeed. The atomic update pattern ensures the second call fails when status is already "processing".'
     );
+});
+
+// --- NSF detection: Insufficient funds routes to pauseJobsForNsf; other errors use failure path ---
+const mockJobNsf: MockJob = {
+    id: 'job-nsf-test',
+    user_id: 'user-nsf',
+    session_id: 'session-nsf',
+    stage_slug: 'thesis',
+    payload: {
+        job_type: 'PLAN',
+        sessionId: 'session-nsf',
+        projectId: 'project-nsf',
+        stageSlug: 'thesis',
+        model_id: 'model-id',
+        iterationNumber: 1,
+    },
+    iteration_number: 1,
+    status: 'pending',
+    attempt_count: 0,
+    max_retries: 3,
+    created_at: new Date().toISOString(),
+    started_at: null,
+    completed_at: null,
+    results: null,
+    error_details: null,
+    parent_job_id: null,
+    target_contribution_id: null,
+    prerequisite_job_id: null,
+    is_test_job: false,
+    job_type: 'PLAN',
+};
+
+const mockSupabaseClientNsf = createMockSupabaseClient(undefined, {
+    genericMockResults: {
+        'dialectic_generation_jobs': {
+            select: { data: [mockJobNsf], error: null },
+            update: { data: [{ id: mockJobNsf.id }], error: null },
+        },
+        'dialectic_stages': {
+            select: {
+                data: [{ id: 1, slug: 'thesis', name: 'Thesis', display_name: 'Thesis' }],
+                error: null,
+            },
+        },
+    },
+    rpcResults: {
+        'create_notification_for_user': { data: null, error: null },
+    },
+});
+
+Deno.test('handleJob - when processJob throws Insufficient funds, routes to pause path and does not run failure path', async () => {
+    mockSupabaseClientNsf.client.clearAllTrackedBuilders();
+    const testDepsNsf = createJobContext(createMockJobContextParams({
+        ...createMockJobContextParams(),
+        logger: mockLogger,
+        fileManager: new MockFileManagerService(),
+        notificationService: new NotificationService(mockSupabaseClientNsf.client as unknown as SupabaseClient<Database>),
+    }));
+    const { processors } = createMockJobProcessors();
+    processors.processComplexJob = async () => {
+        throw new Error('Insufficient funds to cover the input prompt cost.');
+    };
+
+    const pausedNsfSpy = spy(testDepsNsf.notificationService, 'sendContributionGenerationPausedNsfEvent');
+    const failedNotificationSpy = spy(testDepsNsf.notificationService, 'sendContributionFailedNotification');
+    const failedEventSpy = spy(testDepsNsf.notificationService, 'sendContributionGenerationFailedEvent');
+
+    await handleJob(
+        mockSupabaseClientNsf.client as unknown as SupabaseClient<Database>,
+        mockJobNsf,
+        testDepsNsf,
+        'mock-token',
+        processors,
+    );
+
+    const updateSpies = mockSupabaseClientNsf.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+    assertExists(updateSpies, 'Update spy should exist');
+    assert(updateSpies.callCount >= 2, 'Should update to processing, then at least the failing job to paused_nsf (siblings may add more)');
+    const secondUpdatePayload = updateSpies.callsArgs[1][0];
+    assert(secondUpdatePayload && typeof secondUpdatePayload === 'object' && 'status' in secondUpdatePayload);
+    assertEquals(secondUpdatePayload.status, 'paused_nsf', 'Job status should be paused_nsf');
+
+    assertEquals(pausedNsfSpy.calls.length, 1, 'sendContributionGenerationPausedNsfEvent should be called once');
+    assertEquals(failedNotificationSpy.calls.length, 0, 'sendContributionFailedNotification should not be called');
+    assertEquals(failedEventSpy.calls.length, 0, 'sendContributionGenerationFailedEvent should not be called');
+
+    const pausedPayload = pausedNsfSpy.calls[0].args[0];
+    assert(pausedPayload && typeof pausedPayload === 'object');
+    assertEquals(pausedPayload.sessionId, mockJobNsf.session_id);
+    assertEquals(pausedPayload.projectId, 'project-nsf');
+    assertEquals(pausedPayload.stageSlug, mockJobNsf.stage_slug);
+    assertEquals(pausedPayload.iterationNumber, 1);
+    assertEquals(pausedNsfSpy.calls[0].args[1], mockJobNsf.user_id);
+
+    pausedNsfSpy.restore();
+    failedNotificationSpy.restore();
+    failedEventSpy.restore();
+});
+
+Deno.test('handleJob - when processJob throws non-NSF error, runs existing failure path unchanged', async () => {
+    mockSupabaseClientNsf.client.clearAllTrackedBuilders();
+    const testDepsNsf = createJobContext(createMockJobContextParams({
+        ...createMockJobContextParams(),
+        logger: mockLogger,
+        fileManager: new MockFileManagerService(),
+        notificationService: new NotificationService(mockSupabaseClientNsf.client as unknown as SupabaseClient<Database>),
+    }));
+    const { processors } = createMockJobProcessors();
+    processors.processComplexJob = async () => {
+        throw new Error('Simulated processJob error');
+    };
+
+    const pausedNsfSpy = spy(testDepsNsf.notificationService, 'sendContributionGenerationPausedNsfEvent');
+    const failedEventSpy = spy(testDepsNsf.notificationService, 'sendContributionGenerationFailedEvent');
+
+    await handleJob(
+        mockSupabaseClientNsf.client as unknown as SupabaseClient<Database>,
+        mockJobNsf,
+        testDepsNsf,
+        'mock-token',
+        processors,
+    );
+
+    const updateSpies = mockSupabaseClientNsf.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+    assertExists(updateSpies, 'Update spy should exist');
+    assertEquals(updateSpies.callCount, 2, 'Should update to processing, then to failed');
+    const secondUpdatePayload = updateSpies.callsArgs[1][0];
+    assert(secondUpdatePayload && typeof secondUpdatePayload === 'object' && 'status' in secondUpdatePayload);
+    assertEquals(secondUpdatePayload.status, 'failed', 'Job status should be failed');
+
+    assertEquals(pausedNsfSpy.calls.length, 0, 'sendContributionGenerationPausedNsfEvent should not be called');
+    assertEquals(failedEventSpy.calls.length, 1, 'sendContributionGenerationFailedEvent should be called once');
+
+    pausedNsfSpy.restore();
+    failedEventSpy.restore();
+});
+
+Deno.test('handleJob - when processJob throws Insufficient funds but pauseJobsForNsf throws, logs error and runs failure path', async () => {
+    mockSupabaseClientNsf.client.clearAllTrackedBuilders();
+    const testDepsNsf = createJobContext(createMockJobContextParams({
+        ...createMockJobContextParams(),
+        logger: mockLogger,
+        fileManager: new MockFileManagerService(),
+        notificationService: new NotificationService(mockSupabaseClientNsf.client as unknown as SupabaseClient<Database>),
+    }));
+    const pauseThrowsStub = stub(
+        testDepsNsf.notificationService,
+        'sendContributionGenerationPausedNsfEvent',
+        () => Promise.reject(new Error('pause notification failed')),
+    );
+    const { processors } = createMockJobProcessors();
+    processors.processComplexJob = async () => {
+        throw new Error('Insufficient funds: estimated total cost exceeds wallet balance.');
+    };
+
+    const loggerErrorSpy = spy(mockLogger, 'error');
+    const failedEventSpy = spy(testDepsNsf.notificationService, 'sendContributionGenerationFailedEvent');
+
+    await handleJob(
+        mockSupabaseClientNsf.client as unknown as SupabaseClient<Database>,
+        mockJobNsf,
+        testDepsNsf,
+        'mock-token',
+        processors,
+    );
+
+    assert(loggerErrorSpy.calls.length >= 1, 'Logger error should be called at least once for pauseJobsForNsf failure');
+
+    const updateSpies = mockSupabaseClientNsf.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+    assertExists(updateSpies, 'Update spy should exist');
+    const lastIdx = updateSpies.callsArgs.length - 1;
+    const lastUpdatePayload = updateSpies.callsArgs[lastIdx][0];
+    assert(lastUpdatePayload && typeof lastUpdatePayload === 'object' && 'status' in lastUpdatePayload);
+    assertEquals(lastUpdatePayload.status, 'failed', 'Job should fall back to failed status');
+
+    assertEquals(failedEventSpy.calls.length, 1, 'Failure path should send sendContributionGenerationFailedEvent');
+
+    pauseThrowsStub.restore();
+    loggerErrorSpy.restore();
+    failedEventSpy.restore();
 });

--- a/supabase/functions/dialectic-worker/index.ts
+++ b/supabase/functions/dialectic-worker/index.ts
@@ -43,6 +43,7 @@ import { shouldEnqueueRenderJob } from '../_shared/utils/shouldEnqueueRenderJob.
 import { IJobContext } from './JobContext.interface.ts';
 import { createJobContext } from './createJobContext.ts';
 import { findSourceDocuments } from './findSourceDocuments.ts';
+import { pauseJobsForNsf } from './pauseJobsForNsf.ts';
 
 type Job = Database['public']['Tables']['dialectic_generation_jobs']['Row'];
 
@@ -340,6 +341,25 @@ export async function handleJob(
       let projectId = '';
       if (job.payload && typeof job.payload === 'object' && !Array.isArray(job.payload) && 'projectId' in job.payload && typeof job.payload.projectId === 'string') {
           projectId = job.payload.projectId;
+      }
+
+      if (error.message.includes('Insufficient funds')) {
+        try {
+          await pauseJobsForNsf(
+            { adminClient, notificationService: deps.notificationService, logger: deps.logger },
+            {
+              failingJobId: jobId,
+              sessionId: job.session_id,
+              stageSlug: job.stage_slug,
+              iterationNumber: job.payload.iterationNumber ?? 0,
+              projectId,
+              projectOwnerUserId,
+            },
+          );
+          return;
+        } catch (pauseErr) {
+          deps.logger.error(`[dialectic-worker] [handleJob] pauseJobsForNsf failed for job ${jobId}, falling back to failure path`, { error: pauseErr });
+        }
       }
 
       await deps.notificationService.sendContributionFailedNotification({

--- a/supabase/functions/dialectic-worker/pauseJobsForNsf.integration.test.ts
+++ b/supabase/functions/dialectic-worker/pauseJobsForNsf.integration.test.ts
@@ -1,0 +1,115 @@
+// supabase/functions/dialectic-worker/pauseJobsForNsf.integration.test.ts
+
+import { pauseJobsForNsf } from './pauseJobsForNsf.ts';
+import type { PauseJobsForNsfDeps, PauseJobsForNsfParams } from '../dialectic-service/dialectic.interface.ts';
+import type { ContributionGenerationPausedNsfPayload } from '../_shared/types/notification.service.types.ts';
+import { assert, assertEquals, assertExists, assertObjectMatch } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { type SupabaseClient } from 'npm:@supabase/supabase-js@2';
+import { MockLogger } from '../_shared/logger.mock.ts';
+import { createMockSupabaseClient, type MockSupabaseClientSetup } from '../_shared/supabase.mock.ts';
+import type { Database } from '../types_db.ts';
+import { mockNotificationService, resetMockNotificationService } from '../_shared/utils/notification.service.mock.ts';
+import { isRecord } from '../_shared/utils/type_guards.ts';
+
+type UpdateJobRecord = Database['public']['Tables']['dialectic_generation_jobs']['Update'];
+
+function isUpdateJobRecord(record: unknown): record is UpdateJobRecord {
+	if (!isRecord(record)) return false;
+	if ('status' in record && typeof record.status !== 'string') return false;
+	if ('error_details' in record && record.error_details !== null && typeof record.error_details !== 'object') return false;
+	return true;
+}
+
+function hasOriginalStatus(ed: unknown): ed is { original_status: string } {
+	if (!isRecord(ed)) return false;
+	if (!('original_status' in ed)) return false;
+	const v = ed.original_status;
+	return typeof v === 'string';
+}
+
+function isContributionGenerationPausedNsfPayload(p: unknown): p is ContributionGenerationPausedNsfPayload {
+	if (!isRecord(p)) return false;
+	if (p.type !== 'contribution_generation_paused_nsf') return false;
+	const sessionId = p.sessionId;
+	const projectId = p.projectId;
+	const stageSlug = p.stageSlug;
+	const iterationNumber = p.iterationNumber;
+	return typeof sessionId === 'string' && typeof projectId === 'string' && typeof stageSlug === 'string' && typeof iterationNumber === 'number';
+}
+
+Deno.test('pauseJobsForNsf integration', async (t) => {
+	const failingJobId = 'job-processing';
+	const sessionId = 'session-int-1';
+	const stageSlug = 'thesis';
+	const iterationNumber = 1;
+	const projectId = 'project-int-1';
+	const projectOwnerUserId = 'user-int-1';
+
+	const params: PauseJobsForNsfParams = {
+		failingJobId,
+		sessionId,
+		stageSlug,
+		iterationNumber,
+		projectId,
+		projectOwnerUserId,
+	};
+
+	const siblingsFromDb = [
+		{ id: 'sib-p1', status: 'pending' },
+		{ id: 'sib-p2', status: 'pending' },
+		{ id: 'sib-done', status: 'completed' },
+		{ id: 'sib-wfp', status: 'waiting_for_prerequisite' },
+	];
+
+	let mockSupabase: MockSupabaseClientSetup;
+	let deps: PauseJobsForNsfDeps;
+
+	await t.step('parent PLAN (waiting_for_children) with 5 EXECUTE children: 1 processing (failing), 2 pending, 1 completed, 1 waiting_for_prerequisite — only failing + 2 pending paused; completed and waiting_for_prerequisite untouched; parent untouched', async () => {
+		resetMockNotificationService();
+		mockSupabase = createMockSupabaseClient(undefined, {
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: siblingsFromDb, error: null },
+				},
+			},
+		});
+		const mockLogger = new MockLogger();
+		deps = {
+			adminClient: mockSupabase.client as unknown as SupabaseClient<Database>,
+			notificationService: mockNotificationService,
+			logger: mockLogger,
+		};
+
+		await pauseJobsForNsf(deps, params);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assertEquals(updateSpy.callCount, 3, 'expect 3 updates: failing job + 2 active siblings (pending); completed and waiting_for_prerequisite must not be paused');
+
+		const originalStatuses: string[] = [];
+		for (const call of updateSpy.callsArgs) {
+			const payload = call[0];
+			assert(isUpdateJobRecord(payload));
+			assertObjectMatch(payload, { status: 'paused_nsf' });
+			if (hasOriginalStatus(payload.error_details)) {
+				originalStatuses.push(payload.error_details.original_status);
+			}
+		}
+		assert(originalStatuses.includes('processing'), 'failing job must have original_status processing');
+		assertEquals(originalStatuses.filter((s) => s === 'pending').length, 2, 'two siblings must have original_status pending');
+		assertEquals(originalStatuses.length, 3);
+	});
+
+	await t.step('exactly one notification is sent', async () => {
+		const notifySpy = mockNotificationService.sendContributionGenerationPausedNsfEvent;
+		assertEquals(notifySpy.calls.length, 1);
+		const [payload, targetUserId] = notifySpy.calls[0].args;
+		assertEquals(targetUserId, projectOwnerUserId);
+		assert(isContributionGenerationPausedNsfPayload(payload));
+		assertEquals(payload.sessionId, sessionId);
+		assertEquals(payload.projectId, projectId);
+		assertEquals(payload.stageSlug, stageSlug);
+		assertEquals(payload.iterationNumber, iterationNumber);
+	});
+});

--- a/supabase/functions/dialectic-worker/pauseJobsForNsf.test.ts
+++ b/supabase/functions/dialectic-worker/pauseJobsForNsf.test.ts
@@ -1,0 +1,238 @@
+// supabase/functions/dialectic-worker/pauseJobsForNsf.test.ts
+
+import { pauseJobsForNsf } from './pauseJobsForNsf.ts';
+import type { PauseJobsForNsfDeps, PauseJobsForNsfParams } from '../dialectic-service/dialectic.interface.ts';
+import { assert, assertEquals, assertExists, assertObjectMatch } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { type SupabaseClient } from 'npm:@supabase/supabase-js@2';
+import { MockLogger } from '../_shared/logger.mock.ts';
+import { createMockSupabaseClient, type MockSupabaseClientSetup } from '../_shared/supabase.mock.ts';
+import type { Database } from '../types_db.ts';
+import { mockNotificationService, resetMockNotificationService } from '../_shared/utils/notification.service.mock.ts';
+import { isRecord } from '../_shared/utils/type_guards.ts';
+
+type UpdateJobRecord = Database['public']['Tables']['dialectic_generation_jobs']['Update'];
+
+function isUpdateJobRecord(record: unknown): record is UpdateJobRecord {
+	if (!isRecord(record)) return false;
+	if ('status' in record && typeof record.status !== 'string') return false;
+	if ('error_details' in record && record.error_details !== null && typeof record.error_details !== 'object') return false;
+	return true;
+}
+
+const baseParams: PauseJobsForNsfParams = {
+	failingJobId: 'failing-job-id',
+	sessionId: 'session-1',
+	stageSlug: 'thesis',
+	iterationNumber: 1,
+	projectId: 'project-1',
+	projectOwnerUserId: 'user-1',
+};
+
+Deno.test('pauseJobsForNsf', async (t) => {
+	let mockSupabase: MockSupabaseClientSetup;
+	let mockLogger: MockLogger;
+	let deps: PauseJobsForNsfDeps;
+
+	const setup = (mockOverrides?: Parameters<typeof createMockSupabaseClient>[1]) => {
+		resetMockNotificationService();
+		mockSupabase = createMockSupabaseClient(undefined, mockOverrides);
+		mockLogger = new MockLogger();
+		deps = {
+			adminClient: mockSupabase.client as unknown as SupabaseClient<Database>,
+			notificationService: mockNotificationService,
+			logger: mockLogger,
+		};
+	};
+
+	await t.step('sets failing job to paused_nsf with original_status processing and nsf_paused true', async () => {
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: [], error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assert(updateSpy.callCount >= 1);
+		const firstUpdateArgs = updateSpy.callsArgs[0][0];
+		assert(isUpdateJobRecord(firstUpdateArgs));
+		assertObjectMatch(firstUpdateArgs, {
+			status: 'paused_nsf',
+		});
+		if (firstUpdateArgs.error_details && typeof firstUpdateArgs.error_details === 'object') {
+			assertObjectMatch(firstUpdateArgs.error_details as Record<string, unknown>, {
+				original_status: 'processing',
+				nsf_paused: true,
+			});
+		} else {
+			throw new Error('error_details missing or not object');
+		}
+	});
+
+	await t.step('given active sibling jobs (pending, pending_continuation, retrying), all set to paused_nsf with respective original_status', async () => {
+		const siblings = [
+			{ id: 'sib-1', status: 'pending' },
+			{ id: 'sib-2', status: 'pending_continuation' },
+			{ id: 'sib-3', status: 'retrying' },
+		];
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: siblings, error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assertEquals(updateSpy.callCount, 1 + siblings.length);
+		const updateCalls = updateSpy.callsArgs;
+		const originalStatuses: string[] = [];
+		for (const call of updateCalls) {
+			const payload = call[0] as UpdateJobRecord;
+			const ed = payload.error_details;
+			if (ed !== null && ed !== undefined && typeof ed === 'object' && !Array.isArray(ed) && 'original_status' in ed) {
+				originalStatuses.push(String((ed as Record<string, unknown>).original_status));
+			}
+		}
+		assert(originalStatuses.includes('processing'));
+		assert(originalStatuses.includes('pending'));
+		assert(originalStatuses.includes('pending_continuation'));
+		assert(originalStatuses.includes('retrying'));
+	});
+
+	await t.step('jobs in passive wait states (waiting_for_children, waiting_for_prerequisite) are NOT paused', async () => {
+		const siblings = [
+			{ id: 'sib-wfc', status: 'waiting_for_children' },
+			{ id: 'sib-wfp', status: 'waiting_for_prerequisite' },
+		];
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: siblings, error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assertEquals(updateSpy.callCount, 1);
+	});
+
+	await t.step('jobs already in terminal states (completed, failed, retry_loop_failed) are NOT paused', async () => {
+		const siblings = [
+			{ id: 'sib-done', status: 'completed' },
+			{ id: 'sib-fail', status: 'failed' },
+			{ id: 'sib-rlf', status: 'retry_loop_failed' },
+		];
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: siblings, error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assertEquals(updateSpy.callCount, 1);
+	});
+
+	await t.step('jobs already in paused_nsf are NOT re-paused (idempotency)', async () => {
+		const siblings = [
+			{ id: 'sib-paused', status: 'paused_nsf' },
+		];
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: siblings, error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assertEquals(updateSpy.callCount, 1);
+	});
+
+	await t.step('exactly ONE notification is sent regardless of how many jobs are paused', async () => {
+		const siblings = [
+			{ id: 'sib-1', status: 'pending' },
+			{ id: 'sib-2', status: 'pending_continuation' },
+		];
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: siblings, error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const notifySpy = mockNotificationService.sendContributionGenerationPausedNsfEvent;
+		assertEquals(notifySpy.calls.length, 1);
+	});
+
+	await t.step('notification is called with ContributionGenerationPausedNsfPayload and targetUserId matching projectOwnerUserId', async () => {
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: [], error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const notifySpy = mockNotificationService.sendContributionGenerationPausedNsfEvent;
+		assertEquals(notifySpy.calls.length, 1);
+		const [payload, targetUserId] = notifySpy.calls[0].args;
+		assertEquals(targetUserId, baseParams.projectOwnerUserId);
+		assertObjectMatch(payload as Record<string, unknown>, {
+			type: 'contribution_generation_paused_nsf',
+			sessionId: baseParams.sessionId,
+			projectId: baseParams.projectId,
+			stageSlug: baseParams.stageSlug,
+			iterationNumber: baseParams.iterationNumber,
+		});
+	});
+
+	await t.step('if no siblings exist (solo EXECUTE job), still pauses failing job and sends one notification', async () => {
+		setup({
+			genericMockResults: {
+				'dialectic_generation_jobs': {
+					update: { data: [{}], error: null },
+					select: { data: [], error: null },
+				},
+			},
+		});
+
+		await pauseJobsForNsf(deps, baseParams);
+
+		const updateSpy = mockSupabase.spies.getHistoricQueryBuilderSpies('dialectic_generation_jobs', 'update');
+		assertExists(updateSpy);
+		assertEquals(updateSpy.callCount, 1);
+		const notifySpy = mockNotificationService.sendContributionGenerationPausedNsfEvent;
+		assertEquals(notifySpy.calls.length, 1);
+	});
+});

--- a/supabase/functions/dialectic-worker/pauseJobsForNsf.ts
+++ b/supabase/functions/dialectic-worker/pauseJobsForNsf.ts
@@ -1,0 +1,121 @@
+// supabase/functions/dialectic-worker/pauseJobsForNsf.ts
+
+import type {
+	ContributionGenerationPausedNsfPayload,
+	DialecticJobRow,
+} from '../_shared/types/notification.service.types.ts';
+import type { PauseJobsForNsfDeps, PauseJobsForNsfParams } from '../dialectic-service/dialectic.interface.ts';
+import { isRecord } from '../_shared/utils/type-guards/type_guards.common.ts';
+
+const ACTIVE_SIBLING_EXCLUDED_STATUSES: readonly string[] = [
+	'completed',
+	'failed',
+	'retry_loop_failed',
+	'paused_nsf',
+	'waiting_for_children',
+	'waiting_for_prerequisite',
+];
+
+function validateSiblingRow(row: unknown): row is Pick<DialecticJobRow, 'id' | 'status'> {
+	if (!isRecord(row)) {
+		return false;
+	}
+	if (!('id' in row) || !('status' in row)) {
+		return false;
+	}
+	const id = row.id;
+	const status = row.status;
+	if (typeof id !== 'string' || typeof status !== 'string') {
+		return false;
+	}
+	return true;
+}
+
+export async function pauseJobsForNsf(
+	deps: PauseJobsForNsfDeps,
+	params: PauseJobsForNsfParams,
+): Promise<void> {
+	const { adminClient, notificationService, logger } = deps;
+
+	const { error: updateFailingError } = await adminClient
+		.from('dialectic_generation_jobs')
+		.update({
+			status: 'paused_nsf',
+			error_details: { original_status: 'processing', nsf_paused: true },
+		})
+		.eq('id', params.failingJobId);
+
+	if (updateFailingError) {
+		throw new Error(
+			`pauseJobsForNsf: failed to pause failing job ${params.failingJobId}: ${updateFailingError.message}`,
+		);
+	}
+
+	const { data: siblingRows, error: selectError } = await adminClient
+		.from('dialectic_generation_jobs')
+		.select('id, status')
+		.eq('session_id', params.sessionId)
+		.eq('stage_slug', params.stageSlug)
+		.eq('iteration_number', params.iterationNumber)
+		.neq('id', params.failingJobId);
+
+	if (selectError) {
+		throw new Error(
+			`pauseJobsForNsf: failed to query siblings for job ${params.failingJobId}: ${selectError.message}`,
+		);
+	}
+
+	if (siblingRows === null || siblingRows === undefined) {
+		throw new Error(
+			`pauseJobsForNsf: sibling query returned null/undefined for job ${params.failingJobId}`,
+		);
+	}
+
+	const typedSiblings: Pick<DialecticJobRow, 'id' | 'status'>[] = [];
+	for (const row of siblingRows) {
+		if (!validateSiblingRow(row)) {
+			throw new Error(
+				`pauseJobsForNsf: invalid sibling row shape from DB for job ${params.failingJobId}: expected { id: string, status: string }, got ${JSON.stringify(row)}`,
+			);
+		}
+		typedSiblings.push(row);
+	}
+
+	const activeSiblings = typedSiblings.filter(
+		(s) => !ACTIVE_SIBLING_EXCLUDED_STATUSES.includes(s.status),
+	);
+
+	for (const sibling of activeSiblings) {
+		const { error: siblingUpdateError } = await adminClient
+			.from('dialectic_generation_jobs')
+			.update({
+				status: 'paused_nsf',
+				error_details: { original_status: sibling.status, nsf_paused: true },
+			})
+			.eq('id', sibling.id);
+
+		if (siblingUpdateError) {
+			throw new Error(
+				`pauseJobsForNsf: failed to pause sibling job ${sibling.id}: ${siblingUpdateError.message}`,
+			);
+		}
+	}
+
+	const pausedCount = 1 + activeSiblings.length;
+	logger.info('[pauseJobsForNsf] paused jobs for NSF', {
+		failingJobId: params.failingJobId,
+		sessionId: params.sessionId,
+		stageSlug: params.stageSlug,
+		iterationNumber: params.iterationNumber,
+		pausedCount,
+	});
+
+	const payload: ContributionGenerationPausedNsfPayload = {
+		type: 'contribution_generation_paused_nsf',
+		sessionId: params.sessionId,
+		projectId: params.projectId,
+		stageSlug: params.stageSlug,
+		iterationNumber: params.iterationNumber,
+	};
+	await notificationService.sendContributionGenerationPausedNsfEvent(payload, params.projectOwnerUserId);
+}

--- a/supabase/functions/dialectic-worker/type-guards/pauseJobsForNsf.type_guards.test.ts
+++ b/supabase/functions/dialectic-worker/type-guards/pauseJobsForNsf.type_guards.test.ts
@@ -1,0 +1,119 @@
+// supabase/functions/dialectic-worker/type-guards/pauseJobsForNsf.type_guards.test.ts
+
+import { describe, it } from 'https://deno.land/std@0.170.0/testing/bdd.ts';
+import { assertEquals } from 'https://deno.land/std@0.170.0/testing/asserts.ts';
+import type { PauseJobsForNsfParams } from '../../dialectic-service/dialectic.interface.ts';
+import { isPauseJobsForNsfParams } from './pauseJobsForNsf.type_guards.ts';
+
+const validParams: PauseJobsForNsfParams = {
+	failingJobId: 'job-uuid-1',
+	sessionId: 'session-uuid-2',
+	stageSlug: 'thesis',
+	iterationNumber: 0,
+	projectId: 'project-uuid-3',
+	projectOwnerUserId: 'user-uuid-4',
+};
+
+describe('pauseJobsForNsf type guards', () => {
+	describe('isPauseJobsForNsfParams', () => {
+		it('returns true for valid params with all six fields', () => {
+			assertEquals(isPauseJobsForNsfParams(validParams), true);
+		});
+
+		it('returns true for valid params with positive iterationNumber', () => {
+			const params: PauseJobsForNsfParams = { ...validParams, iterationNumber: 2 };
+			assertEquals(isPauseJobsForNsfParams(params), true);
+		});
+
+		it('returns false for null', () => {
+			assertEquals(isPauseJobsForNsfParams(null), false);
+		});
+
+		it('returns false for undefined', () => {
+			assertEquals(isPauseJobsForNsfParams(undefined), false);
+		});
+
+		it('returns false for non-object (string)', () => {
+			assertEquals(isPauseJobsForNsfParams('not an object'), false);
+		});
+
+		it('returns false for non-object (number)', () => {
+			assertEquals(isPauseJobsForNsfParams(42), false);
+		});
+
+		it('returns false when failingJobId is missing', () => {
+			const { failingJobId, ...rest } = validParams;
+			assertEquals(isPauseJobsForNsfParams(rest), false);
+		});
+
+		it('returns false when sessionId is missing', () => {
+			const { sessionId, ...rest } = validParams;
+			assertEquals(isPauseJobsForNsfParams(rest), false);
+		});
+
+		it('returns false when stageSlug is missing', () => {
+			const { stageSlug, ...rest } = validParams;
+			assertEquals(isPauseJobsForNsfParams(rest), false);
+		});
+
+		it('returns false when iterationNumber is missing', () => {
+			const { iterationNumber, ...rest } = validParams;
+			assertEquals(isPauseJobsForNsfParams(rest), false);
+		});
+
+		it('returns false when projectId is missing', () => {
+			const { projectId, ...rest } = validParams;
+			assertEquals(isPauseJobsForNsfParams(rest), false);
+		});
+
+		it('returns false when projectOwnerUserId is missing', () => {
+			const { projectOwnerUserId, ...rest } = validParams;
+			assertEquals(isPauseJobsForNsfParams(rest), false);
+		});
+
+		it('returns false when failingJobId is empty string', () => {
+			const params = { ...validParams, failingJobId: '' };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when sessionId is empty string', () => {
+			const params = { ...validParams, sessionId: '' };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when iterationNumber is negative', () => {
+			const params = { ...validParams, iterationNumber: -1 };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when iterationNumber is not an integer', () => {
+			const params = { ...validParams, iterationNumber: 1.5 };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when iterationNumber is not a number', () => {
+			const params = { ...validParams, iterationNumber: '0' as unknown as number };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when a string field is a number', () => {
+			const params = { ...validParams, failingJobId: 123 as unknown as string };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when stageSlug is empty string', () => {
+			const params = { ...validParams, stageSlug: '' };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when projectId is empty string', () => {
+			const params = { ...validParams, projectId: '' };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+
+		it('returns false when projectOwnerUserId is empty string', () => {
+			const params = { ...validParams, projectOwnerUserId: '' };
+			assertEquals(isPauseJobsForNsfParams(params), false);
+		});
+	});
+});

--- a/supabase/functions/dialectic-worker/type-guards/pauseJobsForNsf.type_guards.ts
+++ b/supabase/functions/dialectic-worker/type-guards/pauseJobsForNsf.type_guards.ts
@@ -1,0 +1,45 @@
+// supabase/functions/dialectic-worker/type-guards/pauseJobsForNsf.type_guards.ts
+
+import type { PauseJobsForNsfParams } from '../../dialectic-service/dialectic.interface.ts';
+import { isRecord } from '../../_shared/utils/type-guards/type_guards.common.ts';
+
+export function isPauseJobsForNsfParams(value: unknown): value is PauseJobsForNsfParams {
+	if (!isRecord(value)) {
+		return false;
+	}
+	if (
+		!('failingJobId' in value) ||
+		!('sessionId' in value) ||
+		!('stageSlug' in value) ||
+		!('iterationNumber' in value) ||
+		!('projectId' in value) ||
+		!('projectOwnerUserId' in value)
+	) {
+		return false;
+	}
+	const failingJobId = value.failingJobId;
+	const sessionId = value.sessionId;
+	const stageSlug = value.stageSlug;
+	const iterationNumber = value.iterationNumber;
+	const projectId = value.projectId;
+	const projectOwnerUserId = value.projectOwnerUserId;
+	if (typeof failingJobId !== 'string' || failingJobId === '') {
+		return false;
+	}
+	if (typeof sessionId !== 'string' || sessionId === '') {
+		return false;
+	}
+	if (typeof stageSlug !== 'string' || stageSlug === '') {
+		return false;
+	}
+	if (typeof iterationNumber !== 'number' || !Number.isInteger(iterationNumber) || iterationNumber < 0) {
+		return false;
+	}
+	if (typeof projectId !== 'string' || projectId === '') {
+		return false;
+	}
+	if (typeof projectOwnerUserId !== 'string' || projectOwnerUserId === '') {
+		return false;
+	}
+	return true;
+}

--- a/supabase/migrations/20260302193405_nsf_pause_resume.sql
+++ b/supabase/migrations/20260302193405_nsf_pause_resume.sql
@@ -1,0 +1,72 @@
+-- paused_nsf job status, trigger exclusions, and resume_paused_nsf_jobs RPC
+--
+-- Introduces the paused_nsf status semantics: jobs paused for "Insufficient funds" are
+-- non-terminal and excluded from worker-invoking triggers. Adds RPC to resume by
+-- restoring original_status from error_details.
+
+-- handle_job_completion() verification (20260109165706_state_machine_fix.sql):
+-- The terminal check (line 204: NEW.status NOT IN ('completed', 'failed', 'retry_loop_failed'))
+-- and the sibling count (lines 240-241: FILTER (WHERE status IN ('completed', 'failed', 'retry_loop_failed')))
+-- already exclude paused_nsf by omission. paused_nsf is intentionally non-terminal so parent
+-- PLAN jobs remain in waiting_for_children until paused jobs resume.
+
+-- on_job_status_change trigger verification (20260109165706_state_machine_fix.sql line 168):
+-- WHEN clause fires only for ('pending', 'pending_next_step', 'pending_continuation', 'retrying', 'processing').
+-- paused_nsf is intentionally excluded so the dialectic-worker is not invoked for paused jobs.
+
+-- on_new_job_created trigger verification (20260220213950_conditional_on_new_job_created.sql line 17):
+-- WHEN clause fires only for ('pending', 'pending_continuation'). paused_nsf is intentionally excluded.
+
+-- status column: dialectic_generation_jobs.status is unconstrained TEXT (20250711142317).
+-- paused_nsf is a valid value; no schema change required.
+
+CREATE OR REPLACE FUNCTION public.resume_paused_nsf_jobs(
+  p_session_id UUID,
+  p_stage_slug TEXT,
+  p_iteration_number INTEGER
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_affected INTEGER;
+BEGIN
+  -- Ownership: only the project owner can resume jobs for their session
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.dialectic_sessions ds
+    JOIN public.dialectic_projects p ON p.id = ds.project_id
+    WHERE ds.id = p_session_id
+      AND p.user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'resume_paused_nsf_jobs: session not found or access denied'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Atomic resume: restore original_status (mapping processing -> pending so worker can re-claim),
+  -- strip original_status and nsf_paused from error_details.
+  -- Assumption: Node 2 (pauseJobsForNsf) never sets paused_nsf for jobs whose original_status
+  -- is waiting_for_children or waiting_for_prerequisite; resume need not handle those.
+  UPDATE public.dialectic_generation_jobs
+  SET
+    status = CASE
+      WHEN (error_details->>'original_status') = 'processing' THEN 'pending'
+      ELSE COALESCE(error_details->>'original_status', 'pending')
+    END,
+    error_details = error_details - 'original_status' - 'nsf_paused'
+  WHERE session_id = p_session_id
+    AND stage_slug = p_stage_slug
+    AND iteration_number = p_iteration_number
+    AND status = 'paused_nsf';
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+COMMENT ON FUNCTION public.resume_paused_nsf_jobs(UUID, TEXT, INTEGER) IS
+'Resumes all jobs in paused_nsf for the given session/stage/iteration. Restores status from error_details.original_status (processing is mapped to pending so the worker can re-claim). Only the project owner may call this. Passive wait statuses (waiting_for_children, waiting_for_prerequisite) are never stored as original_status by the backend.';
+
+GRANT EXECUTE ON FUNCTION public.resume_paused_nsf_jobs(UUID, TEXT, INTEGER) TO authenticated;

--- a/supabase/migrations/20260303033737_superseded_job_status.sql
+++ b/supabase/migrations/20260303033737_superseded_job_status.sql
@@ -1,0 +1,198 @@
+-- superseded job status for regenerated document jobs
+--
+-- Introduces the terminal status 'superseded'. When a document is regenerated, the original
+-- (e.g. failed) job is marked superseded rather than remaining failed. Superseded jobs must
+-- be treated as terminal by handle_job_completion() (do not wake parents or prerequisite
+-- chains), must not appear in worker-invoking trigger WHEN clauses, and must not be resumed
+-- by resume_paused_nsf_jobs (that RPC only updates status = 'paused_nsf', so superseded is
+-- already excluded).
+
+CREATE OR REPLACE FUNCTION public.handle_job_completion()
+RETURNS TRIGGER AS $$
+DECLARE
+    parent_id_val UUID;
+    prereq_for_job_id UUID;
+    total_siblings INTEGER;
+    terminal_siblings INTEGER;
+    failed_siblings INTEGER;
+    parent_payload JSONB;
+    current_step INTEGER;
+    total_steps INTEGER;
+    -- Part 3 variables for session status update
+    v_session_id UUID;
+    v_stage_slug TEXT;
+    v_iteration_number INTEGER;
+    v_completed_plans INTEGER;
+    v_total_plans INTEGER;
+    v_incomplete_jobs INTEGER;
+    v_current_stage_id UUID;
+    v_process_template_id UUID;
+    v_next_stage_id UUID;
+    v_next_stage_slug TEXT;
+BEGIN
+    -- Only act on jobs entering a terminal state.
+    IF NEW.status NOT IN ('completed', 'failed', 'retry_loop_failed', 'superseded') THEN
+        RETURN NEW;
+    END IF;
+
+    -- For updates, ensure it wasn't already in a terminal state to prevent re-triggering.
+    IF TG_OP = 'UPDATE' AND OLD.status IN ('completed', 'failed', 'retry_loop_failed', 'superseded') THEN
+        RETURN NEW;
+    END IF;
+
+    -- --- Part 1: Handle Prerequisite Dependencies ---
+    -- Check if any job was waiting on this one to complete.
+    SELECT id INTO prereq_for_job_id
+    FROM public.dialectic_generation_jobs
+    WHERE prerequisite_job_id = NEW.id
+    AND status = 'waiting_for_prerequisite'
+    LIMIT 1;
+
+    IF prereq_for_job_id IS NOT NULL AND NEW.status = 'completed' THEN
+        -- The prerequisite was met, so set the waiting job to pending.
+        UPDATE public.dialectic_generation_jobs
+        SET status = 'pending'
+        WHERE id = prereq_for_job_id;
+    ELSIF prereq_for_job_id IS NOT NULL AND NEW.status != 'completed' THEN
+        -- The prerequisite failed, so fail the waiting job.
+        UPDATE public.dialectic_generation_jobs
+        SET status = 'failed',
+            error_details = jsonb_build_object('reason', 'Prerequisite job failed.', 'prerequisite_id', NEW.id)
+        WHERE id = prereq_for_job_id;
+    END IF;
+
+    -- --- Part 2: Handle Parent/Child Dependencies ---
+    parent_id_val := NEW.parent_job_id;
+    IF parent_id_val IS NULL THEN
+        -- Not a child job, but might be a root PLAN job that completes a stage
+        -- Continue to Part 3 to check for stage completion
+    ELSE
+        -- Count total and terminal siblings (ALWAYS exclude RENDER jobs - they never block recipe continuation)
+        SELECT COUNT(*), COUNT(*) FILTER (WHERE status IN ('completed', 'failed', 'retry_loop_failed', 'superseded'))
+        INTO total_siblings, terminal_siblings
+        FROM public.dialectic_generation_jobs
+        WHERE parent_job_id = parent_id_val AND job_type != 'RENDER';
+
+        -- If all siblings are now in a terminal state, we can act on the parent.
+        IF total_siblings = terminal_siblings THEN
+            -- Check if any sibling failed (ALWAYS exclude RENDER jobs - their failures never affect parent jobs)
+            SELECT COUNT(*)
+            INTO failed_siblings
+            FROM public.dialectic_generation_jobs
+            WHERE parent_job_id = parent_id_val AND status IN ('failed', 'retry_loop_failed') AND job_type != 'RENDER';
+
+            IF failed_siblings > 0 THEN
+                -- If any child failed, the entire parent plan fails.
+                UPDATE public.dialectic_generation_jobs
+                SET status = 'failed',
+                    error_details = jsonb_build_object('reason', 'One or more child jobs failed.')
+                WHERE id = parent_id_val AND status = 'waiting_for_children';
+            ELSE
+                -- All children completed successfully. Check if it's the final step of a multi-step job.
+                SELECT payload INTO parent_payload
+                FROM public.dialectic_generation_jobs
+                WHERE id = parent_id_val;
+
+                IF parent_payload IS NOT NULL AND jsonb_path_exists(parent_payload, '$.step_info.current_step') AND jsonb_path_exists(parent_payload, '$.step_info.total_steps') THEN
+                    current_step := (parent_payload->'step_info'->>'current_step')::INTEGER;
+                    total_steps := (parent_payload->'step_info'->>'total_steps')::INTEGER;
+
+                    IF current_step >= total_steps THEN
+                        -- This was the final step, so the parent job is now complete.
+                        UPDATE public.dialectic_generation_jobs
+                        SET status = 'completed'
+                        WHERE id = parent_id_val AND status = 'waiting_for_children';
+                    ELSE
+                        -- There are more steps, wake up the parent for the next one.
+                        UPDATE public.dialectic_generation_jobs
+                        SET status = 'pending_next_step'
+                        WHERE id = parent_id_val AND status = 'waiting_for_children';
+                    END IF;
+                ELSE
+                    -- Not a multi-step job, or payload is missing info. Default to waking parent.
+                    UPDATE public.dialectic_generation_jobs
+                    SET status = 'pending_next_step'
+                    WHERE id = parent_id_val AND status = 'waiting_for_children';
+                END IF;
+            END IF;
+        END IF;
+
+        -- After handling parent/child, return (child jobs don't trigger stage completion)
+        RETURN NEW;
+    END IF;
+
+    -- --- Part 3: Session status update on stage completion ---
+    -- Check if this is a root PLAN job completion
+    IF NEW.parent_job_id IS NULL AND NEW.job_type = 'PLAN' AND NEW.status = 'completed' THEN
+        -- Extract identifiers from job table columns (NOT payload)
+        v_session_id := NEW.session_id;
+        v_stage_slug := NEW.stage_slug;
+        v_iteration_number := COALESCE(NEW.iteration_number, 1);
+
+        -- Query root jobs for stage completion
+        -- Note: We don't use FOR UPDATE here because we're using aggregate functions
+        -- The transaction isolation level provides sufficient protection against race conditions
+        -- Count PLAN jobs (all PLAN jobs, regardless of status, to get total)
+        -- Count incomplete jobs (non-RENDER, non-waiting jobs that aren't in terminal states)
+        SELECT 
+            COUNT(*) FILTER (WHERE job_type = 'PLAN' AND status = 'completed') as completed_plans,
+            COUNT(*) FILTER (WHERE job_type = 'PLAN') as total_plans,
+            COUNT(*) FILTER (
+                WHERE job_type != 'RENDER' 
+                  AND status != 'waiting_for_prerequisite'
+                  AND status NOT IN ('completed', 'failed', 'retry_loop_failed', 'superseded')
+            ) as incomplete_jobs
+        INTO v_completed_plans, v_total_plans, v_incomplete_jobs
+        FROM public.dialectic_generation_jobs
+        WHERE parent_job_id IS NULL
+          AND session_id = v_session_id
+          AND stage_slug = v_stage_slug
+          AND COALESCE(iteration_number, 1) = v_iteration_number;
+
+        -- Check completion condition: all PLAN jobs completed and no incomplete jobs
+        IF v_completed_plans = v_total_plans AND v_total_plans > 0 AND v_incomplete_jobs = 0 THEN
+            -- Get current stage ID
+            SELECT id INTO v_current_stage_id
+            FROM public.dialectic_stages
+            WHERE slug = v_stage_slug;
+
+            -- Only proceed if stage ID was found
+            IF v_current_stage_id IS NOT NULL THEN
+                -- Get process template ID via session → project join
+                SELECT p.process_template_id INTO v_process_template_id
+                FROM public.dialectic_sessions s
+                JOIN public.dialectic_projects p ON s.project_id = p.id
+                WHERE s.id = v_session_id;
+
+                -- Only proceed if process template ID was found
+                IF v_process_template_id IS NOT NULL THEN
+                    -- Query stage transitions to find next stage (get both ID and slug)
+                    SELECT ds.id, ds.slug INTO v_next_stage_id, v_next_stage_slug
+                    FROM public.dialectic_stage_transitions dst
+                    JOIN public.dialectic_stages ds ON dst.target_stage_id = ds.id
+                    WHERE dst.source_stage_id = v_current_stage_id
+                      AND dst.process_template_id = v_process_template_id
+                    LIMIT 1;
+
+                    -- Update session status and current_stage_id synchronously (in same transaction)
+                    UPDATE public.dialectic_sessions
+                    SET status = CASE 
+                        WHEN v_next_stage_slug IS NOT NULL THEN 'pending_' || v_next_stage_slug
+                        ELSE 'iteration_complete_pending_review'
+                    END,
+                    current_stage_id = CASE 
+                        WHEN v_next_stage_id IS NOT NULL THEN v_next_stage_id
+                        ELSE current_stage_id  -- Keep current stage if terminal
+                    END,
+                    updated_at = now()
+                    WHERE id = v_session_id;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.handle_job_completion() IS 'Trigger function that handles job completion logic in three parts: (1) Prerequisite dependencies - unblocks jobs waiting for prerequisites, (2) Parent/child dependencies - updates parent job status when all children complete, (3) Session status update - advances session to next stage when all root PLAN jobs for a stage complete. Terminal statuses: completed, failed, retry_loop_failed, superseded. Excludes RENDER jobs and waiting_for_prerequisite jobs from completion checks.';


### PR DESCRIPTION
NSF Protection: 
- UX balance minimum gate per stage
- Backend auto-pause all jobs on first NSF throw
- "Resume" handler on BE 
- "Generate" button provides "Resume" after NSF is resolved
- "Generate" shows "Insufficient Balance" with an overlay 
-- Overlay tells user the minimum balance for the stage 
-- Overlay links to payment portal
-- Overlay pulses so its obvious interaction is needed

Document Regeneration: 
- For the current stage, when the stage has been run
-- Any document can be regenerated
-- Clicking "Redo" on StageRunChecklist creates a pop up
-- Failed documents are automatically selected
-- Any document can be redone
- Backend regenerateDocument function clones original
- Backend regenerateDocument marks original "superseded"